### PR TITLE
[main] Freeze some types for consistency with their inlinable initializers

### DIFF
--- a/Sources/DequeModule/Deque+Collection.swift
+++ b/Sources/DequeModule/Deque+Collection.swift
@@ -16,6 +16,7 @@ extension Deque: Sequence {
   // conversions from indices to storage slots.
 
   /// An iterator over the members of a deque.
+  @frozen
   public struct Iterator: IteratorProtocol {
     @usableFromInline
     internal var _storage: Deque._Storage

--- a/Sources/DequeModule/Deque._Storage.swift
+++ b/Sources/DequeModule/Deque._Storage.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Deque {
+  @frozen
   @usableFromInline
   struct _Storage {
     @usableFromInline

--- a/Sources/DequeModule/Deque._UnsafeHandle.swift
+++ b/Sources/DequeModule/Deque._UnsafeHandle.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Deque {
+  @frozen
   @usableFromInline
   internal struct _UnsafeHandle {
     @usableFromInline

--- a/Sources/DequeModule/_DequeBuffer.swift
+++ b/Sources/DequeModule/_DequeBuffer.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_fixed_layout
 @usableFromInline
 internal class _DequeBuffer<Element>: ManagedBuffer<_DequeBufferHeader, Element> {
   @inlinable

--- a/Sources/DequeModule/_UnsafeWrappedBuffer.swift
+++ b/Sources/DequeModule/_UnsafeWrappedBuffer.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@frozen
 @usableFromInline
 internal struct _UnsafeWrappedBuffer<Element> {
   @usableFromInline
@@ -51,6 +52,7 @@ internal struct _UnsafeWrappedBuffer<Element> {
   internal var count: Int { first.count + (second?.count ?? 0) }
 }
 
+@frozen
 @usableFromInline
 internal struct _UnsafeMutableWrappedBuffer<Element> {
   @usableFromInline

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
@@ -12,6 +12,7 @@
 extension OrderedSet {
   /// An unordered view into an ordered set, providing `SetAlgebra`
   /// conformance.
+  @frozen
   public struct UnorderedView {
     public typealias Element = OrderedSet.Element
 

--- a/Sources/PriorityQueueModule/Heap+OrderedViews.swift
+++ b/Sources/PriorityQueueModule/Heap+OrderedViews.swift
@@ -12,6 +12,7 @@
 extension Heap {
   /// A view of a `Heap`'s elements, as a `Sequence` from the smallest to
   /// largest element.
+  @frozen
   public struct AscendingView: Sequence, IteratorProtocol {
     @usableFromInline
     internal var _base: Heap
@@ -30,6 +31,7 @@ extension Heap {
 
   /// A view of a `Heap`'s elements, as a `Sequence` from the largest to
   /// smallest element.
+  @frozen
   public struct DescendingView: Sequence, IteratorProtocol {
     @usableFromInline
     internal var _base: Heap

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -23,6 +23,7 @@
 /// "Min-Max Heaps and Generalized Priority Queues."
 /// *Communications of the ACM*, vol. 29, no. 10, Oct. 1986., pp. 996-1000,
 /// doi:[10.1145/6617.6621](https://doi.org/10.1145/6617.6621)
+@frozen
 public struct Heap<Element: Comparable> {
   @usableFromInline
   internal var _storage: ContiguousArray<Element>


### PR DESCRIPTION
(This is the `main` branch counterpart for #97.)

Note: `@frozen` does *not* mean that we actually consider these struct types frozen. Their layout may arbitrarily change between even minor releases.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
