### PR TITLE
Fix CollectionTestCase calling super's setup on tearDown issue

### DIFF
--- a/Sources/CollectionsTestSupport/AssertionContexts/CollectionTestCase.swift
+++ b/Sources/CollectionsTestSupport/AssertionContexts/CollectionTestCase.swift
@@ -23,8 +23,8 @@ open class CollectionTestCase: XCTestCase {
   }
 
   public override func tearDown() {
-    super.setUp()
     TestContext.pop(context)
     _context = nil
+    super.tearDown()
   }
 }


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Collections!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Fixes https://github.com/apple/swift-collections/issues/17

Removes calling XCTestCase's setup on the CollectionTestCase tearDown method. Implementation is similar to the solution provided on the issue.


### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
