### PR TITLE
Update to swift-collections-benchmark 0.0.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections-benchmark",
         "state": {
           "branch": null,
-          "revision": "49297647d1c0855eb33ec18cd6ee1181727c159b",
-          "version": "0.0.1"
+          "revision": "665cbb154a55f45bcedd2ab4faf17b1b7ac06de3",
+          "version": "0.0.2"
         }
       },
       {


### PR DESCRIPTION
This PR bumps the pinned version number of the swift-collections-benchmark dependency to 0.0.2. 

(Pinning only takes effect on direct builds of this package, not when the package is merely used as a dependency.)

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [ ] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
