### PR TITLE
Fix typos: missing subscript parameters

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements+SubSequence.swift
@@ -59,7 +59,7 @@ extension OrderedDictionary.Elements.SubSequence {
   ///     let countryCodes: OrderedDictionary = ["BR": "Brazil", "GH": "Ghana", "JP": "Japan"]
   ///     let index = countryCodes.index(forKey: "JP")
   ///
-  ///     print("Country code for \(countryCodes[index!].value): '\(countryCodes[index!].key)'.")
+  ///     print("Country code for \(countryCodes[offset: index!].value): '\(countryCodes[offset: index!].key)'.")
   ///     // Prints "Country code for Japan: 'JP'."
   ///
   /// - Parameter key: The key to find in the dictionary.

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements+SubSequence.swift
@@ -53,19 +53,20 @@ extension OrderedDictionary.Elements.SubSequence {
 extension OrderedDictionary.Elements.SubSequence {
   /// Returns the index for the given key.
   ///
-  /// If the given key is found in the dictionary, this method returns an index
-  /// into the dictionary that corresponds with the key-value pair.
+  /// If the given key is found in the dictionary slice, this method returns an
+  /// index into the dictionary that corresponds with the key-value pair.
   ///
   ///     let countryCodes: OrderedDictionary = ["BR": "Brazil", "GH": "Ghana", "JP": "Japan"]
-  ///     let index = countryCodes.index(forKey: "JP")
+  ///     let slice = countryCodes.elements[1...]
+  ///     let index = slice.index(forKey: "JP")
   ///
   ///     print("Country code for \(countryCodes[offset: index!].value): '\(countryCodes[offset: index!].key)'.")
   ///     // Prints "Country code for Japan: 'JP'."
   ///
-  /// - Parameter key: The key to find in the dictionary.
+  /// - Parameter key: The key to find in the dictionary slice.
   ///
   /// - Returns: The index for `key` and its associated value if `key` is in
-  ///    the dictionary; otherwise, `nil`.
+  ///    the dictionary slice; otherwise, `nil`.
   ///
   /// - Complexity: Expected to be O(1) on average, if `Key` implements
   ///    high-quality hashing.

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
@@ -79,7 +79,7 @@ extension OrderedDictionary.Elements {
   /// into the dictionary that corresponds with the key-value pair.
   ///
   ///     let countryCodes: OrderedDictionary = ["BR": "Brazil", "GH": "Ghana", "JP": "Japan"]
-  ///     let index = countryCodes.index(forKey: "JP")
+  ///     let index = countryCodes.elements.index(forKey: "JP")
   ///
   ///     print("Country code for \(countryCodes[offset: index!].value): '\(countryCodes[offset: index!].key)'.")
   ///     // Prints "Country code for Japan: 'JP'."

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
@@ -81,7 +81,7 @@ extension OrderedDictionary.Elements {
   ///     let countryCodes: OrderedDictionary = ["BR": "Brazil", "GH": "Ghana", "JP": "Japan"]
   ///     let index = countryCodes.index(forKey: "JP")
   ///
-  ///     print("Country code for \(countryCodes[index!].value): '\(countryCodes[index!].key)'.")
+  ///     print("Country code for \(countryCodes[offset: index!].value): '\(countryCodes[offset: index!].key)'.")
   ///     // Prints "Country code for Japan: 'JP'."
   ///
   /// - Parameter key: The key to find in the dictionary.

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
@@ -272,7 +272,7 @@ extension OrderedDictionary {
   ///     let countryCodes: OrderedDictionary = ["BR": "Brazil", "GH": "Ghana", "JP": "Japan"]
   ///     let index = countryCodes.index(forKey: "JP")
   ///
-  ///     print("Country code for \(countryCodes[index!].value): '\(countryCodes[index!].key)'.")
+  ///     print("Country code for \(countryCodes[offset: index!].value): '\(countryCodes[offset: index!].key)'.")
   ///     // Prints "Country code for Japan: 'JP'."
   ///
   /// - Parameter key: The key to find in the dictionary.


### PR DESCRIPTION
Typos in symbol documentation:
Subscripts are missing the `offset:` parameter.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
