### PR TITLE
Add Xcode template file with license comment.

### DIFF
--- a/swift-collections.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/swift-collections.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string>===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//</string>
+</dict>
+</plist>


### PR DESCRIPTION
This adds an `IDETemplateMacros.plist` which means all files created through Xcode automatically have the correct header comment generated with them.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [ ] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
