### PR TITLE
[Deque] Work around stdlib issue with Array.withContiguousStorageIfAvailable

### DIFF
--- a/Sources/DequeModule/Compatibility.swift
+++ b/Sources/DequeModule/Compatibility.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension Array {
+  /// Returns true if `Array.withContiguousStorageIfAvailable` is broken
+  /// in the stdlib we're currently running on.
+  ///
+  /// See https://bugs.swift.org/browse/SR-14663.
+  @inlinable
+  internal static func _isWCSIABroken() -> Bool {
+    #if _runtime(_ObjC)
+    guard _isBridgedVerbatimToObjectiveC(Element.self) else {
+      // SR-14663 only triggers on array values that are verbatim bridged
+      // from Objective-C, so it cannot ever trigger for element types
+      // that aren't verbatim bridged.
+      return false
+    }
+
+    // SR-14663 was introduced in Swift 5.1. Check if we have a broken stdlib.
+
+    // The bug is caused by a bogus precondition inside a non-inlinable stdlib
+    // method, so to determine if we're affected, we need to check the currently
+    // running OS version.
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else {
+      // The OS is too old to be affected by this bug.
+      return false
+    }
+    #endif
+    // FIXME: When a stdlib is released that contains a fix, add a check for it.
+    return true
+
+    #else
+    // Platforms that don't have an Objective-C runtime don't have verbatim
+    // bridged array values, so the bug doesn't apply to them.
+    return false
+    #endif
+  }
+}
+
+extension Sequence {
+  // An adjusted version of the standard `withContiguousStorageIfAvailable`
+  // method that works around https://bugs.swift.org/browse/SR-14663.
+  @inlinable
+  internal func _withContiguousStorageIfAvailable_SR14663<R>(
+    _ body: (UnsafeBufferPointer<Element>) throws -> R
+  ) rethrows -> R? {
+    if Self.self == Array<Element>.self && Array<Element>._isWCSIABroken() {
+      return nil
+    }
+
+    return try self.withContiguousStorageIfAvailable(body)
+  }
+}

--- a/Sources/DequeModule/Deque+Extras.swift
+++ b/Sources/DequeModule/Deque+Extras.swift
@@ -131,7 +131,7 @@ extension Deque {
   /// - SeeAlso: `append(contentsOf:)`
   @inlinable
   public mutating func prepend<C: Collection>(contentsOf newElements: C) where C.Element == Element {
-    let done: Void? = newElements.withContiguousStorageIfAvailable { source in
+    let done: Void? = newElements._withContiguousStorageIfAvailable_SR14663 { source in
       _storage.ensureUnique(minimumCapacity: count + source.count)
       _storage.update { $0.uncheckedPrepend(contentsOf: source) }
     }
@@ -166,6 +166,12 @@ extension Deque {
   /// - SeeAlso: `append(contentsOf:)`
   @inlinable
   public mutating func prepend<S: Sequence>(contentsOf newElements: S) where S.Element == Element {
+    let done: Void? = newElements._withContiguousStorageIfAvailable_SR14663 { source in
+      _storage.ensureUnique(minimumCapacity: count + source.count)
+      _storage.update { $0.uncheckedPrepend(contentsOf: source) }
+    }
+    guard done == nil else { return }
+
     let originalCount = self.count
     self.append(contentsOf: newElements)
     let newCount = self.count

--- a/Sources/DequeModule/Deque+RangeReplaceableCollection.swift
+++ b/Sources/DequeModule/Deque+RangeReplaceableCollection.swift
@@ -141,7 +141,7 @@ extension Deque: RangeReplaceableCollection {
     _storage.update { handle in
       assert(handle.startSlot == .zero)
       let target = handle.mutableBuffer(for: .zero ..< _Slot(at: c))
-      let done: Void? = elements.withContiguousStorageIfAvailable { source in
+      let done: Void? = elements._withContiguousStorageIfAvailable_SR14663 { source in
         target._initialize(from: source)
       }
       if done == nil {
@@ -198,7 +198,7 @@ extension Deque: RangeReplaceableCollection {
   /// - Complexity: Amortized O(`newElements.count`).
   @inlinable
   public mutating func append<S: Sequence>(contentsOf newElements: S) where S.Element == Element {
-    let done: Void? = newElements.withContiguousStorageIfAvailable { source in
+    let done: Void? = newElements._withContiguousStorageIfAvailable_SR14663 { source in
       _storage.ensureUnique(minimumCapacity: count + source.count)
       _storage.update { $0.uncheckedAppend(contentsOf: source) }
     }
@@ -240,7 +240,7 @@ extension Deque: RangeReplaceableCollection {
   /// - Complexity: Amortized O(`newElements.count`).
   @inlinable
   public mutating func append<C: Collection>(contentsOf newElements: C) where C.Element == Element {
-    let done: Void? = newElements.withContiguousStorageIfAvailable { source in
+    let done: Void? = newElements._withContiguousStorageIfAvailable_SR14663 { source in
       _storage.ensureUnique(minimumCapacity: count + source.count)
       _storage.update { $0.uncheckedAppend(contentsOf: source) }
     }


### PR DESCRIPTION
Resolves #27 by updating `Deque.init(_:)`, `.append(contentsOf:)` and `.prepend(contentsOf:)` to not call `Array.withContiguousStorageIfAvailable` if there is a chance doing so may trigger the underlying stdlib issue.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
