### PR TITLE
Efficient diffing for OrderedSet

### DIFF
--- a/Benchmarks/Benchmarks/OrderedSetBenchmarks.swift
+++ b/Benchmarks/Benchmarks/OrderedSetBenchmarks.swift
@@ -242,6 +242,33 @@ extension Benchmark {
       }
     }
 
+    if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+      self.add(
+        title: "OrderedSet<Int> diff computation",
+        input: ([Int], [Int]).self
+      ) { pa, pb in
+        let a = OrderedSet(pa)
+        let b = OrderedSet(pb)
+        return { timer in
+          timer.measure {
+            blackHole(b.difference(from: a))
+          }
+        }
+      }
+
+      self.add(
+        title: "OrderedSet<Int> diff application",
+        input: ([Int], [Int]).self
+      ) { a, b in
+        let d = OrderedSet(b).difference(from: OrderedSet(a))
+        return { timer in
+          timer.measure {
+            blackHole(a.applying(d))
+          }
+        }
+      }
+    }
+
     let overlaps: [(String, (Int) -> Int)] = [
       ("0%",   { c in c }),
       ("25%",  { c in 3 * c / 4 }),

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Diffing.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Diffing.swift
@@ -75,5 +75,27 @@ extension OrderedSet {
     }
     return CollectionDifference(changes)!
   }
+
+  /* Replicating RangeReplaceableCollection.applying here would involve
+   * duplicating a ton of IPI from the stdlib. Dropping down to Array and back
+   * to OrderedSet is still O(n)-ish which still beats the naïve application
+   * algorithm of "remove, then insert"
+   */
+  /// Applies the given difference to this collection.
+  ///
+  /// - Parameter difference: The difference to be applied.
+  ///
+  /// - Returns: An instance representing the state of the receiver with the
+  ///   difference applied, or `nil` if the difference is incompatible with
+  ///   the receiver's state.
+  ///
+  /// - Complexity: O(*n* + 2 × (*n* + *c*)), where *n* is `self.count` and *c*
+  ///   is the number of changes contained by the parameter.
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  public func applying(_ difference: CollectionDifference<Element>) -> Self? {
+    guard let array = Array(self).applying(difference) else { return nil }
+    let result = OrderedSet(array)
+    return result.count == array.count ? result : nil
+  }
 }
 

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Diffing.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Diffing.swift
@@ -89,7 +89,7 @@ extension OrderedSet {
   ///   difference applied, or `nil` if the difference is incompatible with
   ///   the receiver's state.
   ///
-  /// - Complexity: O(*n* + 2 × (*n* + *c*)), where *n* is `self.count` and *c*
+  /// - Complexity: O(*n* + *c*), where *n* is `self.count` and *c*
   ///   is the number of changes contained by the parameter.
   @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public func applying(_ difference: CollectionDifference<Element>) -> Self? {

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Diffing.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Diffing.swift
@@ -57,12 +57,12 @@ extension OrderedSet {
             assert(y == axinb)
             // `a[x]` == `b[y]`
             x += 1; y += 1
-          } else if byina - x >= axinb - y {
-            // `b[y]` exists further away from the current position in `a` than `a[x]` does in `b`
-            remove()
-          } else {
+          } else if byina - x < axinb - y {
             // `a[x]` exists further away from the current position in `b` than `b[y] does in `a`
             insert()
+          } else {
+            // `b[y]` exists further away from the current position in `a` than `a[x]` does in `b`
+            remove()
           }
         } else {
           // `b[y]` does not exist in `a`, the element must have been inserted

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Diffing.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Diffing.swift
@@ -14,7 +14,7 @@ extension OrderedSet {
   /// receiver, using an algorithm specialized to exploit fast membership
   /// testing and the member uniqueness guarantees of `OrderedSet`.
   ///
-  /// - Complexity: O(`left.count + right.count`)
+  /// - Complexity: O(`self.count + other.count`)
   @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public func difference(
     from other: Self

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Diffing.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Diffing.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension OrderedSet {
+  /// Returns the collection difference between the parameter and the
+  /// receiver, using an algorithm specialized to exploit fast membership
+  /// testing and the member uniqueness guarantees of `OrderedSet`.
+  ///
+  /// - Complexity: O(`left.count + right.count`)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  public func difference(
+    from other: Self
+  ) -> CollectionDifference<Element> {
+    /* While admitting that variables with names like "a", "b", "x", and "y" are not especially readable, their use (and meaning) is standard in the diffing literature and familiarity with that literature will help if you're reading this code anyway. */
+    let a = other // The collection we're diffing "from". An element present in this collection but not the other is a "remove"
+    var x = 0 // The working index into `a`
+    let b = self // The collection we're diffing "to". An element present in this collection but not the other is an "insert"
+    var y = 0 // The working index into `b`
+
+    var changes = Array<CollectionDifference<Element>.Change>()
+    func remove() {
+      let ax = a[x]
+      changes.append(.remove(offset: x, element: ax, associatedWith: b.lastIndex(of: ax)))
+      x += 1
+    }
+    func insert() {
+      let by = b[y]
+      changes.append(.insert(offset: y, element: by, associatedWith: a.lastIndex(of: by)))
+      y += 1
+    }
+
+    while x < a.count || y < b.count {
+      if y == b.count {
+        // No more elements to process in `b`, `a[x]` must have been removed
+        remove()
+      } else if x == a.count {
+        // No more elements to process in `a`, `b[y]` must have been inserted
+        insert()
+      } else if let axinb = b.lastIndex(of: a[x]) {
+        if axinb < y {
+          // Element has already been processed as an insertion in `b`, generate associated remove for move
+          remove()
+        }
+        else if let byina = a.lastIndex(of: b[y]) {
+          if byina < x {
+            // Element has already been processed as a remove in `a`, generate associated insert for move
+            insert()
+          } else if x == byina {
+            assert(y == axinb)
+            // `a[x]` == `b[y]`
+            x += 1; y += 1
+          } else if byina - x >= axinb - y {
+            // `b[y]` exists further away from the current position in `a` than `a[x]` does in `b`
+            remove()
+          } else {
+            // `a[x]` exists further away from the current position in `b` than `b[y] does in `a`
+            insert()
+          }
+        } else {
+          // `b[y]` does not exist in `a`, the element must have been inserted
+          insert()
+        }
+      } else {
+        // `a[x]` does not exist in `b`, the element must have been removed
+        remove()
+      }
+    }
+    return CollectionDifference(changes)!
+  }
+}
+

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Diffing.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Diffing.swift
@@ -93,9 +93,8 @@ extension OrderedSet {
   ///   is the number of changes contained by the parameter.
   @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public func applying(_ difference: CollectionDifference<Element>) -> Self? {
-    guard let array = Array(self).applying(difference) else { return nil }
+    guard let array = self.elements.applying(difference) else { return nil }
     let result = OrderedSet(array)
     return result.count == array.count ? result : nil
   }
 }
-

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSet Diffing Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSet Diffing Tests.swift
@@ -29,31 +29,31 @@ class OrderedSetDiffingTests: CollectionTestCase {
     expectEqual(Array(b).applying(e), Array(a))
   }
 
-  func testEqual() {
+  func test_equal() {
     let a = [1, 2, 3, 4, 5]
     _validate(from: a, to: a, mutations: 0)
   }
 
-  func testMoveTrap() {
+  func test_moveTrap() {
     let a = [1, 2, 3]
     let b = [3, 2]
     _validate(from: a, to: b, mutations: 3)
   }
 
-  func testMinimalish() {
+  func test_minimalish() {
     let a = ["g", "1", "2",      "w", "o", "a", "e", "t", "4",               "8"]
     let b = [     "1", "2", "3",                "e",      "4", "5", "6", "7"]
     _validate(from: a, to: b, mutations: 10)
   }
 
-  func testArrowDefeatingMinimalDiff() {
+  func test_arrowDefeatingMinimalDiff() {
     // Arrow diff only finds one match ("n") instead of two ("o", "c")
     let a = [               "o", "c", "n"]
     let b = ["n", "d", "y", "o", "c"]
     _validate(from: a, to: b, mutations: 4)
   }
 
-  func testFuzzerDiscovered00() {
+  func test_fuzzerDiscovered00() {
     //                  X     X        X
     let a = [3, 5, 8, 0, 7, 9]
     let b = [8, 5, 9, 7, 0, 6]
@@ -61,7 +61,7 @@ class OrderedSetDiffingTests: CollectionTestCase {
     _validate(from: a, to: b)
   }
 
-  func testFuzz() {
+  func test_fuzz() {
     for _ in 0..<1000 {
       let a = (0..<10).map { _ in Int.random(in: 0..<10) }
       let b = (0..<10).map { _ in Int.random(in: 0..<10) }

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSet Diffing Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSet Diffing Tests.swift
@@ -22,11 +22,10 @@ class OrderedSetDiffingTests: CollectionTestCase {
     if let mutations = mutations {
       expectEqual(d.count, mutations)
     }
-    // TODO: OrderedSet.applying() since OrderedSet isn't RangeReplaceable
-    expectEqual(Array(a).applying(d), Array(b))
-    expectEqual(Array(b).applying(d.inverse()), Array(a))
-    expectEqual(Array(a).applying(e.inverse()), Array(b))
-    expectEqual(Array(b).applying(e), Array(a))
+    expectEqual(a.applying(d), b)
+    expectEqual(b.applying(d.inverse()), a)
+    expectEqual(a.applying(e.inverse()), b)
+    expectEqual(b.applying(e), a)
   }
 
   func test_equal() {

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSet Diffing Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSet Diffing Tests.swift
@@ -98,6 +98,18 @@ class OrderedSetDiffingTests: CollectionTestCase {
     _validate(from: a, to: b, mutations: 4)
   }
 
+  func test_disparate() {
+    let a = OrderedSet(0..<1000)
+    let b = OrderedSet(1000..<2000)
+    _validate(from: a, to: b, mutations: 2000)
+  }
+
+  func test_reversed() {
+    let a = OrderedSet(0..<1000)
+    let b = OrderedSet((0..<1000).reversed())
+    _validate(from: a, to: b, mutations: 1998)
+  }
+
   func test_fuzzerDiscovered00() {
     //                  X     X        X
     let a = [3, 5, 8, 0, 7, 9]

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSet Diffing Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSet Diffing Tests.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import OrderedCollections
+import CollectionsTestSupport
+
+class OrderedSetDiffingTests: CollectionTestCase {
+
+  func _validate<T: Hashable>(from a: Array<T>, to b: Array<T>, mutations: Int? = nil) {
+    let d = b.difference(from: a)
+    let e = a.difference(from: b)
+    expectEqual(d.count, e.count)
+    if let mutations = mutations {
+      expectEqual(d.count, mutations)
+    }
+    // TODO: OrderedSet.applying() since OrderedSet isn't RangeReplaceable
+    expectEqual(Array(a).applying(d), Array(b))
+    expectEqual(Array(b).applying(d.inverse()), Array(a))
+    expectEqual(Array(a).applying(e.inverse()), Array(b))
+    expectEqual(Array(b).applying(e), Array(a))
+  }
+
+  func testEqual() {
+    let a = [1, 2, 3, 4, 5]
+    _validate(from: a, to: a, mutations: 0)
+  }
+
+  func testMoveTrap() {
+    let a = [1, 2, 3]
+    let b = [3, 2]
+    _validate(from: a, to: b, mutations: 3)
+  }
+
+  func testMinimalish() {
+    let a = ["g", "1", "2",      "w", "o", "a", "e", "t", "4",               "8"]
+    let b = [     "1", "2", "3",                "e",      "4", "5", "6", "7"]
+    _validate(from: a, to: b, mutations: 10)
+  }
+
+  func testArrowDefeatingMinimalDiff() {
+    // Arrow diff only finds one match ("n") instead of two ("o", "c")
+    let a = [               "o", "c", "n"]
+    let b = ["n", "d", "y", "o", "c"]
+    _validate(from: a, to: b, mutations: 4)
+  }
+
+  func testFuzzerDiscovered00() {
+    //                  X     X        X
+    let a = [3, 5, 8, 0, 7, 9]
+    let b = [8, 5, 9, 7, 0, 6]
+    //                     X        X  X
+    _validate(from: a, to: b)
+  }
+
+  func testFuzz() {
+    for _ in 0..<1000 {
+      let a = (0..<10).map { _ in Int.random(in: 0..<10) }
+      let b = (0..<10).map { _ in Int.random(in: 0..<10) }
+      _validate(from: a, to: b)
+    }
+  }
+}


### PR DESCRIPTION
### Description
Adds an overload of `difference(from:)` that implements a linear time algorithm (same as used by Foundation's `NSOrderedSet`, SwiftUI's `List`, and UIKit's Diffable Data Source), as well as an implementation of `applying(:)` that is linear, though slower than if `OrderedSet` conformed to `RangeReplaceableCollection`.

### Detailed Design
```swift
extension OrderedSet {
  /// Returns the collection difference between the parameter and the
  /// receiver, using an algorithm specialized to exploit fast membership
  /// testing and the member uniqueness guarantees of `OrderedSet`.
  ///
  /// - Complexity: O(`self.count + other.count`)
  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
  public func difference(
    from other: Self
  ) -> CollectionDifference<Element>

  /// Applies the given difference to this collection.
  ///
  /// - Parameter difference: The difference to be applied.
  ///
  /// - Returns: An instance representing the state of the receiver with the
  ///   difference applied, or `nil` if the difference is incompatible with
  ///   the receiver's state.
  ///
  /// - Complexity: O(*n* + 2 × (*n* + *c*)), where *n* is `self.count` and *c*
  ///   is the number of changes contained by the parameter.
  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
  public func applying(_ difference: CollectionDifference<Element>) -> Self?
}
```

### Documentation
As shown above:

* `OrderedSet.difference(from:)` has headerdoc that refines the documentation from `BidirectionalCollection.difference(from:)` (which it overloads)
* `OrderedSet.applying(:)` has headerdoc that duplicates `RangeReplaceable.applying(:)` but with a slower `Complexity` 😬

### Testing
Pretty exhaustive correctness and performance testing added in `OrderedSet Diffing Tests.swift`.

### Performance
All unit tests perform a diff with a box type with counters for calls to `==` and `hash(into:)`, and then validate that both are < nlogn. Despite advertising linear performance, checking "less than the next meaningful order of magnitude" allows the non-deterministic tests some wiggle room for constant factors, multiple linear passes, and bad hash luck while still proving performance far superior to traditional diffing algorithms, which run in O(n**2) worst case (represented in the unit tests).

The implementation of `applying(:)` is still O(n), but definitely exposes room for improvement in the stdlib—a single-pass implementation could exist for all collection types with an O(1) `append(:)` but implementing it here would duplicate [`RangeReplaceableCollection.applying(:)`](https://github.com/apple/swift/blob/main/stdlib/public/core/Diffing.swift) and all of its support functions.

### Source Impact
Solely additive changes.

### Checklist
- [X] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (to the extent possible).
- [X] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexpected benchmark regressions.
- [X] I've updated the documentation (if appropriate).
