### PR TITLE
[OrderedDictionary] Document encoding format

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Codable.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Codable.swift
@@ -19,11 +19,11 @@ extension OrderedDictionary: Encodable where Key: Encodable, Value: Encodable {
   /// encoder's format.
   ///
   /// - Note: Unlike the standard `Dictionary` type, ordered dictionaries
-  ///    always encode in an unkeyed container, because `Codable`'s keyed
-  ///    containers do not guarantee that they preserve the ordering of the
-  ///    items they contain. (And in popular encoding formats, keyed containers
-  ///    tend to map to unordered data structures -- e.g., JSON's "object"
-  ///    construct is explicitly unordered.)
+  ///    always encode themselves into an unkeyed container, because
+  ///    `Codable`'s keyed containers do not guarantee that they preserve the
+  ///    ordering of the items they contain. (And in popular encoding formats,
+  ///    keyed containers tend to map to unordered data structures -- e.g.,
+  ///    JSON's "object" construct is explicitly unordered.)
   ///
   /// - Parameter encoder: The encoder to write data to.
   @inlinable
@@ -40,8 +40,18 @@ extension OrderedDictionary: Encodable where Key: Encodable, Value: Encodable {
 extension OrderedDictionary: Decodable where Key: Decodable, Value: Decodable {
   /// Creates a new dictionary by decoding from the given decoder.
   ///
+  /// `OrderedDictionary` expects its contents to be encoded as alternating
+  /// key-value pairs in an unkeyed container.
+  ///
   /// This initializer throws an error if reading from the decoder fails, or
-  /// if the decoded contents are corrupt (such as they contain duplicate values).
+  /// if the decoded contents are not in the expected format.
+  ///
+  /// - Note: Unlike the standard `Dictionary` type, ordered dictionaries
+  ///    always encode themselves into an unkeyed container, because
+  ///    `Codable`'s keyed containers do not guarantee that they preserve the
+  ///    ordering of the items they contain. (And in popular encoding formats,
+  ///    keyed containers tend to map to unordered data structures -- e.g.,
+  ///    JSON's "object" construct is explicitly unordered.)
   ///
   /// - Parameter decoder: The decoder to read data from.
   @inlinable


### PR DESCRIPTION
Unlike the regular unordered `Dictionary`, `OrderedDictionary` always encodes/decodes itself as alternating key/value pairs in an unkeyed container. Document this fact (and the reason behind it) in the `Decodable` implementation.

Resolves #12.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [X] I've updated the documentation if necessary.
