### PR TITLE
Follow stdlib's leading underscore rule

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements+SubSequence.swift
@@ -96,10 +96,10 @@ extension OrderedDictionary.Elements.SubSequence: Sequence {
 
     @inlinable
     @inline(__always)
-    internal init(_ base: OrderedDictionary.Elements.SubSequence) {
-      self._base = base._base
-      self._end = base._bounds.upperBound
-      self._index = base._bounds.lowerBound
+    internal init(_base: OrderedDictionary.Elements.SubSequence) {
+      self._base = _base._base
+      self._end = _base._bounds.upperBound
+      self._index = _base._bounds.lowerBound
     }
 
     /// Advances to the next element and returns it, or `nil` if no next
@@ -118,7 +118,7 @@ extension OrderedDictionary.Elements.SubSequence: Sequence {
   @inlinable
   @inline(__always)
   public func makeIterator() -> Iterator {
-    Iterator(self)
+    Iterator(_base: self)
   }
 }
 

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+RandomAccessCollection.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+RandomAccessCollection.swift
@@ -244,7 +244,7 @@ extension OrderedSet: RandomAccessCollection {
   @inlinable
   public subscript(bounds: Range<Int>) -> SubSequence {
     _failEarlyRangeCheck(bounds, bounds: startIndex ..< endIndex)
-    return SubSequence(base: self, bounds: bounds)
+    return SubSequence(_base: self, bounds: bounds)
   }
 
   /// A Boolean value indicating whether the collection is empty.

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
@@ -26,8 +26,8 @@ extension OrderedSet {
 
     @inlinable
     @inline(__always)
-    internal init(base: OrderedSet, bounds: Range<Int>) {
-      self._base = base
+    internal init(_base: OrderedSet, bounds: Range<Int>) {
+      self._base = _base
       self._bounds = bounds
     }
   }
@@ -289,7 +289,7 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
   @inline(__always)
   public subscript(bounds: Range<Int>) -> SubSequence {
     _failEarlyRangeCheck(bounds, bounds: startIndex ..< endIndex)
-    return SubSequence(base: _base, bounds: bounds)
+    return SubSequence(_base: _base, bounds: bounds)
   }
 
   /// A Boolean value indicating whether the collection is empty.


### PR DESCRIPTION
Renames a couple of non-public symbols which don't follow stdlib's [Leading Underscore Rule](https://github.com/apple/swift/blob/main/docs/StandardLibraryProgrammersManual.md#the-leading-underscore-rule):

```swift
OrderedDictionary.Elements.SubSequence.Iterator.init(_ base: OrderedDictionary.Elements.SubSequence)
```
changed to
```swift
OrderedDictionary.Elements.SubSequence.Iterator.init(_base: OrderedDictionary.Elements.SubSequence)
```
and
```swift
OrderedSet.SubSequence.init(base: OrderedSet, bounds: Range<Int>)
```
changed to 
```swift
OrderedSet.SubSequence.init(_base: OrderedSet, bounds: Range<Int>)
```


### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
