### PR TITLE
Fix Markdown link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The package currently provides the following implementations:
 
 - [`OrderedDictionary<Key, Value>`][OrderedDictionary], an ordered variant of the standard `Dictionary`, providing similar benefits.
 
-- [`Heap<Element>`](Documentation/Heap.md], a min-max heap backed by an array.
+- [`Heap<Element>`](Documentation/Heap.md), a min-max heap backed by an array.
 
 [Deque]: Documentation/Deque.md
 [OrderedSet]: Documentation/OrderedSet.md


### PR DESCRIPTION
The markdown link has a closing bracket instead of a parenthesis.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've updated the documentation if necessary.
