### PR TITLE
Remove outdated passage in `OrderedSet.init(minimumCapacity:persistent:)` docs

### DIFF
--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+ReserveCapacity.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+ReserveCapacity.swift
@@ -20,10 +20,7 @@ extension OrderedSet {
   /// If you have a good idea of the expected working size of the set, calling
   /// this initializer with `persistent` set to true can sometimes improve
   /// performance by eliminating churn due to repeated rehashings when the set
-  /// temporarily shrinks below its regular size. You can cancel any capacity
-  /// you've previously reserved by persistently reserving a capacity of zero.
-  /// (This also shrinks the hash table to the ideal size for its current number
-  /// elements.)
+  /// temporarily shrinks below its regular size.
   ///
   /// - Parameter minimumCapacity: The minimum number of elements that the newly
   ///   created set should be able to store without reallocating its storage.


### PR DESCRIPTION
This sentence refers to a `reserveCapacity` variant that did not end up in the public OrderedSet API. (It remains internal for now.)

### Checklist
- [X] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [X] I've updated the documentation if necessary.
