### PR TITLE
Replace Index with Int where possible

### DIFF
--- a/Sources/DequeModule/Deque+MutableCollection.swift
+++ b/Sources/DequeModule/Deque+MutableCollection.swift
@@ -22,7 +22,7 @@ extension Deque: MutableCollection {
   /// - Complexity: O(1) when this instance has a unique reference to its
   ///    underlying storage; O(`count`) otherwise.
   @inlinable
-  public mutating func swapAt(_ i: Index, _ j: Index) {
+  public mutating func swapAt(_ i: Int, _ j: Int) {
     precondition(i >= 0 && i < count, "Index out of bounds")
     precondition(j >= 0 && j < count, "Index out of bounds")
     _storage.ensureUnique()

--- a/Sources/DequeModule/Deque+RandomAccessCollection.swift
+++ b/Sources/DequeModule/Deque+RandomAccessCollection.swift
@@ -28,7 +28,7 @@ extension Deque: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public var startIndex: Index { 0 }
+  public var startIndex: Int { 0 }
 
   /// The deque’s “past the end” position—that is, the position one greater than
   /// the last valid subscript argument.
@@ -39,7 +39,7 @@ extension Deque: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public var endIndex: Index { count }
+  public var endIndex: Int { count }
 
   /// Returns the position immediately after the given index.
   ///
@@ -51,7 +51,7 @@ extension Deque: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(after i: Index) -> Index {
+  public func index(after i: Int) -> Int {
     // Note: Like `Array`, index manipulation methods on deques don't trap on
     // invalid indices. (Indices are still validated on element access.)
     return i + 1
@@ -65,7 +65,7 @@ extension Deque: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func formIndex(after i: inout Index) {
+  public func formIndex(after i: inout Int) {
     // Note: Like `Array`, index manipulation methods on deques
     // don't trap on invalid indices.
     // (Indices are still validated on element access.)
@@ -82,7 +82,7 @@ extension Deque: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(before i: Index) -> Index {
+  public func index(before i: Int) -> Int {
     // Note: Like `Array`, index manipulation methods on deques don't trap on
     // invalid indices. (Indices are still validated on element access.)
     return i - 1
@@ -95,7 +95,7 @@ extension Deque: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func formIndex(before i: inout Index) {
+  public func formIndex(before i: inout Int) {
     // Note: Like `Array`, index manipulation methods on deques don't trap on
     // invalid indices. (Indices are still validated on element access.)
     i -= 1
@@ -118,7 +118,7 @@ extension Deque: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+  public func index(_ i: Int, offsetBy distance: Int) -> Int {
     // Note: Like `Array`, index manipulation methods on deques don't trap on
     // invalid indices. (Indices are still validated on element access.)
     return i + distance
@@ -170,7 +170,7 @@ extension Deque: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func distance(from start: Index, to end: Index) -> Int {
+  public func distance(from start: Int, to end: Int) -> Int {
     // Note: Like `Array`, index manipulation method on deques
     // don't trap on invalid indices.
     // (Indices are still validated on element access.)
@@ -187,7 +187,7 @@ extension Deque: RandomAccessCollection {
   ///    unless the deque’s storage is shared with another deque, in which case
   ///    writing is O(`count`).
   @inlinable
-  public subscript(index: Index) -> Element {
+  public subscript(index: Int) -> Element {
     get {
       precondition(index >= 0 && index < count, "Index out of bounds")
       return _storage.read { $0.ptr(at: $0.slot(forOffset: index)).pointee }
@@ -228,7 +228,7 @@ extension Deque: RandomAccessCollection {
   /// The accessed slice uses the same indices for the same elements as the
   /// original collection.
   @inlinable
-  public subscript(bounds: Range<Index>) -> Slice<Self> {
+  public subscript(bounds: Range<Int>) -> Slice<Self> {
     get {
       precondition(bounds.lowerBound >= 0 && bounds.upperBound <= count,
                    "Invalid bounds")

--- a/Sources/DequeModule/Deque+RangeReplaceableCollection.swift
+++ b/Sources/DequeModule/Deque+RangeReplaceableCollection.swift
@@ -47,7 +47,7 @@ extension Deque: RangeReplaceableCollection {
   ///    `subrange`.
   @inlinable
   public mutating func replaceSubrange<C: Collection>(
-    _ subrange: Range<Index>,
+    _ subrange: Range<Int>,
     with newElements: __owned C
   ) where C.Element == Element {
     precondition(subrange.lowerBound >= 0 && subrange.upperBound <= count, "Index range out of bounds")
@@ -272,7 +272,7 @@ extension Deque: RangeReplaceableCollection {
   ///    elements that need to be moved. When inserting at the start or the end,
   ///    this reduces the complexity to amortized O(1).
   @inlinable
-  public mutating func insert(_ newElement: Element, at index: Index) {
+  public mutating func insert(_ newElement: Element, at index: Int) {
     precondition(index >= 0 && index <= count,
                  "Can't insert element at invalid index")
     _storage.ensureUnique(minimumCapacity: count + 1)
@@ -310,7 +310,7 @@ extension Deque: RangeReplaceableCollection {
   ///    amortized O(1).
   @inlinable
   public mutating func insert<C: Collection>(
-    contentsOf newElements: __owned C, at index: Index
+    contentsOf newElements: __owned C, at index: Int
   ) where C.Element == Element {
     precondition(index >= 0 && index <= count,
                  "Can't insert elements at an invalid index")
@@ -338,7 +338,7 @@ extension Deque: RangeReplaceableCollection {
   ///    deque costs O(1) if the deque's storage isn't shared.
   @inlinable
   @discardableResult
-  public mutating func remove(at index: Index) -> Element {
+  public mutating func remove(at index: Int) -> Element {
     precondition(index >= 0 && index < self.count, "Index out of bounds")
     // FIXME: Implement storage shrinking
     _storage.ensureUnique()
@@ -364,7 +364,7 @@ extension Deque: RangeReplaceableCollection {
   /// - Complexity: O(`count`). Removing elements from the start or end of the
   ///    deque costs O(`bounds.count`) if the deque's storage isn't shared.
   @inlinable
-  public mutating func removeSubrange(_ bounds: Range<Index>) {
+  public mutating func removeSubrange(_ bounds: Range<Int>) {
     precondition(bounds.lowerBound >= 0 && bounds.upperBound <= self.count,
                  "Index range out of bounds")
     _storage.ensureUnique()

--- a/Sources/DequeModule/Deque+Sequence.swift
+++ b/Sources/DequeModule/Deque+Sequence.swift
@@ -43,7 +43,7 @@ extension Deque: Sequence {
     }
 
     @inlinable
-    internal init(_base: Deque, from index: Index) {
+    internal init(_base: Deque, from index: Int) {
       assert(index <= _base.count)
       self = _base._storage.read { handle in
         let start = handle.slot(forOffset: index)

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
@@ -154,7 +154,7 @@ extension OrderedDictionary.Elements: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(after i: Index) -> Index { i + 1 }
+  public func index(after i: Int) -> Int { i + 1 }
 
   /// Returns the position immediately before the given index.
   ///
@@ -168,7 +168,7 @@ extension OrderedDictionary.Elements: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(before i: Index) -> Index { i - 1 }
+  public func index(before i: Int) -> Int { i - 1 }
 
   /// Replaces the given index with its successor.
   ///
@@ -180,7 +180,7 @@ extension OrderedDictionary.Elements: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func formIndex(after i: inout Index) { i += 1 }
+  public func formIndex(after i: inout Int) { i += 1 }
 
   /// Replaces the given index with its predecessor.
   ///
@@ -192,7 +192,7 @@ extension OrderedDictionary.Elements: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func formIndex(before i: inout Index) { i -= 1 }
+  public func formIndex(before i: inout Int) { i -= 1 }
 
   /// Returns an index that is the specified distance from the given index.
   ///
@@ -211,7 +211,7 @@ extension OrderedDictionary.Elements: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+  public func index(_ i: Int, offsetBy distance: Int) -> Int {
     i + distance
   }
 
@@ -238,10 +238,10 @@ extension OrderedDictionary.Elements: RandomAccessCollection {
   @inlinable
   @inline(__always)
   public func index(
-    _ i: Index,
+    _ i: Int,
     offsetBy distance: Int,
-    limitedBy limit: Index
-  ) -> Index? {
+    limitedBy limit: Int
+  ) -> Int? {
     _base._values.index(i, offsetBy: distance, limitedBy: limit)
   }
 
@@ -257,7 +257,7 @@ extension OrderedDictionary.Elements: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func distance(from start: Index, to end: Index) -> Int {
+  public func distance(from start: Int, to end: Int) -> Int {
     end - start
   }
 
@@ -270,7 +270,7 @@ extension OrderedDictionary.Elements: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public subscript(position: Index) -> Element {
+  public subscript(position: Int) -> Element {
     (_base._keys[position], _base._values[position])
   }
 
@@ -313,13 +313,13 @@ extension OrderedDictionary.Elements: RandomAccessCollection {
 
   @inlinable
   @inline(__always)
-  public func _failEarlyRangeCheck(_ index: Index, bounds: ClosedRange<Index>) {
+  public func _failEarlyRangeCheck(_ index: Int, bounds: ClosedRange<Int>) {
     _base._values._failEarlyRangeCheck(index, bounds: bounds)
   }
 
   @inlinable
   @inline(__always)
-  public func _failEarlyRangeCheck(_ range: Range<Index>, bounds: Range<Index>) {
+  public func _failEarlyRangeCheck(_ range: Range<Int>, bounds: Range<Int>) {
     _base._values._failEarlyRangeCheck(range, bounds: bounds)
   }
 }
@@ -373,7 +373,7 @@ extension OrderedDictionary.Elements {
   ///    value; O(`count`) otherwise.
   @inlinable
   @inline(__always)
-  public mutating func swapAt(_ i: Index, _ j: Index) {
+  public mutating func swapAt(_ i: Int, _ j: Int) {
     _base.swapAt(i, j)
   }
 
@@ -398,7 +398,7 @@ extension OrderedDictionary.Elements {
   @inline(__always)
   public mutating func partition(
     by belongsInSecondPartition: (Element) throws -> Bool
-  ) rethrows -> Index {
+  ) rethrows -> Int {
     try _base.partition(by: belongsInSecondPartition)
   }
 }

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift
@@ -22,7 +22,7 @@ extension OrderedDictionary {
   /// - Complexity: O(1) when the dictionary's storage isn't shared with another
   ///    value; O(`count`) otherwise.
   @inlinable
-  public mutating func swapAt(_ i: Index, _ j: Index) {
+  public mutating func swapAt(_ i: Int, _ j: Int) {
     _keys.swapAt(i, j)
     _values.swapAt(i, j)
   }
@@ -47,7 +47,7 @@ extension OrderedDictionary {
   @inlinable
   public mutating func partition(
     by belongsInSecondPartition: (Element) throws -> Bool
-  ) rethrows -> Index {
+  ) rethrows -> Int {
     let pivot = try _values.withUnsafeMutableBufferPointer { values in
       try _keys._partition(values: values, by: belongsInSecondPartition)
     }

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
@@ -143,7 +143,7 @@ extension OrderedDictionary.Values: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(after i: Index) -> Index { i + 1 }
+  public func index(after i: Int) -> Int { i + 1 }
 
   /// Returns the position immediately before the given index.
   ///
@@ -157,7 +157,7 @@ extension OrderedDictionary.Values: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(before i: Index) -> Index { i - 1 }
+  public func index(before i: Int) -> Int { i - 1 }
 
   /// Replaces the given index with its successor.
   ///
@@ -169,7 +169,7 @@ extension OrderedDictionary.Values: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func formIndex(after i: inout Index) { i += 1 }
+  public func formIndex(after i: inout Int) { i += 1 }
 
   /// Replaces the given index with its predecessor.
   ///
@@ -181,7 +181,7 @@ extension OrderedDictionary.Values: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func formIndex(before i: inout Index) { i -= 1 }
+  public func formIndex(before i: inout Int) { i -= 1 }
 
   /// Returns an index that is the specified distance from the given index.
   ///
@@ -200,7 +200,7 @@ extension OrderedDictionary.Values: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+  public func index(_ i: Int, offsetBy distance: Int) -> Int {
     i + distance
   }
 
@@ -227,10 +227,10 @@ extension OrderedDictionary.Values: RandomAccessCollection {
   @inlinable
   @inline(__always)
   public func index(
-    _ i: Index,
+    _ i: Int,
     offsetBy distance: Int,
-    limitedBy limit: Index
-  ) -> Index? {
+    limitedBy limit: Int
+  ) -> Int? {
     _base._values.index(i, offsetBy: distance, limitedBy: limit)
   }
 
@@ -246,7 +246,7 @@ extension OrderedDictionary.Values: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func distance(from start: Index, to end: Index) -> Int {
+  public func distance(from start: Int, to end: Int) -> Int {
     end - start
   }
 
@@ -279,7 +279,7 @@ extension OrderedDictionary.Values: MutableCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public subscript(position: Index) -> Value {
+  public subscript(position: Int) -> Value {
     get {
       _base._values[position]
     }

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
@@ -120,8 +120,8 @@
 /// existing members:
 ///
 ///     // Permutation operations from MutableCollection:
-///     func swapAt(_ i: Index, _ j: Index)
-///     func partition(by predicate: (Element) throws -> Bool) -> rethrows Index
+///     func swapAt(_ i: Int, _ j: Int)
+///     func partition(by predicate: (Element) throws -> Bool) -> rethrows Int
 ///     func sort() where Element: Comparable
 ///     func sort(by predicate: (Element, Element) throws -> Bool) rethrows
 ///     func shuffle()
@@ -129,7 +129,7 @@
 ///
 ///     // Removal operations from RangeReplaceableCollection:
 ///     func removeAll(keepingCapacity: Bool = false)
-///     func remove(at index: Index) -> Element
+///     func remove(at index: Int) -> Element
 ///     func removeSubrange(_ bounds: Range<Int>)
 ///     func removeLast() -> Element
 ///     func removeLast(_ n: Int)
@@ -284,7 +284,7 @@ extension OrderedDictionary {
   ///    high-quality hashing.
   @inlinable
   @inline(__always)
-  public func index(forKey key: Key) -> Index? {
+  public func index(forKey key: Key) -> Int? {
     _keys.firstIndex(of: key)
   }
 
@@ -298,7 +298,7 @@ extension OrderedDictionary {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public subscript(offset offset: Index) -> Element {
+  public subscript(offset offset: Int) -> Element {
     (_keys[offset], _values[offset])
   }
 }
@@ -616,8 +616,8 @@ extension OrderedDictionary {
   public mutating func updateValue(
     _ value: Value,
     forKey key: Key,
-    insertingAt index: Index
-  ) -> (originalMember: Value?, index: Index) {
+    insertingAt index: Int
+  ) -> (originalMember: Value?, index: Int) {
     let (inserted, offset) = _keys.insert(key, at: index)
     if inserted {
       assert(offset == index)

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
@@ -115,7 +115,7 @@ extension OrderedSet {
   @inlinable
   internal mutating func _insertNew(
     _ item: Element,
-    at index: Index,
+    at index: Int,
     in bucket: _Bucket
   ) {
     guard _elements.count < _capacity else {
@@ -155,8 +155,8 @@ extension OrderedSet {
   @discardableResult
   public mutating func insert(
     _ item: Element,
-    at index: Index
-  ) -> (inserted: Bool, index: Index) {
+    at index: Int
+  ) -> (inserted: Bool, index: Int) {
     let (existing, bucket) = _find(item)
     if let existing = existing { return (false, existing) }
     _insertNew(item, at: index, in: bucket)
@@ -181,7 +181,7 @@ extension OrderedSet {
   /// - Complexity: Amortized O(1).
   @inlinable
   @discardableResult
-  public mutating func update(_ item: Element, at index: Index) -> Element {
+  public mutating func update(_ item: Element, at index: Int) -> Element {
     let old = _elements[index]
     precondition(
       item == old,
@@ -239,8 +239,8 @@ extension OrderedSet {
   @discardableResult
   public mutating func updateOrInsert(
     _ item: Element,
-    at index: Index
-  ) -> (originalMember: Element?, index: Index) {
+    at index: Int
+  ) -> (originalMember: Element?, index: Int) {
     let (existing, bucket) = _find(item)
     if let existing = existing {
       let old = _elements[existing]

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial MutableCollection.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial MutableCollection.swift
@@ -24,7 +24,7 @@ extension OrderedSet {
   /// - Complexity: O(1) when the set's storage isn't shared with another
   ///    value; O(`count`) otherwise.
   @inlinable
-  public mutating func swapAt(_ i: Index, _ j: Index) {
+  public mutating func swapAt(_ i: Int, _ j: Int) {
     guard i != j else { return }
     _elements.swapAt(i, j)
     guard _table != nil else { return }
@@ -74,7 +74,7 @@ extension OrderedSet {
   @inlinable
   public mutating func partition(
     by belongsInSecondPartition: (Element) throws -> Bool
-  ) rethrows -> Index {
+  ) rethrows -> Int {
     try _partition(by: belongsInSecondPartition, callback: { a, b in })
   }
 }
@@ -84,12 +84,12 @@ extension OrderedSet {
   public mutating func _partition(
     by belongsInSecondPartition: (Element) throws -> Bool,
     callback: (Int, Int) -> Void
-  ) rethrows -> Index {
+  ) rethrows -> Int {
     guard _table != nil else {
       return try _elements.partition(by: belongsInSecondPartition)
     }
     _ensureUnique()
-    let result: Index = try _table!.update { hashTable in
+    let result: Int = try _table!.update { hashTable in
       let maybeOffset: Int? = try _elements.withContiguousMutableStorageIfAvailable { buffer in
         let pivot = try buffer._partition(
           with: hashTable,

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial RangeReplaceableCollection.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial RangeReplaceableCollection.swift
@@ -47,7 +47,7 @@ extension OrderedSet {
   /// - Complexity: O(`count`)
   @inlinable
   @discardableResult
-  public mutating func remove(at index: Index) -> Self.Element {
+  public mutating func remove(at index: Int) -> Self.Element {
     _elements._failEarlyRangeCheck(index, bounds: startIndex ..< endIndex)
     let bucket = _bucket(for: index)
     return _removeExistingMember(at: index, in: bucket)
@@ -63,7 +63,7 @@ extension OrderedSet {
   ///
   /// - Complexity: O(`count`)
   @inlinable
-  public mutating func removeSubrange(_ bounds: Range<Index>) {
+  public mutating func removeSubrange(_ bounds: Range<Int>) {
     _elements._failEarlyRangeCheck(
       bounds,
       bounds: _elements.startIndex ..< _elements.endIndex)
@@ -113,7 +113,7 @@ extension OrderedSet {
   @inlinable
   public mutating func removeSubrange<R: RangeExpression>(
     _ bounds: R
-  ) where R.Bound == Index {
+  ) where R.Bound == Int {
     removeSubrange(bounds.relative(to: self))
   }
 

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+RandomAccessCollection.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+RandomAccessCollection.swift
@@ -77,7 +77,7 @@ extension OrderedSet: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public var startIndex: Index { _elements.startIndex }
+  public var startIndex: Int { _elements.startIndex }
 
   /// The set's "past the end" position---that is, the position one greater
   /// than the last valid subscript argument.
@@ -88,7 +88,7 @@ extension OrderedSet: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public var endIndex: Index { _elements.endIndex }
+  public var endIndex: Int { _elements.endIndex }
 
   /// The indices that are valid for subscripting the collection, in ascending
   /// order.
@@ -110,7 +110,7 @@ extension OrderedSet: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(after i: Index) -> Index { i + 1 }
+  public func index(after i: Int) -> Int { i + 1 }
 
   /// Returns the position immediately before the given index.
   ///
@@ -124,7 +124,7 @@ extension OrderedSet: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(before i: Index) -> Index { i - 1 }
+  public func index(before i: Int) -> Int { i - 1 }
 
   /// Replaces the given index with its successor.
   ///
@@ -136,7 +136,7 @@ extension OrderedSet: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func formIndex(after i: inout Index) { i += 1 }
+  public func formIndex(after i: inout Int) { i += 1 }
 
   /// Replaces the given index with its predecessor.
   ///
@@ -148,7 +148,7 @@ extension OrderedSet: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func formIndex(before i: inout Index) { i -= 1 }
+  public func formIndex(before i: inout Int) { i -= 1 }
 
   /// Returns an index that is the specified distance from the given index.
   ///
@@ -167,7 +167,7 @@ extension OrderedSet: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+  public func index(_ i: Int, offsetBy distance: Int) -> Int {
     i + distance
   }
 
@@ -194,10 +194,10 @@ extension OrderedSet: RandomAccessCollection {
   @inlinable
   @inline(__always)
   public func index(
-    _ i: Index,
+    _ i: Int,
     offsetBy distance: Int,
-    limitedBy limit: Index
-  ) -> Index? {
+    limitedBy limit: Int
+  ) -> Int? {
     _elements.index(i, offsetBy: distance, limitedBy: limit)
   }
 
@@ -213,7 +213,7 @@ extension OrderedSet: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func distance(from start: Index, to end: Index) -> Int {
+  public func distance(from start: Int, to end: Int) -> Int {
     end - start
   }
 
@@ -225,7 +225,7 @@ extension OrderedSet: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public subscript(position: Index) -> Element {
+  public subscript(position: Int) -> Element {
     _elements[position]
   }
 
@@ -242,7 +242,7 @@ extension OrderedSet: RandomAccessCollection {
   ///
   /// - Complexity: O(1)
   @inlinable
-  public subscript(bounds: Range<Index>) -> SubSequence {
+  public subscript(bounds: Range<Int>) -> SubSequence {
     _failEarlyRangeCheck(bounds, bounds: startIndex ..< endIndex)
     return SubSequence(base: self, bounds: bounds)
   }
@@ -262,7 +262,7 @@ extension OrderedSet: RandomAccessCollection {
   public var count: Int { _elements.count }
 
   @inlinable
-  public func _customIndexOfEquatableElement(_ element: Element) -> Index?? {
+  public func _customIndexOfEquatableElement(_ element: Element) -> Int?? {
     guard let table = _table else {
       return _elements._customIndexOfEquatableElement(element)
     }
@@ -275,26 +275,26 @@ extension OrderedSet: RandomAccessCollection {
 
   @inlinable
   @inline(__always)
-  public func _customLastIndexOfEquatableElement(_ element: Element) -> Index?? {
+  public func _customLastIndexOfEquatableElement(_ element: Element) -> Int?? {
     // OrderedSet holds unique elements.
     _customIndexOfEquatableElement(element)
   }
 
   @inlinable
   @inline(__always)
-  public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
+  public func _failEarlyRangeCheck(_ index: Int, bounds: Range<Int>) {
     _elements._failEarlyRangeCheck(index, bounds: bounds)
   }
 
   @inlinable
   @inline(__always)
-  public func _failEarlyRangeCheck(_ index: Index, bounds: ClosedRange<Index>) {
+  public func _failEarlyRangeCheck(_ index: Int, bounds: ClosedRange<Int>) {
     _elements._failEarlyRangeCheck(index, bounds: bounds)
   }
 
   @inlinable
   @inline(__always)
-  public func _failEarlyRangeCheck(_ range: Range<Index>, bounds: Range<Index>) {
+  public func _failEarlyRangeCheck(_ range: Range<Int>, bounds: Range<Int>) {
     _elements._failEarlyRangeCheck(range, bounds: bounds)
   }
 }

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
@@ -22,11 +22,11 @@ extension OrderedSet {
     internal var _base: OrderedSet
 
     @usableFromInline
-    internal var _bounds: Range<Index>
+    internal var _bounds: Range<Int>
 
     @inlinable
     @inline(__always)
-    internal init(base: OrderedSet, bounds: Range<Index>) {
+    internal init(base: OrderedSet, bounds: Range<Int>) {
       self._base = base
       self._bounds = bounds
     }
@@ -40,7 +40,7 @@ extension OrderedSet.SubSequence {
   }
 
   @inlinable
-  internal func _index(of element: Element) -> Index? {
+  internal func _index(of element: Element) -> Int? {
     guard let index = _base._find(element).index else { return nil }
     guard _bounds.contains(index) else { return nil }
     return index
@@ -121,7 +121,7 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public var startIndex: Index { _bounds.lowerBound }
+  public var startIndex: Int { _bounds.lowerBound }
 
   /// The "past the end" position---that is, the position one greater
   /// than the last valid subscript argument.
@@ -132,7 +132,7 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public var endIndex: Index { _bounds.upperBound }
+  public var endIndex: Int { _bounds.upperBound }
 
   /// The indices that are valid for subscripting the collection, in ascending
   /// order.
@@ -154,7 +154,7 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(after i: Index) -> Index { i + 1 }
+  public func index(after i: Int) -> Int { i + 1 }
 
   /// Returns the position immediately before the given index.
   ///
@@ -168,7 +168,7 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(before i: Index) -> Index { i - 1 }
+  public func index(before i: Int) -> Int { i - 1 }
 
   /// Replaces the given index with its successor.
   ///
@@ -180,7 +180,7 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func formIndex(after i: inout Index) { i += 1 }
+  public func formIndex(after i: inout Int) { i += 1 }
 
   /// Replaces the given index with its predecessor.
   ///
@@ -192,7 +192,7 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func formIndex(before i: inout Index) { i -= 1 }
+  public func formIndex(before i: inout Int) { i -= 1 }
 
   /// Returns an index that is the specified distance from the given index.
   ///
@@ -211,7 +211,7 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+  public func index(_ i: Int, offsetBy distance: Int) -> Int {
     i + distance
   }
 
@@ -238,10 +238,10 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
   @inlinable
   @inline(__always)
   public func index(
-    _ i: Index,
+    _ i: Int,
     offsetBy distance: Int,
-    limitedBy limit: Index
-  ) -> Index? {
+    limitedBy limit: Int
+  ) -> Int? {
     _slice.index(i, offsetBy: distance, limitedBy: limit)
   }
 
@@ -257,7 +257,7 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public func distance(from start: Index, to end: Index) -> Int {
+  public func distance(from start: Int, to end: Int) -> Int {
     end - start
   }
 
@@ -269,7 +269,7 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public subscript(position: Index) -> Element {
+  public subscript(position: Int) -> Element {
     _slice[position]
   }
 
@@ -287,7 +287,7 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
   /// - Complexity: O(1)
   @inlinable
   @inline(__always)
-  public subscript(bounds: Range<Index>) -> SubSequence {
+  public subscript(bounds: Range<Int>) -> SubSequence {
     _failEarlyRangeCheck(bounds, bounds: startIndex ..< endIndex)
     return SubSequence(base: _base, bounds: bounds)
   }
@@ -308,31 +308,31 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
 
   @inlinable
   @inline(__always)
-  public func _customIndexOfEquatableElement(_ element: Element) -> Index?? {
+  public func _customIndexOfEquatableElement(_ element: Element) -> Int?? {
     .some(_index(of: element))
   }
 
   @inlinable
   @inline(__always)
-  public func _customLastIndexOfEquatableElement(_ element: Element) -> Index?? {
+  public func _customLastIndexOfEquatableElement(_ element: Element) -> Int?? {
     .some(_index(of: element))
   }
 
   @inlinable
   @inline(__always)
-  public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
+  public func _failEarlyRangeCheck(_ index: Int, bounds: Range<Int>) {
     _slice._failEarlyRangeCheck(index, bounds: bounds)
   }
 
   @inlinable
   @inline(__always)
-  public func _failEarlyRangeCheck(_ index: Index, bounds: ClosedRange<Index>) {
+  public func _failEarlyRangeCheck(_ index: Int, bounds: ClosedRange<Int>) {
     _slice._failEarlyRangeCheck(index, bounds: bounds)
   }
 
   @inlinable
   @inline(__always)
-  public func _failEarlyRangeCheck(_ range: Range<Index>, bounds: Range<Index>) {
+  public func _failEarlyRangeCheck(_ range: Range<Int>, bounds: Range<Int>) {
     _slice._failEarlyRangeCheck(range, bounds: bounds)
   }
 }

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
@@ -66,7 +66,7 @@
 /// it provides its own variants for insertion that are more explicit about
 /// where in the collection new elements gets inserted:
 ///
-///     func insert(_ item: Element, at index: Index) -> (inserted: Bool, index: Int)
+///     func insert(_ item: Element, at index: Int) -> (inserted: Bool, index: Int)
 ///     func append(_ item: Element) -> (inserted: Bool, index: Int)
 ///     func update(at index: Int, with item: Element) -> Element
 ///     func updateOrAppend(_ item: Element) -> Element?
@@ -381,13 +381,13 @@ extension OrderedSet {
 
 extension OrderedSet {
   @inlinable
-  internal func _find(_ item: Element) -> (index: Index?, bucket: _Bucket) {
+  internal func _find(_ item: Element) -> (index: Int?, bucket: _Bucket) {
     _find_inlined(item)
   }
 
   @inlinable
   @inline(__always)
-  internal func _find_inlined(_ item: Element) -> (index: Index?, bucket: _Bucket) {
+  internal func _find_inlined(_ item: Element) -> (index: Int?, bucket: _Bucket) {
     _elements.withUnsafeBufferPointer { elements in
       guard let table = _table else {
         return (elements.firstIndex(of: item), _Bucket(offset: 0))
@@ -399,7 +399,7 @@ extension OrderedSet {
   }
 
   @inlinable
-  internal func _bucket(for index: Index) -> _Bucket {
+  internal func _bucket(for index: Int) -> _Bucket {
     guard let table = _table else { return _Bucket(offset: 0) }
     return table.read { hashTable in
       var it = hashTable.bucketIterator(for: _elements[index])
@@ -419,7 +419,7 @@ extension OrderedSet {
   ///    average, provided that `Element` implements high-quality hashing.
   @inlinable
   @inline(__always)
-  public func firstIndex(of element: Element) -> Index? {
+  public func firstIndex(of element: Element) -> Int? {
     _find(element).index
   }
 
@@ -433,7 +433,7 @@ extension OrderedSet {
   ///    average, provided that `Element` implements high-quality hashing.
   @inlinable
   @inline(__always)
-  public func lastIndex(of element: Element) -> Index? {
+  public func lastIndex(of element: Element) -> Int? {
     _find(element).index
   }
 }
@@ -468,7 +468,7 @@ extension OrderedSet {
   @inlinable
   @discardableResult
   internal mutating func _removeExistingMember(
-    at index: Index,
+    at index: Int,
     in bucket: _Bucket
   ) -> Element {
     guard _elements.count - 1 >= _minimumCapacity else {


### PR DESCRIPTION
Closes #30. I tried to find all instances of Int where Index should have been used in the Source. I did not search the tests because the issue is semantic only, and my changes only have impact on the public API.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
