### PR TITLE
Fixes link to combinatorics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The test support library currently provides the following functionality:
 
     </details>
 
-- [`Combinatorics`](./Sources/CollectionsTestSupport/Combinatorics): Basic support for exhaustive combinatorial testing. This allows us to easily verify that a collection operation works correctly on all possible instances up to a certain size, including behavioral variations such as unique/shared storage.
+- [`Combinatorics`](./Sources/CollectionsTestSupport/AssertionContexts/Combinatorics.swift): Basic support for exhaustive combinatorial testing. This allows us to easily verify that a collection operation works correctly on all possible instances up to a certain size, including behavioral variations such as unique/shared storage.
 
   <details>
    <summary><strong>Click here for an example</strong></summary>


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Collections!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [] I've completed this task
    - [x] This task isn't completed
-->

The link to [Combinatorics](https://github.com/apple/swift-collections/blob/main/Sources/CollectionsTestSupport/Combinatorics) appears to be wrong, this change updates it to [Combinatorics.swift](https://github.com/apple/swift-collections/blob/main/Sources/CollectionsTestSupport/AssertionContexts/Combinatorics.swift).

### Checklist
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've updated the documentation if necessary.
