### PR TITLE
Add the @discardableResult attribute to OrderedSet.insert(_:at:)

### DIFF
--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
@@ -152,6 +152,7 @@ extension OrderedSet {
   ///    type, if it implements high-quality hashing. (Insertions need to make
   ///    room in the storage array to add the inserted element.)
   @inlinable
+  @discardableResult
   public mutating func insert(
     _ item: Element,
     at index: Index

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
@@ -207,6 +207,7 @@ extension OrderedSet {
   ///    hash, and compare operations on the `Element` type, if it implements
   ///    high-quality hashing.
   @inlinable
+  @discardableResult
   public mutating func updateOrAppend(_ item: Element) -> Element? {
     let (inserted, index) = _append(item)
     if inserted { return nil }

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
@@ -236,6 +236,7 @@ extension OrderedSet {
   ///    hash, and compare operations on the `Element` type, if it implements
   ///    high-quality hashing.
   @inlinable
+  @discardableResult
   public mutating func updateOrInsert(
     _ item: Element,
     at index: Index


### PR DESCRIPTION
Fixes #19.

It does not seem appropriate to write a test for this change. However, I am open to other points of view and will gladly own further work.

<!--
    Thanks for contributing to Swift Collections!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
