### PR TITLE
[OrderedDictionary] modifyValue → updateValue

### DIFF
--- a/Documentation/OrderedDictionary.md
+++ b/Documentation/OrderedDictionary.md
@@ -88,14 +88,14 @@ for character in text {
 
 If the `Value` type implements reference semantics, or when you need to
 perform a series of individual mutations on the values, the closure-based
-`modifyValue(forKey:default:_:)` method provides an easier-to-use
+`updateValue(forKey:default:with:)` method provides an easier-to-use
 alternative to the defaulted key-based subscript.
 
 ```swift
 let text = "short string"
 var counts: OrderedDictionary<Character, Int> = [:]
 for character in text {
-  counts.modifyValue(forKey: character, default: 0) { value in
+  counts.updateValue(forKey: character, default: 0) { value in
     value += 1
   }
 }

--- a/Sources/OrderedCollections/CMakeLists.txt
+++ b/Sources/OrderedCollections/CMakeLists.txt
@@ -8,6 +8,7 @@ See https://swift.org/LICENSE.txt for license information
 #]]
 
 add_library(OrderedCollections
+  "HashTable/_HashTable.swift"
   "HashTable/_HashTable+Bucket.swift"
   "HashTable/_HashTable+BucketIterator.swift"
   "HashTable/_HashTable+Constants.swift"
@@ -15,8 +16,8 @@ add_library(OrderedCollections
   "HashTable/_Hashtable+Header.swift"
   "HashTable/_HashTable+Testing.swift"
   "HashTable/_HashTable+UnsafeHandle.swift"
-  "HashTable/_HashTable.swift"
 
+  "OrderedDictionary/OrderedDictionary.swift"
   "OrderedDictionary/OrderedDictionary+Codable.swift"
   "OrderedDictionary/OrderedDictionary+CustomDebugStringConvertible.swift"
   "OrderedDictionary/OrderedDictionary+CustomReflectable.swift"
@@ -32,8 +33,9 @@ add_library(OrderedCollections
   "OrderedDictionary/OrderedDictionary+Partial RangeReplaceableCollection.swift"
   "OrderedDictionary/OrderedDictionary+Sequence.swift"
   "OrderedDictionary/OrderedDictionary+Values.swift"
-  "OrderedDictionary/OrderedDictionary.swift"
+  "OrderedDictionary/OrderedDictionary+Deprecations.swift"
 
+  "OrderedSet/OrderedSet.swift"
   "OrderedSet/OrderedSet+Codable.swift"
   "OrderedSet/OrderedSet+CustomDebugStringConvertible.swift"
   "OrderedSet/OrderedSet+CustomReflectable.swift"
@@ -56,7 +58,6 @@ add_library(OrderedCollections
   "OrderedSet/OrderedSet+Testing.swift"
   "OrderedSet/OrderedSet+UnorderedView.swift"
   "OrderedSet/OrderedSet+UnstableInternals.swift"
-  "OrderedSet/OrderedSet.swift"
 
   "Utilities/_UnsafeBitset.swift"
   "Utilities/RandomAccessCollection+Offsets.swift")

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Deprecations.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Deprecations.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension OrderedDictionary {
+  @available(*, deprecated, renamed: "updateValue(forKey:default:with:)")
+  @inlinable
+  public mutating func modifyValue<R>(
+    forKey key: Key,
+    default defaultValue: @autoclosure () -> Value,
+    _ body: (inout Value) throws -> R
+  ) rethrows -> R {
+    try self.updateValue(forKey: key, default: defaultValue(), with: body)
+  }
+
+  @available(*, deprecated, renamed: "updateValue(forKey:insertingDefault:at:with:)")
+  @inlinable
+  public mutating func modifyValue<R>(
+    forKey key: Key,
+    insertingDefault defaultValue: @autoclosure () -> Value,
+    at index: Int,
+    _ body: (inout Value) throws -> R
+  ) rethrows -> R {
+    try self.updateValue(
+      forKey: key,
+      insertingDefault: defaultValue(),
+      at: index,
+      with: body)
+  }
+}

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Initializers.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Initializers.swift
@@ -282,7 +282,7 @@ extension OrderedDictionary {
     self.init()
     for value in values {
       let key = try keyForValue(value)
-      self.modifyValue(forKey: key, default: Value()) { array in
+      self.updateValue(forKey: key, default: Value()) { array in
         array.append(value)
       }
     }

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
@@ -79,13 +79,13 @@
 ///
 /// If the `Value` type implements reference semantics, or when you need to
 /// perform a series of individual mutations on the values, the closure-based
-/// `modifyValue(forKey:default:_:)` method provides an easier-to-use
+/// `updateValue(forKey:default:_:)` method provides an easier-to-use
 /// alternative to the defaulted key-based subscript.
 ///
 ///     let text = "short string"
 ///     var counts: OrderedDictionary<Character, Int> = [:]
 ///     for character in text {
-///       counts.modifyValue(forKey: character, default: 0) { value in
+///       counts.updateValue(forKey: character, default: 0) { value in
 ///         value += 1
 ///       }
 ///     }
@@ -641,7 +641,7 @@ extension OrderedDictionary {
   ///     let message = "Hello, Elle!"
   ///     var letterCounts: [Character: Int] = [:]
   ///     for letter in message {
-  ///         letterCounts.modifyValue(forKey: letter, default: 0) { count in
+  ///         letterCounts.updateValue(forKey: letter, default: 0) { count in
   ///             count += 1
   ///         }
   ///     }
@@ -660,10 +660,10 @@ extension OrderedDictionary {
   /// - Complexity: expected complexity is amortized O(1), if `Key` implements
   ///    high-quality hashing. (Ignoring the complexity of calling `body`.)
   @inlinable
-  public mutating func modifyValue<R>(
+  public mutating func updateValue<R>(
     forKey key: Key,
     default defaultValue: @autoclosure () -> Value,
-    _ body: (inout Value) throws -> R
+    with body: (inout Value) throws -> R
   ) rethrows -> R {
     let (index, bucket) = _keys._find(key)
     if let index = index {
@@ -687,7 +687,7 @@ extension OrderedDictionary {
   ///     let message = "Hello, Elle!"
   ///     var letterCounts: [Character: Int] = [:]
   ///     for letter in message {
-  ///         letterCounts.modifyValue(forKey: letter, default: 0) { count in
+  ///         letterCounts.updateValue(forKey: letter, default: 0) { count in
   ///             count += 1
   ///         }
   ///     }
@@ -706,11 +706,11 @@ extension OrderedDictionary {
   /// - Complexity: expected complexity is amortized O(1), if `Key` implements
   ///    high-quality hashing. (Ignoring the complexity of calling `body`.)
   @inlinable
-  public mutating func modifyValue<R>(
+  public mutating func updateValue<R>(
     forKey key: Key,
     insertingDefault defaultValue: @autoclosure () -> Value,
     at index: Int,
-    _ body: (inout Value) throws -> R
+    with body: (inout Value) throws -> R
   ) rethrows -> R {
     let (existingIndex, bucket) = _keys._find(key)
     if let existingIndex = existingIndex {

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
@@ -606,7 +606,7 @@ class OrderedDictionaryTests: CollectionTestCase {
     }
   }
 
-  func test_modifyValue_forKey_default_closure_update() {
+  func test_updateValue_forKey_default_closure_update() {
     withEvery("count", in: 0 ..< 30) { count in
       withEvery("offset", in: 0 ..< count) { offset in
         withEvery("isShared", in: [false, true]) { isShared in
@@ -616,7 +616,7 @@ class OrderedDictionaryTests: CollectionTestCase {
             let fallback = tracker.instance(for: -2)
             withHiddenCopies(if: isShared, of: &d) { d in
               let key = keys[offset]
-              d.modifyValue(forKey: key, default: fallback) { value in
+              d.updateValue(forKey: key, default: fallback) { value in
                 expectEqual(value, values[offset])
                 value = replacement
               }
@@ -633,7 +633,7 @@ class OrderedDictionaryTests: CollectionTestCase {
     }
   }
 
-  func test_modifyValue_forKey_default_closure_insert() {
+  func test_updateValue_forKey_default_closure_insert() {
     withEvery("count", in: 0 ..< 30) { count in
       withEvery("isShared", in: [false, true]) { isShared in
         withLifetimeTracking { tracker in
@@ -644,7 +644,7 @@ class OrderedDictionaryTests: CollectionTestCase {
           withEvery("offset", in: 0 ..< count) { offset in
             withHiddenCopies(if: isShared, of: &d) { d in
               let key = keys[offset]
-              d.modifyValue(forKey: key, default: fallback) { value in
+              d.updateValue(forKey: key, default: fallback) { value in
                 expectEqual(value, fallback)
                 value = values[offset]
               }
@@ -661,7 +661,7 @@ class OrderedDictionaryTests: CollectionTestCase {
     }
   }
 
-  func test_modifyValue_forKey_insertingDefault_at_closure_update() {
+  func test_updateValue_forKey_insertingDefault_at_closure_update() {
     withEvery("count", in: 0 ..< 30) { count in
       withEvery("offset", in: 0 ..< count) { offset in
         withEvery("isShared", in: [false, true]) { isShared in
@@ -672,7 +672,7 @@ class OrderedDictionaryTests: CollectionTestCase {
             withHiddenCopies(if: isShared, of: &d) { d in
               let key = keys[offset]
               let value = values[offset]
-              d.modifyValue(forKey: key, insertingDefault: fallback, at: 0) { v in
+              d.updateValue(forKey: key, insertingDefault: fallback, at: 0) { v in
                 expectEqual(v, value)
                 v = replacement
               }
@@ -689,7 +689,7 @@ class OrderedDictionaryTests: CollectionTestCase {
     }
   }
 
-  func test_modifyValue_forKey_insertingDefault_at_closure_insert() {
+  func test_updateValue_forKey_insertingDefault_at_closure_insert() {
     withEvery("count", in: 0 ..< 30) { count in
       withEvery("isShared", in: [false, true]) { isShared in
         withLifetimeTracking { tracker in
@@ -701,7 +701,7 @@ class OrderedDictionaryTests: CollectionTestCase {
             withHiddenCopies(if: isShared, of: &d) { d in
               let key = keys[count - 1 - offset]
               let value = values[count - 1 - offset]
-              d.modifyValue(forKey: key, insertingDefault: fallback, at: 0) { v in
+              d.updateValue(forKey: key, insertingDefault: fallback, at: 0) { v in
                 expectEqual(v, fallback)
                 v = value
               }


### PR DESCRIPTION
Resolves #90. This also adds a `with` label to the closure argument of these two methods, clarifying its role.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [X] I've updated the documentation if necessary.
