### PR TITLE
Fix documentation for types conforming to ExpressibleByArrayLiteral o…

### DIFF
--- a/Sources/DequeModule/Deque+ExpressibleByArrayLiteral.swift
+++ b/Sources/DequeModule/Deque+ExpressibleByArrayLiteral.swift
@@ -13,12 +13,12 @@ extension Deque: ExpressibleByArrayLiteral {
   /// Creates a new deque from the contents of an array literal.
   ///
   /// Do not call this initializer directly. It is used by the compiler when
-  /// you use an array literal. Instead, create a new set using an array
+  /// you use an array literal. Instead, create a new deque using an array
   /// literal as its value by enclosing a comma-separated list of values in
-  /// square brackets. You can use an array literal anywhere a set is expected
+  /// square brackets. You can use an array literal anywhere a deque is expected
   /// by the type context.
   ///
-  /// - Parameter elements: A variadic list of elements of the new set.
+  /// - Parameter elements: A variadic list of elements of the new deque.
   @inlinable
   @inline(__always)
   public init(arrayLiteral elements: Element...) {

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+ExpressibleByDictionaryLiteral.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+ExpressibleByDictionaryLiteral.swift
@@ -13,17 +13,14 @@ extension OrderedDictionary: ExpressibleByDictionaryLiteral {
   /// Creates a new ordered dictionary from the contents of a dictionary
   /// literal.
   ///
-  /// Duplicate elements in the literal are allowed, but the resulting
-  /// set will only contain the first occurrence of each.
-  ///
   /// Do not call this initializer directly. It is used by the compiler when you
   /// use a dictionary literal. Instead, create a new ordered dictionary using a
   /// dictionary literal as its value by enclosing a comma-separated list of
-  /// values in square brackets. You can use an array literal anywhere a set is
-  /// expected by the type context.
+  /// key-value pairs in square brackets. You can use a dictionary literal
+  /// anywhere an ordered dictionary is expected by the type context.
   ///
   /// - Parameter elements: A variadic list of key-value pairs for the new
-  ///    dictionary.
+  ///    ordered dictionary.
   ///
   /// - Complexity: O(`elements.count`) if `Key` implements
   ///    high-quality hashing.

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+ExpressibleByArrayLiteral.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+ExpressibleByArrayLiteral.swift
@@ -12,16 +12,16 @@
 extension OrderedSet: ExpressibleByArrayLiteral {
   /// Creates a new ordered set from the contents of an array literal.
   ///
-  /// Duplicate elements in the literal are allowed, but the resulting
+  /// Duplicate elements in the literal are allowed, but the resulting ordered
   /// set will only contain the first occurrence of each.
   ///
   /// Do not call this initializer directly. It is used by the compiler when
-  /// you use an array literal. Instead, create a new set using an array
+  /// you use an array literal. Instead, create a new ordered set using an array
   /// literal as its value by enclosing a comma-separated list of values in
-  /// square brackets. You can use an array literal anywhere a set is expected
-  /// by the type context.
+  /// square brackets. You can use an array literal anywhere an ordered set is
+  /// expected by the type context.
   ///
-  /// - Parameter elements: A variadic list of elements of the new set.
+  /// - Parameter elements: A variadic list of elements of the new ordered set.
   ///
   /// - Complexity: O(`elements.count`) if `Element` implements
   ///    high-quality hashing.

--- a/Sources/PriorityQueueModule/Heap+ExpressibleByArrayLiteral.swift
+++ b/Sources/PriorityQueueModule/Heap+ExpressibleByArrayLiteral.swift
@@ -18,7 +18,7 @@ extension Heap: ExpressibleByArrayLiteral {
   /// square brackets. You can use an array literal anywhere a heap is expected
   /// by the type context.
   ///
-  /// - Parameter elements: A variadic list of elements of the new set.
+  /// - Parameter elements: A variadic list of elements of the new heap.
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }


### PR DESCRIPTION
Fixes a few issues with documentation of `init(arrayLiteral:)` and `init(dictionaryLiteral:)` functions:
- Some typos are corrected to the correct object type.
- `OrderedDictionary` does not allow duplicate elements in `init(dictionaryLiteral:)` so I removed that section.
- In general there are many places in the documentation where `set` and `dictionary` are used as shorthands for `ordered set` and `ordered dictionary`. I think for these functions it is clearer if we are specific and use `ordered set` and `ordered dictionary`.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
