### PR TITLE
Fixing a small typo on quick help docs

### DIFF
--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
@@ -144,7 +144,7 @@ extension OrderedSet {
   ///
   /// - Returns: A pair `(inserted, index)`, where `inserted` is a Boolean value
   ///    indicating whether the operation added a new element, and `index` is
-  ///    the index of `item` in the resulting set. If `inserted` is true, then
+  ///    the index of `item` in the resulting set. If `inserted` is false, then
   ///    the returned `index` may be different from the index requested.
   ///
   /// - Complexity: The operation is expected to perform amortized


### PR DESCRIPTION
When calling `insert(_:at:)` the returned index may be different than the requested index in case `selected` is **false** rather than true

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [ ] I've followed the coding style of the rest of the project. (No changes on code were made, only on the documentation)
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [X] I've updated the documentation if necessary.
