### PR TITLE
[test] checkCollection: Don’t pass decreasing indices to distance(from:to:)

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-collections-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-collections-Package.xcscheme
@@ -37,28 +37,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DequeTests"
-               BuildableName = "DequeTests"
-               BlueprintName = "DequeTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CollectionsTestSupport"
-               BuildableName = "CollectionsTestSupport"
-               BlueprintName = "CollectionsTestSupport"
+               BlueprintIdentifier = "OrderedCollections"
+               BuildableName = "OrderedCollections"
+               BlueprintName = "OrderedCollections"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -73,6 +59,20 @@
                BlueprintIdentifier = "swift-collections-benchmark"
                BuildableName = "swift-collections-benchmark"
                BlueprintName = "swift-collections-benchmark"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CollectionsTestSupport"
+               BuildableName = "CollectionsTestSupport"
+               BlueprintName = "CollectionsTestSupport"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -106,15 +106,29 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "OrderedCollections"
-               BuildableName = "OrderedCollections"
-               BlueprintName = "OrderedCollections"
+               BlueprintIdentifier = "DequeTests"
+               BuildableName = "DequeTests"
+               BlueprintName = "DequeTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CollectionsTestSupportTests"
+               BuildableName = "CollectionsTestSupportTests"
+               BlueprintName = "CollectionsTestSupportTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -143,6 +157,16 @@
                BlueprintIdentifier = "OrderedCollectionsTests"
                BuildableName = "OrderedCollectionsTests"
                BlueprintName = "OrderedCollectionsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CollectionsTestSupportTests"
+               BuildableName = "CollectionsTestSupportTests"
+               BlueprintName = "CollectionsTestSupportTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>

--- a/Package.swift
+++ b/Package.swift
@@ -81,6 +81,10 @@ let package = Package(
           .when(platforms: [.macOS, .iOS, .watchOS, .tvOS])),
       ]
     ),
+    .testTarget(
+      name: "CollectionsTestSupportTests",
+      dependencies: ["CollectionsTestSupport"],
+      swiftSettings: settings),
 
     // Benchmarking
     .target(

--- a/Sources/CollectionsTestSupport/ConformanceCheckers/CheckCollection.swift
+++ b/Sources/CollectionsTestSupport/ConformanceCheckers/CheckCollection.swift
@@ -203,7 +203,7 @@ public func _checkCollection<C: Collection, Expected: Sequence>(
 
   // Check `distance(from:to:)`
   withEvery("i", in: allIndices.indices) { i in
-    withEvery("j", in: allIndices.indices) { j in
+    withEvery("j", in: allIndices.indices[i...]) { j in
       let d = collection.distance(from: allIndices[i], to: allIndices[j])
       expectEqual(d, j - i)
     }

--- a/Sources/CollectionsTestSupport/MinimalTypes/MinimalSequence.swift
+++ b/Sources/CollectionsTestSupport/MinimalTypes/MinimalSequence.swift
@@ -43,7 +43,7 @@ public enum UnderestimatedCountBehavior {
 /// A Sequence that implements the protocol contract in the most
 /// narrow way possible.
 ///
-/// This sequence is consumed when its generator is advanced.
+/// This sequence is consumed when its iterator is advanced.
 public struct MinimalSequence<T>: Sequence, CustomDebugStringConvertible {
   public let timesMakeIteratorCalled = ResettableValue(0)
 

--- a/Tests/CollectionsTestSupportTests/MinimalTypeConformances.swift
+++ b/Tests/CollectionsTestSupportTests/MinimalTypeConformances.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import CollectionsTestSupport
+
+final class DequeTests: CollectionTestCase {
+  func testMinimalSequence() {
+    withEvery(
+      "behavior",
+      in: [
+        UnderestimatedCountBehavior.precise,
+        UnderestimatedCountBehavior.half,
+        UnderestimatedCountBehavior.value(0)
+      ]
+    ) { behavior in
+      withEvery("isContiguous", in: [false, true]) { isContiguous in
+        func make() -> MinimalSequence<Int> {
+          MinimalSequence(
+            elements: 0 ..< 50,
+            underestimatedCount: behavior,
+            isContiguous: isContiguous)
+        }
+        checkSequence(make, expectedContents: 0 ..< 50)
+      }
+    }
+  }
+
+  func testMinimalCollection() {
+    checkCollection(MinimalCollection(0 ..< 50), expectedContents: 0 ..< 50)
+  }
+
+  func testMinimalBidirectionalCollection() {
+    checkBidirectionalCollection(MinimalBidirectionalCollection(0 ..< 50), expectedContents: 0 ..< 50)
+  }
+}


### PR DESCRIPTION
Also, try running the conformance checkers on the minimal collection types to catch similar issues.

Resolves #59.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
