### PR TITLE
Mark OrderedSetDiffingTests with availability

### DIFF
--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSet Diffing Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSet Diffing Tests.swift
@@ -33,6 +33,7 @@ class MeasuringHashable: Hashable {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 class OrderedSetDiffingTests: CollectionTestCase {
 
   func _validatePerformance<T: Hashable>(from a: OrderedSet<T>, to b: OrderedSet<T>) {


### PR DESCRIPTION
The `OrderedSetDiffingTests` are testing `difference` and `applying` methods on the `OrderedSet` type. Those methods are defined in [`OrderedSet+Diffing.swift`](https://github.com/apple/swift-collections/blob/main/Sources/OrderedCollections/OrderedSet/OrderedSet%2BDiffing.swift) and have an availability annotation. That annotation was missing from the associated test class.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
~~- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).~~
~~- [ ] I've added benchmarks covering new functionality (if appropriate).~~
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
~~- [ ] I've updated the documentation if necessary.~~
