### PR TITLE
[Heap] Disable heap tests in release builds

### DIFF
--- a/Tests/PriorityQueueTests/HeapTests.swift
+++ b/Tests/PriorityQueueTests/HeapTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if DEBUG
 import XCTest
 @testable import PriorityQueueModule
 
@@ -419,3 +420,4 @@ final class HeapTests: XCTestCase {
     }
   }
 }
+#endif


### PR DESCRIPTION
These tests rely on @testable imports, which sadly won't work in optimized builds.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
