### PR TITLE
[Heap] Performance tweaks

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/PriorityQueueModule.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/PriorityQueueModule.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Sources/PriorityQueueModule/Heap+Invariants.swift
+++ b/Sources/PriorityQueueModule/Heap+Invariants.swift
@@ -14,78 +14,39 @@ import Foundation
 
 extension Heap {
   #if COLLECTIONS_INTERNAL_CHECKS
-  /// Iterates through all the levels in the heap, ensuring that items in min
-  /// levels are smaller than all their descendants and items in max levels
-  /// are larger than all their descendants.
-  ///
-  /// The min-max heap indices are structured like this:
-  ///
-  /// ```
-  /// min               0
-  /// max        1             2
-  /// min      3   4         5     6
-  /// max     7 8 9 10     11 12 13 14
-  /// min    15...
-  /// ...
-  /// ```
-  ///
-  /// The iteration happens in depth-first order, so the descendants of the
-  /// element at index 0 are checked to ensure they are >= that element. This is
-  /// repeated for each child of the element at index 0 (inverting the
-  /// comparison at each level).
-  ///
-  /// In the case of 7 elements total (spread across 3 levels), the checking
-  /// happens in the following order:
-  ///
-  /// ```
-  /// compare >= 0: 1, 3, 4, 2, 5, 6
-  /// compare <= 1: 3, 4
-  /// compare >= 3: (no children)
-  /// compare >= 4: (no children)
-  /// compare <= 2: 5, 6
-  /// compare >= 5: (no children)
-  /// compare >= 6: (no children)
-  /// ```
+  /// Visits each item in the heap in depth-first order, verifying that the
+  /// contents satisfy the min-max heap property.
   @inlinable
   @inline(never)
   internal func _checkInvariants() {
     guard count > 1 else { return }
-    var indicesToVisit: [Int] = [0]
+    _checkInvariants(index: 0, min: nil, max: nil)
+  }
 
-    while let elementIdx = indicesToVisit.popLast() {
-      let element = _storage[elementIdx]
-
-      let isMinLevel = _minMaxHeapIsMinLevel(elementIdx)
-
-      var descendantIndicesToVisit = [Int]()
-
-      // Add the children of this element to the outer loop (as we want to check
-      // that they are >= or <= their descendants as well)
-      if let rightIdx = _rightChildIndex(of: elementIdx) {
-        descendantIndicesToVisit.append(rightIdx)
-        indicesToVisit.append(rightIdx)
+  @inlinable
+  internal func _checkInvariants(index: Int, min: Element?, max: Element?) {
+    let value = _storage[index]
+    if let min = min {
+      precondition(value >= min,
+                   "Element '\(value)' at index \(index) should be >= '\(min)'")
+    }
+    if let max = max {
+      precondition(value <= max,
+                   "Element '\(value)' at index \(index) should be <= '\(max)'")
+    }
+    if _minMaxHeapIsMinLevel(index) {
+      if let left = _leftChildIndex(of: index) {
+        _checkInvariants(index: left, min: value, max: max)
       }
-      if let leftIdx = _leftChildIndex(of: elementIdx) {
-        descendantIndicesToVisit.append(leftIdx)
-        indicesToVisit.append(leftIdx)
+      if let right = _rightChildIndex(of: index) {
+        _checkInvariants(index: right, min: value, max: max)
       }
-
-      // Compare the current element against its descendants
-      while let idx = descendantIndicesToVisit.popLast() {
-        if isMinLevel {
-          precondition(element <= _storage[idx],
-            "Element '\(_storage[idx])' at index \(idx) should be >= '\(element)'")
-        } else {
-          precondition(element >= _storage[idx],
-            "Element '\(_storage[idx])' at index \(idx) should be <= '\(element)'")
-        }
-
-        if let rightIdx = _rightChildIndex(of: idx) {
-          descendantIndicesToVisit.append(rightIdx)
-        }
-        if let leftIdx = _leftChildIndex(of: idx) {
-          descendantIndicesToVisit.append(leftIdx)
-        }
+    } else {
+      if let left = _leftChildIndex(of: index) {
+        _checkInvariants(index: left, min: min, max: value)
+      }
+      if let right = _rightChildIndex(of: index) {
+        _checkInvariants(index: right, min: min, max: value)
       }
     }
   }

--- a/Sources/PriorityQueueModule/Heap+Invariants.swift
+++ b/Sources/PriorityQueueModule/Heap+Invariants.swift
@@ -25,7 +25,7 @@ extension Heap {
 
   @inlinable
   internal func _checkInvariants(node: _Node, min: Element?, max: Element?) {
-    let value = _element(at: node)
+    let value = _storage[node.offset]
     if let min = min {
       precondition(value >= min,
                    "Element \(value) at \(node) is less than min \(min)")
@@ -34,18 +34,20 @@ extension Heap {
       precondition(value <= max,
                    "Element \(value) at \(node) is greater than max \(max)")
     }
+    let left = node.leftChild()
+    let right = node.rightChild()
     if node.isMinLevel {
-      if let left = node.leftChild(limit: count) {
+      if left.offset < count {
         _checkInvariants(node: left, min: value, max: max)
       }
-      if let right = node.rightChild(limit: count) {
+      if right.offset < count {
         _checkInvariants(node: right, min: value, max: max)
       }
     } else {
-      if let left = node.leftChild(limit: count) {
+      if left.offset < count {
         _checkInvariants(node: left, min: min, max: value)
       }
-      if let right = node.rightChild(limit: count) {
+      if right.offset < count {
         _checkInvariants(node: right, min: min, max: value)
       }
     }

--- a/Sources/PriorityQueueModule/Heap+Invariants.swift
+++ b/Sources/PriorityQueueModule/Heap+Invariants.swift
@@ -20,33 +20,33 @@ extension Heap {
   @inline(never)
   internal func _checkInvariants() {
     guard count > 1 else { return }
-    _checkInvariants(index: 0, min: nil, max: nil)
+    _checkInvariants(node: .root, min: nil, max: nil)
   }
 
   @inlinable
-  internal func _checkInvariants(index: Int, min: Element?, max: Element?) {
-    let value = _storage[index]
+  internal func _checkInvariants(node: _Node, min: Element?, max: Element?) {
+    let value = _element(at: node)
     if let min = min {
       precondition(value >= min,
-                   "Element '\(value)' at index \(index) should be >= '\(min)'")
+                   "Element \(value) at \(node) is less than min \(min)")
     }
     if let max = max {
       precondition(value <= max,
-                   "Element '\(value)' at index \(index) should be <= '\(max)'")
+                   "Element \(value) at \(node) is greater than max \(max)")
     }
-    if _minMaxHeapIsMinLevel(index) {
-      if let left = _leftChildIndex(of: index) {
-        _checkInvariants(index: left, min: value, max: max)
+    if node.isMinLevel {
+      if let left = node.leftChild(limit: count) {
+        _checkInvariants(node: left, min: value, max: max)
       }
-      if let right = _rightChildIndex(of: index) {
-        _checkInvariants(index: right, min: value, max: max)
+      if let right = node.rightChild(limit: count) {
+        _checkInvariants(node: right, min: value, max: max)
       }
     } else {
-      if let left = _leftChildIndex(of: index) {
-        _checkInvariants(index: left, min: min, max: value)
+      if let left = node.leftChild(limit: count) {
+        _checkInvariants(node: left, min: min, max: value)
       }
-      if let right = _rightChildIndex(of: index) {
-        _checkInvariants(index: right, min: min, max: value)
+      if let right = node.rightChild(limit: count) {
+        _checkInvariants(node: right, min: min, max: value)
       }
     }
   }

--- a/Sources/PriorityQueueModule/Heap+UnsafeHandle.swift
+++ b/Sources/PriorityQueueModule/Heap+UnsafeHandle.swift
@@ -98,15 +98,24 @@ extension Heap._UnsafeHandle {
     let parent = node.parent()
 
     var node = node
-    if node.isMinLevel == (self[node] > self[parent]) {
+    if (node.isMinLevel && self[node] > self[parent])
+        || (!node.isMinLevel && self[node] < self[parent]){
       swapAt(node, parent)
       node = parent
     }
 
-    while let grandparent = node.grandParent(),
-          node.isMinLevel == (self[node] < self[grandparent]) {
-      swapAt(node, grandparent)
-      node = grandparent
+    if node.isMinLevel {
+      while let grandparent = node.grandParent(),
+            self[node] < self[grandparent] {
+        swapAt(node, grandparent)
+        node = grandparent
+      }
+    } else {
+      while let grandparent = node.grandParent(),
+            self[node] > self[grandparent] {
+        swapAt(node, grandparent)
+        node = grandparent
+      }
     }
   }
 }

--- a/Sources/PriorityQueueModule/Heap+UnsafeHandle.swift
+++ b/Sources/PriorityQueueModule/Heap+UnsafeHandle.swift
@@ -63,6 +63,13 @@ extension Heap._UnsafeHandle {
   internal func swapAt(_ i: _Node, _ j: _Node) {
     buffer.swapAt(i.offset, j.offset)
   }
+
+  /// Swaps the element at the given node with the supplied value.
+  @inlinable @inline(__always)
+  internal func swapAt(_ i: _Node, with value: inout Element) {
+    let p = buffer.baseAddress.unsafelyUnwrapped + i.offset
+    swap(&p.pointee, &value)
+  }
 }
 
 extension Heap._UnsafeHandle {
@@ -132,19 +139,10 @@ extension Heap._UnsafeHandle {
 }
 
 extension Heap._UnsafeHandle {
-  @inline(__always)
-  @inlinable
-  internal func trickleDown(_ node: _Node) {
-    if node.isMinLevel {
-      trickleDownMin(node)
-    } else {
-      trickleDownMax(node)
-    }
-  }
-
-  @inline(__always)
+  @_effects(releasenone)
   @inlinable
   internal func trickleDownMin(_ node: _Node) {
+    assert(node.isMinLevel)
     var node = node
 
     while let minDescendant = minChildOrGrandchild(of: node) {
@@ -167,9 +165,10 @@ extension Heap._UnsafeHandle {
     }
   }
 
-  @inline(__always)
+  @_effects(releasenone)
   @inlinable
   internal func trickleDownMax(_ node: _Node) {
+    assert(!node.isMinLevel)
     var node = node
 
     while let maxDescendant = maxChildOrGrandchild(of: node) {

--- a/Sources/PriorityQueueModule/Heap+UnsafeHandle.swift
+++ b/Sources/PriorityQueueModule/Heap+UnsafeHandle.swift
@@ -1,0 +1,302 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension Heap {
+  @usableFromInline @frozen
+  struct _UnsafeHandle {
+    @usableFromInline
+    var buffer: UnsafeMutableBufferPointer<Element>
+
+    @inlinable @inline(__always)
+    init(_ buffer: UnsafeMutableBufferPointer<Element>) {
+      self.buffer = buffer
+    }
+  }
+
+  @inlinable @inline(__always)
+  mutating func _update<R>(_ body: (_UnsafeHandle) -> R) -> R {
+    #if false
+    @inline(__always)
+    func _body(
+      _ buffer: inout UnsafeMutableBufferPointer<Element>
+    ) -> R {
+      body(_UnsafeHandle(buffer))
+    }
+
+    return _storage.withUnsafeMutableBufferPointer(_body)
+    #else
+    _storage.withUnsafeMutableBufferPointer { buffer in
+      body(_UnsafeHandle(buffer))
+    }
+    #endif
+  }
+}
+
+extension Heap._UnsafeHandle {
+  @inlinable @inline(__always)
+  internal var count: Int {
+    buffer.count
+  }
+
+  @inlinable
+  subscript(node: _Node) -> Element {
+    @inline(__always)
+    get {
+      buffer[node.offset]
+    }
+    @inline(__always)
+    nonmutating _modify {
+      yield &buffer[node.offset]
+    }
+  }
+
+  /// Swaps the elements in the heap at the given indices.
+  @inlinable @inline(__always)
+  internal func swapAt(_ i: _Node, _ j: _Node) {
+    buffer.swapAt(i.offset, j.offset)
+  }
+}
+
+extension Heap._UnsafeHandle {
+  @inline(__always)
+  @inlinable
+  internal func bubbleUp(_ node: _Node) {
+    guard let parent = node.parent() else {
+      // We're already at the root -- can't go any further
+      return
+    }
+
+    if node.isMinLevel {
+      if self[node] > self[parent] {
+        swapAt(node, parent)
+        bubbleUpMax(parent)
+      } else {
+        bubbleUpMin(node)
+      }
+    } else {
+      if self[node] < self[parent] {
+        swapAt(node, parent)
+        bubbleUpMin(parent)
+      } else {
+        bubbleUpMax(node)
+      }
+    }
+  }
+
+  @inline(__always)
+  @inlinable
+  internal func bubbleUpMin(_ node: _Node) {
+    var node = node
+
+    while let grandparent = node.grandParent(),
+          self[node] < self[grandparent] {
+      swapAt(node, grandparent)
+      node = grandparent
+    }
+  }
+
+  @inline(__always)
+  @inlinable
+  internal func bubbleUpMax(_ node: _Node) {
+    var node = node
+
+    while let grandparent = node.grandParent(),
+          self[node] > self[grandparent] {
+      swapAt(node, grandparent)
+      node = grandparent
+    }
+  }
+}
+
+extension Heap._UnsafeHandle {
+  @inline(__always)
+  @inlinable
+  internal func trickleDown(_ node: _Node) {
+    if node.isMinLevel {
+      trickleDownMin(node)
+    } else {
+      trickleDownMax(node)
+    }
+  }
+
+  @inline(__always)
+  @inlinable
+  internal func trickleDownMin(_ node: _Node) {
+    var node = node
+
+    while let minDescendant = minChildOrGrandchild(of: node) {
+      guard self[minDescendant] < self[node] else {
+        return
+      }
+      swapAt(minDescendant, node)
+
+      if minDescendant.level == node.level + 1 {
+        return
+      }
+
+      // Smallest is a grandchild
+      let parent = minDescendant.parent()!
+      if self[minDescendant] > self[parent] {
+        swapAt(minDescendant, parent)
+      }
+
+      node = minDescendant
+    }
+  }
+
+  @inline(__always)
+  @inlinable
+  internal func trickleDownMax(_ node: _Node) {
+    var node = node
+
+    while let maxDescendant = maxChildOrGrandchild(of: node) {
+      guard self[maxDescendant] > self[node] else {
+        return
+      }
+      swapAt(maxDescendant, node)
+
+      if maxDescendant.level == node.level + 1 {
+        return
+      }
+
+      // Largest is a grandchild
+      let parent = maxDescendant.parent()!
+      if self[maxDescendant] < self[parent] {
+        swapAt(maxDescendant, parent)
+      }
+
+      node = maxDescendant
+    }
+  }
+
+  /// Returns the lowest priority child or grandchild of the element at the
+  /// given index.
+  ///
+  /// Returns `nil` if the element has no descendants.
+  ///
+  /// - parameter index: The index of the element whose descendants should be
+  ///                    compared.
+  @inline(__always)
+  @inlinable
+  internal func minChildOrGrandchild(of node: _Node) -> _Node? {
+    assert(node.isMinLevel)
+    guard let leftChild = node.leftChild(limit: count) else {
+      return nil
+    }
+
+    guard let rightChild = node.rightChild(limit: count) else {
+      return leftChild
+    }
+
+    guard let grandchildren = node.grandchildren(limit: count) else {
+      // We have no grandchildren -- compare the two children instead
+      return (self[rightChild] < self[leftChild] ? rightChild : leftChild)
+    }
+
+    var minValue = self[leftChild]
+    var minNode = leftChild
+
+    // If we have at least 3 grandchildren, we can skip comparing the children
+    // as the heap invariants will ensure that the grandchildren will be smaller.
+    // Otherwise, we need to do the comparison.
+    if grandchildren._count < 3 {
+      // Compare the two children
+      let rightValue = self[rightChild]
+      if rightValue < minValue {
+        minValue = rightValue
+        minNode = rightChild
+      }
+    }
+
+    // Iterate through the grandchildren
+    grandchildren._forEach { grandchild in
+      let value = self[grandchild]
+      if value < minValue {
+        minValue = value
+        minNode = grandchild
+      }
+    }
+
+    return minNode
+  }
+
+  /// Returns the highest priority child or grandchild of the element at the
+  /// given index.
+  ///
+  /// Returns `nil` if the element has no descendants.
+  ///
+  /// - parameter index: The index of the item whose descendants should be
+  ///                    compared.
+  @inline(__always)
+  @inlinable
+  internal func maxChildOrGrandchild(of node: _Node) -> _Node? {
+    assert(!node.isMinLevel)
+    guard let leftChild = node.leftChild(limit: count) else {
+      return nil
+    }
+
+    guard let rightChild = node.rightChild(limit: count) else {
+      return leftChild
+    }
+
+    guard let grandchildren = node.grandchildren(limit: count) else {
+      // We have no grandchildren -- compare the two children instead
+      return (self[rightChild] > self[leftChild] ? rightChild : leftChild)
+    }
+
+    var maxValue = self[leftChild]
+    var maxNode = leftChild
+
+    // If we have at least 3 grandchildren, we can skip comparing the children
+    // as the heap invariants will ensure that the grandchildren will be smaller.
+    // Otherwise, we need to do the comparison.
+    if grandchildren._count < 3 {
+      // Compare the two children
+      let rightValue = self[rightChild]
+      if rightValue > maxValue {
+        maxValue = rightValue
+        maxNode = rightChild
+      }
+    }
+
+    // Iterate through the grandchildren
+    grandchildren._forEach { grandchild in
+      let value = self[grandchild]
+      if value > maxValue {
+        maxValue = value
+        maxNode = grandchild
+      }
+    }
+
+    return maxNode
+  }
+}
+
+extension Heap._UnsafeHandle {
+  @inlinable
+  internal func heapify() {
+    let limit = count / 2 // The first offset without a left child
+    var level = _Node.level(forOffset: limit &- 1)
+    while level >= 0 {
+      let nodes = _Node.allNodes(onLevel: level, limit: limit)
+      if _Node.isMinLevel(level) {
+        nodes?._forEach { node in
+          trickleDownMin(node)
+        }
+      } else {
+        nodes?._forEach { node in
+          trickleDownMax(node)
+        }
+      }
+      level &-= 1
+    }
+  }
+}

--- a/Sources/PriorityQueueModule/Heap+UnsafeHandle.swift
+++ b/Sources/PriorityQueueModule/Heap+UnsafeHandle.swift
@@ -23,20 +23,9 @@ extension Heap {
 
   @inlinable @inline(__always)
   mutating func _update<R>(_ body: (_UnsafeHandle) -> R) -> R {
-    #if false
-    @inline(__always)
-    func _body(
-      _ buffer: inout UnsafeMutableBufferPointer<Element>
-    ) -> R {
-      body(_UnsafeHandle(buffer))
-    }
-
-    return _storage.withUnsafeMutableBufferPointer(_body)
-    #else
     _storage.withUnsafeMutableBufferPointer { buffer in
       body(_UnsafeHandle(buffer))
     }
-    #endif
   }
 }
 

--- a/Sources/PriorityQueueModule/Heap+UnsafeHandle.swift
+++ b/Sources/PriorityQueueModule/Heap+UnsafeHandle.swift
@@ -91,66 +91,20 @@ extension Heap._UnsafeHandle {
 }
 
 extension Heap._UnsafeHandle {
-  // Note: the releasenone annotation here tells the compiler that this function
-  // will not release any strong references, so it doesn't need to worry about
-  // retaining things. This is true in the sense that `bubbleUp` just reorders
-  // storage contents, but it does call `Element.<`, which we cannot really
-  // promise anything about -- it may release things!
-  //
-  // FWIW, I think `Element`'s Comparable implementation can only cause the
-  // heap's storage to be released if it included an exclusivity violation --
-  // `bubbleUp` is only ever called from mutating heap members, after all.
-  // So if there is an issue, I think it would be triggered by the `Comparable`
-  // implementation releasing something inside `Element`, and/or by the
-  // `releasenone` annotation here having an effect in client code that called
-  // into `Heap`.
-  @_effects(releasenone)
   @inlinable
   internal func bubbleUp(_ node: _Node) {
-    if node.isRoot {
-      // We're can't go any further
-      return
-    }
+    guard !node.isRoot else { return }
+
     let parent = node.parent()
 
-    if node.isMinLevel {
-      if self[node] > self[parent] {
-        swapAt(node, parent)
-        bubbleUpMax(parent)
-      } else {
-        bubbleUpMin(node)
-      }
-    } else {
-      if self[node] < self[parent] {
-        swapAt(node, parent)
-        bubbleUpMin(parent)
-      } else {
-        bubbleUpMax(node)
-      }
-    }
-  }
-
-  @_effects(releasenone)
-  @inline(__always)
-  @inlinable
-  internal func bubbleUpMin(_ node: _Node) {
     var node = node
+    if node.isMinLevel == (self[node] > self[parent]) {
+      swapAt(node, parent)
+      node = parent
+    }
 
     while let grandparent = node.grandParent(),
-          self[node] < self[grandparent] {
-      swapAt(node, grandparent)
-      node = grandparent
-    }
-  }
-
-  @_effects(releasenone)
-  @inline(__always)
-  @inlinable
-  internal func bubbleUpMax(_ node: _Node) {
-    var node = node
-
-    while let grandparent = node.grandParent(),
-          self[node] > self[grandparent] {
+          node.isMinLevel == (self[node] < self[grandparent]) {
       swapAt(node, grandparent)
       node = grandparent
     }

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -25,8 +25,16 @@
 /// doi:[10.1145/6617.6621](https://doi.org/10.1145/6617.6621)
 public struct Heap<Element: Comparable> {
   @usableFromInline
-  internal var _storage: [Element]
+  internal var _storage: ContiguousArray<Element>
 
+  /// Creates an empty heap.
+  @inlinable
+  public init() {
+    _storage = []
+  }
+}
+
+extension Heap {
   /// A Boolean value indicating whether or not the heap is empty.
   ///
   /// - Complexity: O(1)
@@ -52,13 +60,7 @@ public struct Heap<Element: Comparable> {
   /// - Complexity: O(1)
   @inlinable
   public var unordered: [Element] {
-    _storage
-  }
-
-  /// Creates an empty heap.
-  @inlinable
-  public init() {
-    _storage = []
+    Array(_storage)
   }
 
   /// Inserts the given element into the heap.
@@ -183,7 +185,7 @@ extension Heap {
     //
     // FIXME: See if a more cache friendly algorithm would be faster.
 
-    _storage = Array(elements)
+    _storage = ContiguousArray(elements)
     guard _storage.count > 1 else { return }
 
     _update { handle in

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -135,13 +135,11 @@ extension Heap {
 
     _update { handle in
       if handle.count == 2 {
-        if handle.buffer[1] > removed {
+        if handle[.leftMax] > removed {
           handle.swapAt(.leftMax, with: &removed)
         }
       } else {
-        let maxNode = handle.buffer[2] > handle.buffer[1]
-          ? _Node.rightMax
-          : _Node.leftMax
+        let maxNode = handle.maxValue(.rightMax, .leftMax)
         handle.swapAt(maxNode, with: &removed)
         handle.trickleDownMax(maxNode)
       }

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -203,6 +203,10 @@ extension Heap {
   public mutating func insert<S: Sequence>(
     contentsOf newElements: S
   ) where S.Element == Element {
+    if count == 0 {
+      self = Self(newElements)
+      return
+    }
     _storage.reserveCapacity(count + newElements.underestimatedCount)
     for element in newElements {
       insert(element)

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -30,7 +30,7 @@ public struct Heap<Element: Comparable> {
   /// A Boolean value indicating whether or not the heap is empty.
   ///
   /// - Complexity: O(1)
-  @inlinable
+  @inlinable @inline(__always)
   public var isEmpty: Bool {
     _storage.isEmpty
   }
@@ -38,7 +38,7 @@ public struct Heap<Element: Comparable> {
   /// The number of elements in the heap.
   ///
   /// - Complexity: O(1)
-  @inlinable
+  @inlinable @inline(__always)
   public var count: Int {
     _storage.count
   }
@@ -67,7 +67,7 @@ public struct Heap<Element: Comparable> {
   @inlinable
   public mutating func insert(_ element: Element) {
     _storage.append(element)
-    _bubbleUp(elementAt: _storage.endIndex - 1)
+    _bubbleUp(elementAt: _Node(offset: _storage.endIndex - 1))
     _checkInvariants()
   }
 
@@ -104,7 +104,7 @@ public struct Heap<Element: Comparable> {
   @inlinable
   public mutating func popMin() -> Element? {
     defer { _checkInvariants() }
-    return _remove(at: 0)
+    return _remove(at: .root)
   }
 
   /// Removes and returns the element with the highest priority, if available.
@@ -113,18 +113,16 @@ public struct Heap<Element: Comparable> {
   @inlinable
   public mutating func popMax() -> Element? {
     defer { _checkInvariants() }
-    switch _storage.count {
-    case 0, 1, 2:
+    guard count > 2 else {
       // If count is 0, `popLast` will return `nil`
       // If count is 1, the last (and only) item is the max
       // If count is 2, the last item is the max (as it's the only item in the
       // first max level)
       return _storage.popLast()
-    default:
-      // The max item is the larger of the two items in the first max level
-      let maxIdx = _storage[2] > _storage[1] ? 2 : 1
-      return _remove(at: maxIdx)
     }
+    // The max item is the larger of the two items in the first max level
+    let max = _Node(offset: _storage[2] > _storage[1] ? 2 : 1)
+    return _remove(at: max)
   }
 
   /// Removes and returns the element with the lowest priority.
@@ -149,72 +147,75 @@ public struct Heap<Element: Comparable> {
 
   // MARK: -
 
+  @inlinable @inline(__always)
+  internal func _element(at index: _Node) -> Element {
+    _storage[index.offset]
+  }
+
   @inline(__always)
   @inlinable
-  internal mutating func _bubbleUp(elementAt index: Int) {
-    guard let parentIdx = _parentIndex(of: index) else {
+  internal mutating func _bubbleUp(elementAt node: _Node) {
+    guard let parent = node.parent() else {
       // We're already at the root -- can't go any further
       return
     }
 
-    // Figure out if `index` is on an even or odd level
-    let levelIsMin = _minMaxHeapIsMinLevel(index)
-
-    if levelIsMin {
-      if _storage[index] > _storage[parentIdx] {
-        _swapAt(index, parentIdx)
-        _bubbleUpMax(elementAt: parentIdx)
+    if node.isMinLevel {
+      if _element(at: node) > _element(at: parent) {
+        _swapAt(node, parent)
+        _bubbleUpMax(elementAt: parent)
       } else {
-        _bubbleUpMin(elementAt: index)
+        _bubbleUpMin(elementAt: node)
       }
     } else {
-      if _storage[index] < _storage[parentIdx] {
-        _swapAt(index, parentIdx)
-        _bubbleUpMin(elementAt: parentIdx)
+      if _element(at: node) < _element(at: parent) {
+        _swapAt(node, parent)
+        _bubbleUpMin(elementAt: parent)
       } else {
-        _bubbleUpMax(elementAt: index)
+        _bubbleUpMax(elementAt: node)
       }
     }
   }
 
   @inline(__always)
   @inlinable
-  internal mutating func _bubbleUpMin(elementAt index: Int) {
-    var index = index
+  internal mutating func _bubbleUpMin(elementAt node: _Node) {
+    var node = node
 
-    while let grandparentIdx = _grandparentIndex(of: index),
-          _storage[index] < _storage[grandparentIdx] {
-      _swapAt(index, grandparentIdx)
-      index = grandparentIdx
+    while let grandparent = node.grandParent(),
+          _element(at: node) < _element(at: grandparent) {
+      _swapAt(node, grandparent)
+      node = grandparent
     }
   }
 
   @inline(__always)
   @inlinable
-  internal mutating func _bubbleUpMax(elementAt index: Int) {
-    var index = index
+  internal mutating func _bubbleUpMax(elementAt node: _Node) {
+    var node = node
 
-    while let grandparentIdx = _grandparentIndex(of: index),
-          _storage[index] > _storage[grandparentIdx] {
-      _swapAt(index, grandparentIdx)
-      index = grandparentIdx
+    while let grandparent = node.grandParent(),
+          _element(at: node) > _element(at: grandparent) {
+      _swapAt(node, grandparent)
+      node = grandparent
     }
   }
 
   // MARK: -
 
   @discardableResult
+  @inline(__always)
   @inlinable
-  internal mutating func _remove(at index: Int) -> Element? {
-    guard _storage.count > index else {
+  internal mutating func _remove(at node: _Node) -> Element? {
+    guard _storage.count > node.offset else {
       return nil
     }
 
     var removed = _storage.removeLast()
 
-    if index < _storage.count {
-      swap(&removed, &_storage[index])
-      _trickleDown(elementAt: index)
+    if node.offset < _storage.count {
+      swap(&removed, &_storage[node.offset])
+      _trickleDown(elementAt: node)
     }
 
     return removed
@@ -224,68 +225,61 @@ public struct Heap<Element: Comparable> {
 
   @inline(__always)
   @inlinable
-  internal mutating func _trickleDown(elementAt index: Int) {
-    // Figure out if `index` is on an even or odd level
-    let levelIsMin = _minMaxHeapIsMinLevel(index)
-
-    if levelIsMin {
-      _trickleDownMin(elementAt: index)
+  internal mutating func _trickleDown(elementAt node: _Node) {
+    if node.isMinLevel {
+      _trickleDownMin(elementAt: node)
     } else {
-      _trickleDownMax(elementAt: index)
+      _trickleDownMax(elementAt: node)
     }
   }
  
   @inline(__always)
   @inlinable
-  internal mutating func _trickleDownMin(elementAt index: Int) {
-    var index = index
+  internal mutating func _trickleDownMin(elementAt node: _Node) {
+    var node = node
 
-    while let (smallestDescendantIdx, isChild) =
-            _indexOfLowestPriorityChildOrGrandchild(of: index) {
-      if _storage[smallestDescendantIdx] < _storage[index] {
-        _swapAt(smallestDescendantIdx, index)
-
-        if isChild {
-          return
-        }
-
-        // Smallest is a grandchild
-        let parentIdx = _parentIndex(of: smallestDescendantIdx)!
-        if _storage[smallestDescendantIdx] > _storage[parentIdx] {
-          _swapAt(smallestDescendantIdx, parentIdx)
-        }
-
-        index = smallestDescendantIdx
-      } else {
+    while let minDescendant = _minChildOrGrandchild(of: node) {
+      guard _element(at: minDescendant) < _element(at: node) else {
         return
       }
+      _swapAt(minDescendant, node)
+
+      if minDescendant.level == node.level + 1 {
+        return
+      }
+
+      // Smallest is a grandchild
+      let parent = minDescendant.parent()!
+      if _element(at: minDescendant) > _element(at: parent) {
+        _swapAt(minDescendant, parent)
+      }
+
+      node = minDescendant
     }
   }
 
   @inline(__always)
   @inlinable
-  internal mutating func _trickleDownMax(elementAt index: Int) {
-    var index = index
+  internal mutating func _trickleDownMax(elementAt node: _Node) {
+    var node = node
 
-    while let (largestDescendantIdx, isChild) =
-            _indexOfHighestPriorityChildOrGrandchild(of: index) {
-      if _storage[largestDescendantIdx] > _storage[index] {
-        _swapAt(largestDescendantIdx, index)
-
-        if isChild {
-          return
-        }
-
-        // Largest is a grandchild
-        let parentIdx = _parentIndex(of: largestDescendantIdx)!
-        if _storage[largestDescendantIdx] < _storage[parentIdx] {
-          _swapAt(largestDescendantIdx, parentIdx)
-        }
-
-        index = largestDescendantIdx
-      } else {
+    while let maxDescendant = _maxChildOrGrandchild(of: node) {
+      guard _element(at: maxDescendant) > _element(at: node) else {
         return
       }
+      _swapAt(maxDescendant, node)
+
+      if maxDescendant.level == node.level + 1 {
+        return
+      }
+
+      // Largest is a grandchild
+      let parent = maxDescendant.parent()!
+      if _element(at: maxDescendant) < _element(at: parent) {
+        _swapAt(maxDescendant, parent)
+      }
+
+      node = maxDescendant
     }
   }
 
@@ -298,49 +292,48 @@ public struct Heap<Element: Comparable> {
   ///                    compared.
   @inline(__always)
   @inlinable
-  internal func _indexOfLowestPriorityChildOrGrandchild(
-    of index: Int
-  ) -> (index: Int, isChild: Bool)? {
-    guard let leftChildIdx = _leftChildIndex(of: index) else {
+  internal func _minChildOrGrandchild(of node: _Node) -> _Node? {
+    assert(node.isMinLevel)
+    guard let leftChild = node.leftChild(limit: count) else {
       return nil
     }
 
-    var result: (index: Int, isChild: Bool) = (leftChildIdx, true)
-
-    guard let rightChildIdx = _rightChildIndex(of: index) else {
-      return result
+    guard let rightChild = node.rightChild(limit: count) else {
+      return leftChild
     }
 
-    guard let firstGrandchildIdx = _firstGrandchildIndex(of: index),
-          let lastGrandchildIdx = _lastGrandchildIndex(of: index)
-    else {
+    guard let grandchildren = node.grandchildren(limit: count) else {
       // We have no grandchildren -- compare the two children instead
-      if _storage[rightChildIdx] < _storage[leftChildIdx] {
-        result.index = rightChildIdx
-      }
-
-      return result
+      return (_element(at: rightChild) < _element(at: leftChild)
+              ? rightChild
+              : leftChild)
     }
 
-    // If we have 4 grandchildren, we can skip comparing the children as the
-    // heap invariants will ensure that the grandchildren will be smaller.
+    var minValue = _element(at: leftChild)
+    var minNode = leftChild
+
+    // If we have at least 3 grandchildren, we can skip comparing the children
+    // as the heap invariants will ensure that the grandchildren will be smaller.
     // Otherwise, we need to do the comparison.
-    if lastGrandchildIdx != firstGrandchildIdx + 3 {
+    if grandchildren._count < 3 {
       // Compare the two children
-      if _storage[rightChildIdx] < _storage[leftChildIdx] {
-        result.index = rightChildIdx
+      let rightValue = _element(at: rightChild)
+      if rightValue < minValue {
+        minValue = rightValue
+        minNode = rightChild
       }
     }
 
     // Iterate through the grandchildren
-    for i in firstGrandchildIdx...lastGrandchildIdx {
-      if _storage[i] < _storage[result.index] {
-        result.index = i
-        result.isChild = false
+    grandchildren._forEach { grandchild in
+      let value = _element(at: grandchild)
+      if value < minValue {
+        minValue = value
+        minNode = grandchild
       }
     }
 
-    return result
+    return minNode
   }
 
   /// Returns the highest priority child or grandchild of the element at the
@@ -352,151 +345,58 @@ public struct Heap<Element: Comparable> {
   ///                    compared.
   @inline(__always)
   @inlinable
-  internal func _indexOfHighestPriorityChildOrGrandchild(
-    of index: Int
-  ) -> (index: Int, isChild: Bool)? {
-    guard let leftChildIdx = _leftChildIndex(of: index) else {
+  internal func _maxChildOrGrandchild(of node: _Node) -> _Node? {
+    assert(!node.isMinLevel)
+    guard let leftChild = node.leftChild(limit: count) else {
       return nil
     }
 
-    var result: (index: Int, isChild: Bool) = (leftChildIdx, true)
-
-    guard let rightChildIdx = _rightChildIndex(of: index) else {
-      return result
+    guard let rightChild = node.rightChild(limit: count) else {
+      return leftChild
     }
 
-    guard let firstGrandchildIdx = _firstGrandchildIndex(of: index),
-          let lastGrandchildIdx = _lastGrandchildIndex(of: index)
-    else {
+    guard let grandchildren = node.grandchildren(limit: count) else {
       // We have no grandchildren -- compare the two children instead
-      if _storage[rightChildIdx] > _storage[leftChildIdx] {
-        result.index = rightChildIdx
-      }
-
-      return result
+      return (_element(at: rightChild) > _element(at: leftChild)
+              ? rightChild
+              : leftChild)
     }
+
+    var maxValue = _element(at: leftChild)
+    var maxNode = leftChild
 
     // If we have 4 grandchildren, we can skip comparing the children as the
     // heap invariants will ensure that the grandchildren will be larger.
     // Otherwise, we need to do the comparison.
-    if lastGrandchildIdx != firstGrandchildIdx + 3 {
+    if grandchildren._count < 4 {
       // Compare the two children
-      if _storage[rightChildIdx] > _storage[leftChildIdx] {
-        result.index = rightChildIdx
+      let rightValue = _element(at: rightChild)
+      if rightValue > maxValue {
+        maxValue = rightValue
+        maxNode = rightChild
       }
     }
 
     // Iterate through the grandchildren
-    for i in firstGrandchildIdx...lastGrandchildIdx {
-      if _storage[i] > _storage[result.index] {
-        result.index = i
-        result.isChild = false
+    grandchildren._forEach { grandchild in
+      let value = _element(at: grandchild)
+      if value > maxValue {
+        maxValue = value
+        maxNode = grandchild
       }
     }
 
-    return result
+    return maxNode
   }
 
   // MARK: - Helpers
 
-  /// Returns `true` if `index` falls on a min level in a min-max heap.
-  ///
-  /// - Precondition: `index` must be non-negative.
-  @inline(__always)
-  @inlinable
-  internal func _minMaxHeapIsMinLevel(_ index: Int) -> Bool {
-    precondition(index >= 0)
-
-    return (index + 1)._binaryLogarithm() & 0b1 == 0
-  }
-
   /// Swaps the elements in the heap at the given indices.
-  @inline(__always)
-  @inlinable
-  internal mutating func _swapAt(_ i: Int, _ j: Int) {
-    let tmp = _storage[i]
-    _storage[i] = _storage[j]
-    _storage[j] = tmp
-  }
-
-  /// Returns the parent index of the given `index`
-  /// or `nil` if the index has no parent (i.e. `index == 0`).
-  @inline(__always)
-  @inlinable
-  internal func _parentIndex(of index: Int) -> Int? {
-    guard index > 0 else {
-      return nil
-    }
-
-    return (index - 1) / 2
-  }
-
-  /// Returns the grandparent index of the given `index`
-  /// or `nil` if the index has no grandparent.
-  @inline(__always)
-  @inlinable
-  internal func _grandparentIndex(of index: Int) -> Int? {
-    guard index > 2 else {
-      return nil
-    }
-
-    return (index - 3) / 4
-  }
-
-  /// Returns the first child index of the given `index`
-  /// or `nil` if the index has no children.
-  @inline(__always)
-  @inlinable
-  internal func _leftChildIndex(of index: Int) -> Int? {
-    let childIdx = index * 2 + 1
-    guard childIdx < _storage.count else {
-      return nil
-    }
-
-    return childIdx
-  }
-
-  /// Returns the right child index of the given `index`
-  /// or `nil` if the index has no right child.
-  @inline(__always)
-  @inlinable
-  internal func _rightChildIndex(of index: Int) -> Int? {
-    let childIdx = index * 2 + 2
-    guard childIdx < _storage.count else {
-      return nil
-    }
-
-    return childIdx
-  }
-
-  /// Returns the first grandchild index of the given `index`
-  /// or `nil` if the index has no grandchildren.
-  @inline(__always)
-  @inlinable
-  internal func _firstGrandchildIndex(of index: Int) -> Int? {
-    let grandchildIdx = index * 4 + 3
-    guard grandchildIdx < _storage.count else {
-      return nil
-    }
-
-    return grandchildIdx
-  }
-
-  /// Returns the last valid grandchild index of the given `index`
-  /// or `nil` if the index has no grandchildren.
-  ///
-  /// In cases where the given index only has one grandchild, the index
-  /// returned by this function is the same as that returned by
-  /// `_firstGrandchildIndex`.
-  @inline(__always)
-  @inlinable
-  internal func _lastGrandchildIndex(of index: Int) -> Int? {
-    guard _firstGrandchildIndex(of: index) != nil else {
-      // There are no grandchildren of the node at `index`
-      return nil
-    }
-
-    return Swift.min(index * 4 + 6, _storage.count - 1)
+  @inlinable @inline(__always)
+  internal mutating func _swapAt(_ i: _Node, _ j: _Node) {
+    let tmp = _storage[i.offset]
+    _storage[i.offset] = _storage[j.offset]
+    _storage[j.offset] = tmp
   }
 }
 
@@ -505,15 +405,31 @@ public struct Heap<Element: Comparable> {
 extension Heap {
   /// Initializes a heap from a sequence.
   ///
-  /// Utilizes [Floyd's linear-time heap construction algorithm](https://en.wikipedia.org/wiki/Heapsort#Floyd's_heap_construction).
-  ///
-  /// - Complexity: O(n), where `n` is the length of `elements`.
+  /// - Complexity: O(*n*), where *n* is the length of `elements`.
   @inlinable
   public init<S: Sequence>(_ elements: S) where S.Element == Element {
-    _storage = Array(elements)
+    // This is Floyd's linear-time heap construction algorithm.
+    // (https://en.wikipedia.org/wiki/Heapsort#Floyd's_heap_construction).
+    //
+    // FIXME: See if a more cache friendly algorithm would be faster.
 
-    for idx in (0 ..< (_storage.count / 2)).reversed() {
-      _trickleDown(elementAt: idx)
+    _storage = Array(elements)
+    guard _storage.count > 1 else { return }
+
+    let limit = _storage.count / 2 // The first offset without a left child
+    var level = _Node.level(forOffset: limit &- 1)
+    while level >= 0 {
+      let nodes = _Node.allNodes(onLevel: level, limit: limit)
+      if _Node.isMinLevel(level) {
+        nodes?._forEach { node in
+          _trickleDownMin(elementAt: node)
+        }
+      } else {
+        nodes?._forEach { node in
+          _trickleDownMax(elementAt: node)
+        }
+      }
+      level &-= 1
     }
 
     _checkInvariants()
@@ -523,9 +439,12 @@ extension Heap {
   ///
   /// - Parameter newElements: The new elements to insert into the heap.
   ///
-  /// - Complexity: O(n * log `count`), where `n` is the length of `newElements`.
+  /// - Complexity: O(*n* * log(`count`)), where *n* is the length of `newElements`.
   @inlinable
-  public mutating func insert<S: Sequence>(contentsOf newElements: S) where S.Element == Element {
+  public mutating func insert<S: Sequence>(
+    contentsOf newElements: S
+  ) where S.Element == Element {
+    _storage.reserveCapacity(count + newElements.underestimatedCount)
     for element in newElements {
       insert(element)
     }

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -149,7 +149,6 @@ public struct Heap<Element: Comparable> {
 
   // MARK: -
 
-  @inline(__always)
   @inlinable
   internal mutating func _bubbleUp(elementAt index: Int) {
     guard let parentIdx = _parentIndex(of: index) else {
@@ -177,7 +176,6 @@ public struct Heap<Element: Comparable> {
     }
   }
 
-  @inline(__always)
   @inlinable
   internal mutating func _bubbleUpMin(elementAt index: Int) {
     var index = index
@@ -189,7 +187,6 @@ public struct Heap<Element: Comparable> {
     }
   }
 
-  @inline(__always)
   @inlinable
   internal mutating func _bubbleUpMax(elementAt index: Int) {
     var index = index
@@ -222,7 +219,6 @@ public struct Heap<Element: Comparable> {
 
   // MARK: -
 
-  @inline(__always)
   @inlinable
   internal mutating func _trickleDown(elementAt index: Int) {
     // Figure out if `index` is on an even or odd level
@@ -235,7 +231,6 @@ public struct Heap<Element: Comparable> {
     }
   }
  
-  @inline(__always)
   @inlinable
   internal mutating func _trickleDownMin(elementAt index: Int) {
     var index = index
@@ -262,7 +257,6 @@ public struct Heap<Element: Comparable> {
     }
   }
 
-  @inline(__always)
   @inlinable
   internal mutating func _trickleDownMax(elementAt index: Int) {
     var index = index
@@ -296,7 +290,6 @@ public struct Heap<Element: Comparable> {
   ///
   /// - parameter index: The index of the element whose descendants should be
   ///                    compared.
-  @inline(__always)
   @inlinable
   internal func _indexOfLowestPriorityChildOrGrandchild(
     of index: Int
@@ -350,7 +343,6 @@ public struct Heap<Element: Comparable> {
   ///
   /// - parameter index: The index of the item whose descendants should be
   ///                    compared.
-  @inline(__always)
   @inlinable
   internal func _indexOfHighestPriorityChildOrGrandchild(
     of index: Int

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -17,12 +17,14 @@ import Swift
 /// its descendants, while each node at an odd level in the tree is greater than
 /// all of its descendants.
 ///
-/// The implementation is based off [Atkinson et al. Min-Max Heaps and
-/// Generalized Priority Queues (1986)](http://akira.ruc.dk/~keld/teaching/algoritmedesign_f03/Artikler/02/Atkinson86.pdf).
+/// The implementation is based on [Atkinson 1986]:
 ///
-/// M.D. Atkinson, J.-R. Sack, N. Santoro, T. Strothotte. October 1986.
-/// Min-Max Heaps and Generalized Priority Queues. Communications of the ACM.
-/// 29(10):996-1000.
+/// [Atkinson 1986]: https://doi.org/10.1145/6617.6621
+///
+/// M.D. Atkinson, J.-R. Sack, N. Santoro, T. Strothotte.
+/// "Min-Max Heaps and Generalized Priority Queues."
+/// *Communications of the ACM*, vol. 29, no. 10, Oct. 1986., pp. 996-1000,
+/// doi:[10.1145/6617.6621](https://doi.org/10.1145/6617.6621)
 public struct Heap<Element: Comparable> {
   @usableFromInline
   internal var _storage: [Element]

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -9,8 +9,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Swift
-
 /// A [Min-Max Heap](https://en.wikipedia.org/wiki/Min-max_heap) data structure.
 ///
 /// In a min-max heap, each node at an even level in the tree is less than all

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -149,6 +149,7 @@ public struct Heap<Element: Comparable> {
 
   // MARK: -
 
+  @inline(__always)
   @inlinable
   internal mutating func _bubbleUp(elementAt index: Int) {
     guard let parentIdx = _parentIndex(of: index) else {
@@ -176,6 +177,7 @@ public struct Heap<Element: Comparable> {
     }
   }
 
+  @inline(__always)
   @inlinable
   internal mutating func _bubbleUpMin(elementAt index: Int) {
     var index = index
@@ -187,6 +189,7 @@ public struct Heap<Element: Comparable> {
     }
   }
 
+  @inline(__always)
   @inlinable
   internal mutating func _bubbleUpMax(elementAt index: Int) {
     var index = index
@@ -219,6 +222,7 @@ public struct Heap<Element: Comparable> {
 
   // MARK: -
 
+  @inline(__always)
   @inlinable
   internal mutating func _trickleDown(elementAt index: Int) {
     // Figure out if `index` is on an even or odd level
@@ -231,6 +235,7 @@ public struct Heap<Element: Comparable> {
     }
   }
  
+  @inline(__always)
   @inlinable
   internal mutating func _trickleDownMin(elementAt index: Int) {
     var index = index
@@ -257,6 +262,7 @@ public struct Heap<Element: Comparable> {
     }
   }
 
+  @inline(__always)
   @inlinable
   internal mutating func _trickleDownMax(elementAt index: Int) {
     var index = index
@@ -290,6 +296,7 @@ public struct Heap<Element: Comparable> {
   ///
   /// - parameter index: The index of the element whose descendants should be
   ///                    compared.
+  @inline(__always)
   @inlinable
   internal func _indexOfLowestPriorityChildOrGrandchild(
     of index: Int
@@ -343,6 +350,7 @@ public struct Heap<Element: Comparable> {
   ///
   /// - parameter index: The index of the item whose descendants should be
   ///                    compared.
+  @inline(__always)
   @inlinable
   internal func _indexOfHighestPriorityChildOrGrandchild(
     of index: Int

--- a/Sources/PriorityQueueModule/_Node.swift
+++ b/Sources/PriorityQueueModule/_Node.swift
@@ -77,9 +77,22 @@ extension _Node {
 }
 
 extension _Node {
+  /// The root node in the heap.
   @inlinable @inline(__always)
   internal static var root: Self {
     Self.init(offset: 0, level: 0)
+  }
+
+  /// The first max node in the heap. (I.e., the left child of the root.)
+  @inlinable @inline(__always)
+  internal static var leftMax: Self {
+    Self.init(offset: 1, level: 1)
+  }
+
+  /// The second max node in the heap. (I.e., the right child of the root.)
+  @inlinable @inline(__always)
+  internal static var rightMax: Self {
+    Self.init(offset: 2, level: 1)
   }
 
   @inlinable

--- a/Sources/PriorityQueueModule/_Node.swift
+++ b/Sources/PriorityQueueModule/_Node.swift
@@ -1,0 +1,170 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@usableFromInline @frozen
+internal struct _Node {
+  @usableFromInline
+  internal var offset: Int
+
+  @usableFromInline
+  internal var level: Int
+
+  @inlinable
+  internal init(offset: Int, level: Int) {
+    assert(offset >= 0)
+#if COLLECTIONS_INTERNAL_CHECKS
+    assert(level == Self.level(forOffset: offset))
+#endif
+    self.offset = offset
+    self.level = level
+  }
+
+  @inlinable
+  internal init(offset: Int) {
+    self.init(offset: offset, level: Self.level(forOffset: offset))
+  }
+}
+
+extension _Node: Comparable {
+  @inlinable @inline(__always)
+  internal static func ==(left: Self, right: Self) -> Bool {
+    left.offset == right.offset
+  }
+
+  @inlinable @inline(__always)
+  internal static func <(left: Self, right: Self) -> Bool {
+    left.offset < right.offset
+  }
+}
+
+extension _Node: CustomStringConvertible {
+  @usableFromInline
+  internal var description: String {
+    "(offset: \(offset), level: \(level))"
+  }
+}
+
+extension _Node {
+  @inlinable @inline(__always)
+  internal static func level(forOffset offset: Int) -> Int {
+    (offset &+ 1)._binaryLogarithm()
+  }
+
+  @inlinable @inline(__always)
+  internal static func firstNode(onLevel level: Int) -> _Node {
+    assert(level >= 0)
+    return _Node(offset: (1 &<< level) &- 1, level: level)
+  }
+
+  @inlinable @inline(__always)
+  internal static func lastNode(onLevel level: Int) -> _Node {
+    assert(level >= 0)
+    return _Node(offset: (1 &<< (level &+ 1)) &- 2, level: level)
+  }
+
+  @inlinable @inline(__always)
+  internal static func isMinLevel(_ level: Int) -> Bool {
+    level & 0b1 == 0
+  }
+}
+
+extension _Node {
+  @inlinable @inline(__always)
+  internal static var root: Self {
+    Self.init(offset: 0, level: 0)
+  }
+
+  @inlinable
+  internal var isMinLevel: Bool {
+    Self.isMinLevel(level)
+  }
+}
+
+extension _Node {
+  /// Returns the parent of this index, or `nil` if the index has no parent
+  /// (i.e. when this is the root index).
+  @inlinable @inline(__always)
+  internal func parent() -> Self? {
+    guard offset > 0 else { return nil }
+    return Self(offset: (offset &- 1) / 2, level: level &- 1)
+  }
+
+  /// Returns the grandparent of this index, or `nil` if the index has
+  /// no grandparent.
+  @inlinable @inline(__always)
+  internal func grandParent() -> Self? {
+    guard offset > 2 else { return nil }
+    return Self(offset: (offset &- 3) / 4, level: level &- 2)
+  }
+
+  /// Returns the left child of this index or `nil` if the index has no
+  /// children.
+  @inlinable @inline(__always)
+  internal func leftChild(limit: Int) -> Self? {
+    let left = offset * 2 &+ 1
+    guard left < limit else { return nil }
+    return Self(offset: left, level: level &+ 1)
+  }
+
+  /// Returns the right child of this index or `nil` if the index has no
+  /// right child.
+  @inlinable @inline(__always)
+  internal func rightChild(limit: Int) -> Self? {
+    let right = offset * 2 &+ 2
+    guard right < limit else { return nil }
+    return Self(offset: right, level: level &+ 1)
+  }
+
+  /// Returns the grandchildren of this index or `nil` if the index has no
+  /// grandchildren.
+  @inlinable
+  internal func grandchildren(limit: Int) -> ClosedRange<Self>? {
+    let start = offset * 4 &+ 3
+    guard start < limit else { return nil }
+    let end = min(offset * 4 &+ 6, limit &- 1)
+    return ClosedRange(
+      uncheckedBounds: (
+        lower: Self(offset: start, level: level &+ 2),
+        upper: Self(offset: end, level: level &+ 2)))
+  }
+
+  @inlinable
+  internal static func allNodes(
+    onLevel level: Int,
+    limit: Int
+  ) -> ClosedRange<Self>? {
+    let first = Self.firstNode(onLevel: level)
+    guard first.offset < limit else { return nil }
+    var last = self.lastNode(onLevel: level)
+    if last.offset >= limit {
+      last = _Node(offset: limit &- 1, level: level)
+    }
+    return ClosedRange(uncheckedBounds: (first, last))
+  }
+}
+
+extension ClosedRange where Bound == _Node {
+  @inlinable @inline(__always)
+  internal var _count: Int {
+    upperBound.offset - lowerBound.offset + 1
+  }
+
+  @inlinable @inline(__always)
+  internal func _forEach(_ body: (_Node) -> Void) {
+    assert(
+      isEmpty || _Node.level(forOffset: upperBound.offset) == lowerBound.level)
+    var node = self.lowerBound
+    while node.offset <= self.upperBound.offset {
+      body(node)
+      node.offset &+= 1
+    }
+  }
+}

--- a/Tests/PriorityQueueTests/HeapTests.swift
+++ b/Tests/PriorityQueueTests/HeapTests.swift
@@ -350,18 +350,13 @@ final class HeapTests: XCTestCase {
 
   func test_levelCalculation() {
     // Check alternating min and max levels in the heap
-    let q = Heap<Int>()
     var isMin = true
     for exp in 0...12 {
       // Check [2^exp, 2^(exp + 1))
-      for i in Int(pow(2, Double(exp)) - 1)..<Int(pow(2, Double(exp + 1)) - 1) {
-        if isMin {
-          XCTAssertTrue(q._minMaxHeapIsMinLevel(i), "\(i) should be on a max level")
-        } else {
-          XCTAssertFalse(q._minMaxHeapIsMinLevel(i), "\(i) should be on a min level")
-        }
+      for offset in Int(pow(2, Double(exp)) - 1)..<Int(pow(2, Double(exp + 1)) - 1) {
+        let node = _Node(offset: offset)
+        XCTAssertEqual(node.isMinLevel, isMin)
       }
-
       isMin.toggle()
     }
   }


### PR DESCRIPTION
- `@inline(__always)` has a detrimental effect when used on large functions. Let's not do that.
- Speed up invariant checking with COLLECTIONS_INTERNAL_CHECKS (resolves #69)
- Replace naked ints with `_Node`, precalculating levels for each offset (resolves #71)
- Rebase heap operations on UMBP instead Array, eliminating unnecessary index validation (resolves #75)
- ~Add some (slightly questionable) effects attributes to heap internals.~
- Optimize removals and heap construction

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
