### PR TITLE
[PoC] Conform `OrderedDictionary` to `Collection` by wrapping its integer indices in a non-`Hashable` index type

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Collection.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Collection.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension OrderedDictionary: Collection {
+
+  public struct Index: Comparable {
+    @inlinable
+    @inline(__always)
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+      lhs.value < rhs.value
+    }
+    
+    @inlinable
+    public init(value: Int) {
+      self.value = value
+    }
+    
+    public let value: Int
+  }
+
+  @inlinable
+  @inline(__always)
+  public var startIndex: Index {
+    Index(value: _keys.startIndex)
+  }
+
+  @inlinable
+  @inline(__always)
+  public var endIndex: Index {
+    Index(value: _keys.endIndex)
+  }
+
+  @inlinable
+  @inline(__always)
+  public func index(after i: Index) -> Index {
+    Index(value: _keys.index(after: i.value))
+  }
+
+  @inlinable
+  @inline(__always)
+  public subscript(position: Index) -> (key: Key, value: Value) {
+    get { (_keys[position.value], _values[position.value]) }
+  }
+
+}

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
@@ -248,8 +248,6 @@ extension OrderedDictionary {
 }
 
 extension OrderedDictionary {
-  public typealias Index = Int
-
   /// A Boolean value indicating whether the dictionary is empty.
   ///
   /// - Complexity: O(1)


### PR DESCRIPTION
### Description
This is a proof of concept for #57.

### Detailed Design

This PR changes `OrderedDictionary.Index` from a type alias of `Int` to a new concrete type, and adds the following new declarations:

```swift
extension OrderedDictionary: Collection {

  public struct Index: Comparable {
    @inlinable
    @inline(__always)
    public static func < (lhs: Self, rhs: Self) -> Bool {
      lhs.value < rhs.value
    }
    
    @inlinable
    public init(value: Int) {
      self.value = value
    }
    
    public let value: Int
  }

  @inlinable
  @inline(__always)
  public var startIndex: Index {
    Index(value: _keys.startIndex)
  }

  @inlinable
  @inline(__always)
  public var endIndex: Index {
    Index(value: _keys.endIndex)
  }

  @inlinable
  @inline(__always)
  public func index(after i: Index) -> Index {
    Index(value: _keys.index(after: i.value))
  }

  @inlinable
  @inline(__always)
  public subscript(position: Index) -> (key: Key, value: Value) {
    get { (_keys[position.value], _values[position.value]) }
  }

}
```

### Documentation
There is no change to documentation. I'll add new documentation if/when this graduates from simply a proof of concept.

### Testing
There is no change to testing, and all the new APIs introduced in this PR are untested. I'll add tests for them if/when this graduates from simply a proof of concept.

### Performance
I didn't verify the new feature's performance.

### Source Impact
`OrderedDictionary.Index` is no longer an alias of `Int`, so it's a source break for all users who use `OrderedDictionary.Index` in their code.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (to the extent possible).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexpected benchmark regressions.
- [ ] I've updated the documentation (if appropriate).
