### PR TITLE
Update invalid OrderedDictionary invariant check.

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Invariants.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Invariants.swift
@@ -14,7 +14,7 @@ extension OrderedDictionary {
   @inline(never) @_effects(releasenone)
   public func _checkInvariants() {
     precondition(_keys.count == _values.count)
-    _keys.__unstable._checkInvariants()
+    self._keys._checkInvariants()
   }
   #else
   @inline(__always) @inlinable


### PR DESCRIPTION
Currently, `OrderedDictionary._checkInvariants()` delegates to `_UnstableInternals._checkInvariants()` which doesn't exist. This updates the invariant check to delegate to the invariant check on `OrderedSet` instead.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
