### PR TITLE
Documentation: Remove in-place mutation comments

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Deprecations.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Deprecations.swift
@@ -10,8 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension OrderedDictionary {
-  /// Accesses the element at the specified index. This can be used to
-  /// perform in-place mutations on dictionary values.
+  /// Accesses the element at the specified index.
   ///
   /// - Parameter offset: The offset of the element to access, measured from
   ///   the start of the collection. `offset` must be greater than or equal to

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
@@ -261,8 +261,7 @@ extension OrderedDictionary.Elements: RandomAccessCollection {
     end - start
   }
 
-  /// Accesses the element at the specified position. This can be used to
-  /// perform in-place mutations on dictionary values.
+  /// Accesses the element at the specified position.
   ///
   /// - Parameter index: The position of the element to access. `index` must be
   ///   greater than or equal to `startIndex` and less than `endIndex`.


### PR DESCRIPTION
Removed comments about using read only subscripts for in place mutations.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
