### PR TITLE
Fix compilation under BUILD_LIBRARY_FOR_DISTRIBUTION flag

### DIFF
--- a/Sources/DequeModule/Deque+Sequence.swift
+++ b/Sources/DequeModule/Deque+Sequence.swift
@@ -16,6 +16,7 @@ extension Deque: Sequence {
   // conversions from indices to storage slots.
 
   /// An iterator over the members of a deque.
+  @frozen
   public struct Iterator: IteratorProtocol {
     @usableFromInline
     internal var _storage: Deque._Storage

--- a/Sources/DequeModule/Deque._Storage.swift
+++ b/Sources/DequeModule/Deque._Storage.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Deque {
+  @frozen
   @usableFromInline
   struct _Storage {
     @usableFromInline

--- a/Sources/DequeModule/Deque._UnsafeHandle.swift
+++ b/Sources/DequeModule/Deque._UnsafeHandle.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Deque {
+  @frozen
   @usableFromInline
   internal struct _UnsafeHandle {
     @usableFromInline

--- a/Sources/DequeModule/_DequeBuffer.swift
+++ b/Sources/DequeModule/_DequeBuffer.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_fixed_layout
 @usableFromInline
 internal class _DequeBuffer<Element>: ManagedBuffer<_DequeBufferHeader, Element> {
   @inlinable

--- a/Sources/DequeModule/_UnsafeWrappedBuffer.swift
+++ b/Sources/DequeModule/_UnsafeWrappedBuffer.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@frozen
 @usableFromInline
 internal struct _UnsafeWrappedBuffer<Element> {
   @usableFromInline
@@ -51,6 +52,7 @@ internal struct _UnsafeWrappedBuffer<Element> {
   internal var count: Int { first.count + (second?.count ?? 0) }
 }
 
+@frozen
 @usableFromInline
 internal struct _UnsafeMutableWrappedBuffer<Element> {
   @usableFromInline

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
@@ -48,8 +48,6 @@ extension OrderedSet.SubSequence {
 }
 
 extension OrderedSet.SubSequence: Sequence {
-  // A type representing the collection’s elements.
-  public typealias Element = OrderedSet.Element
   /// The type that allows iteration over the collection's elements.
   public typealias Iterator = IndexingIterator<Self>
 

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
@@ -14,7 +14,6 @@ extension OrderedSet {
   /// conformance.
   @frozen
   public struct UnorderedView {
-    public typealias Element = OrderedSet.Element
 
     @usableFromInline
     internal var _base: OrderedSet
@@ -302,7 +301,7 @@ extension OrderedSet.UnorderedView {
   @inlinable
   @inline(__always)
   @discardableResult
-  public mutating func remove(_ member: Self.Element) -> Self.Element? {
+    public mutating func remove(_ member: OrderedSet.Element) -> OrderedSet.Element? {
     _base.remove(member)
   }
 }

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
@@ -12,6 +12,7 @@
 extension OrderedSet {
   /// An unordered view into an ordered set, providing `SetAlgebra`
   /// conformance.
+  @frozen
   public struct UnorderedView {
     public typealias Element = OrderedSet.Element
 


### PR DESCRIPTION
When building this package with `BUILD_LIBRARY_FOR_DISTRIBUTION` set to `YES`, the compilation fails in number of places with errors listed further below. You can reproduce the issue by attempting the following from the package root directory:

```
xcodebuild -workspace . -scheme Collections BUILD_LIBRARY_FOR_DISTRIBUTION=YES
```

Suggestions in compiler errors do not really work, but after some experimenting and from looking into stdlib, I found out that adding `@frozen` attribute to the problematic types fixes the problem.

I'm not sure if this is the right solution, but I'm happy to update my PR if you could point me into the right direction. I don't actually need support for library evolution, but I do need to be able to compile this package into an xcframework.
 

```swift
/Users/srdan/dev/swift-collections/Sources/DequeModule/Deque._UnsafeHandle.swift:31:12: error: 'let' property '_header' may not be initialized directly; use "self.init(...)" or "self = ..." instead
      self._header = header
           ^
/Users/srdan/dev/swift-collections/Sources/DequeModule/Deque._UnsafeHandle.swift:16:9: note: '_header' declared here
    let _header: UnsafeMutablePointer<_DequeBufferHeader>
        ^
/Users/srdan/dev/swift-collections/Sources/DequeModule/Deque._UnsafeHandle.swift:32:12: error: 'let' property '_elements' may not be initialized directly; use "self.init(...)" or "self = ..." instead
      self._elements = elements
           ^
/Users/srdan/dev/swift-collections/Sources/DequeModule/Deque._UnsafeHandle.swift:18:9: note: '_elements' declared here
    let _elements: UnsafeMutablePointer<Element>
        ^
/Users/srdan/dev/swift-collections/Sources/DequeModule/Deque._UnsafeHandle.swift:34:12: error: 'let' property '_isMutable' may not be initialized directly; use "self.init(...)" or "self = ..." instead
      self._isMutable = isMutable
           ^
/Users/srdan/dev/swift-collections/Sources/DequeModule/Deque._UnsafeHandle.swift:21:9: note: '_isMutable' declared here
    let _isMutable: Bool
        ^

/Users/srdan/dev/swift-collections/Sources/DequeModule/Deque+Sequence.swift:31:21: error: 'self' used before 'self.init' call or assignment to 'self'
      self._storage = _storage
                    ^
/Users/srdan/dev/swift-collections/Sources/DequeModule/Deque+Sequence.swift:32:22: error: 'self' used before 'self.init' call or assignment to 'self'
      self._nextSlot = start
                     ^
/Users/srdan/dev/swift-collections/Sources/DequeModule/Deque+Sequence.swift:33:21: error: 'self' used before 'self.init' call or assignment to 'self'
      self._endSlot = end
                    ^
/Users/srdan/dev/swift-collections/Sources/DequeModule/Deque+Sequence.swift:34:5: error: 'self.init' isn't called on all paths before returning from initializer
    }
    ^
/Users/srdan/dev/swift-collections/Sources/DequeModule/Deque._Storage.swift:24:20: error: 'self' used before 'self.init' call or assignment to 'self'
      self._buffer = _buffer
                   ^
/Users/srdan/dev/swift-collections/Sources/DequeModule/Deque._Storage.swift:25:5: error: 'self.init' isn't called on all paths before returning from initializer
    }
    ^

/Users/srdan/dev/swift-collections/Sources/DequeModule/Deque._Storage.swift:24:20: error: 'self' used before 'self.init' call or assignment to 'self'
      self._buffer = _buffer
                   ^
/Users/srdan/dev/swift-collections/Sources/DequeModule/Deque._Storage.swift:25:5: error: 'self.init' isn't called on all paths before returning from initializer
```

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
