### PR TITLE
[1.0][OrderedSet] Make _checkInvariants public and call it in more operations

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Codable.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Codable.swift
@@ -82,5 +82,6 @@ extension OrderedDictionary: Decodable where Key: Decodable, Value: Decodable {
       _keys._appendNew(key, in: bucket)
       _values.append(value)
     }
+    _checkInvariants()
   }
 }

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Initializers.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Initializers.swift
@@ -300,6 +300,7 @@ extension OrderedDictionary {
       _keys._appendNew(key)
       _values.append(value)
     }
+    _checkInvariants()
   }
 
   /// Creates a new dictionary from the key-value pairs in the given sequence,

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift
@@ -51,6 +51,7 @@ extension OrderedDictionary {
     let pivot = try _values.withUnsafeMutableBufferPointer { values in
       try _keys._partition(values: values, by: belongsInSecondPartition)
     }
+    _checkInvariants()
     return pivot
   }
 }
@@ -103,6 +104,7 @@ extension OrderedDictionary {
       _keys = OrderedSet(uncheckedUniqueElements: source.lazy.map { $0.key })
       _values = ContiguousArray(source.lazy.map { $0.value })
     }
+    _checkInvariants()
   }
 }
 

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial RangeReplaceableCollection.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial RangeReplaceableCollection.swift
@@ -178,6 +178,7 @@ extension OrderedDictionary {
         by: shouldBeRemoved)
     }
     removeSubrange(pivot...)
+    _checkInvariants()
   }
 }
 

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
@@ -350,7 +350,7 @@ extension OrderedDictionary {
     }
     set {
       // We have a separate `set` in addition to `_modify` in hopes of getting
-      // rid of `_modify`'s swapAt dance in the usua case where the calle just
+      // rid of `_modify`'s swapAt dance in the usual case where the caller just
       // wants to assign a new value.
       let (index, bucket) = _keys._find(key)
       switch (index, newValue) {
@@ -365,6 +365,7 @@ extension OrderedDictionary {
       case (nil, nil): // Noop
         break
       }
+      _checkInvariants()
     }
     _modify {
       let (index, bucket) = _keys._find(key)
@@ -394,6 +395,7 @@ extension OrderedDictionary {
         case (nil, nil): // Noop
           break
         }
+        _checkInvariants()
       }
 
       yield &value

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
@@ -10,17 +10,18 @@
 //===----------------------------------------------------------------------===//
 
 extension OrderedSet {
-  /// Append a new member to the end of the set, without verifying
-  /// that the set doesn't already contain it.
+  /// Append a new item to the end of the set, assuming it's not already
+  /// a member.
   ///
-  /// This operation performs no hashing operations unless it needs to
-  /// reallocate the hash table.
+  /// In optimized builds, this does not check for duplicates.
   ///
+  /// - Parameter item: The item to add to the set. The item must no be already
+  ///    a member.
   /// - Complexity: Expected to be O(1) on average if `Element`
   ///    implements high-quality hashing.
   @inlinable
   internal mutating func _appendNew(_ item: Element) {
-    assert(!contains(item))
+    assert(!contains(item), "Duplicate item")
     _elements.append(item)
     guard _elements.count <= _capacity else {
       _regenerateHashTable()

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Invariants.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Invariants.swift
@@ -13,7 +13,7 @@ extension OrderedSet {
   #if COLLECTIONS_INTERNAL_CHECKS
   @inlinable
   @inline(never) @_effects(releasenone)
-  internal func _checkInvariants() {
+  public func _checkInvariants() {
     if _table == nil {
       precondition(_elements.count <= _HashTable.maximumUnhashedCount,
                    "Oversized set without a hash table")

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial RangeReplaceableCollection.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial RangeReplaceableCollection.swift
@@ -215,7 +215,10 @@ extension OrderedSet {
   public mutating func removeAll(
     where shouldBeRemoved: (Element) throws -> Bool
   ) rethrows {
-    defer { _regenerateHashTable() }
+    defer {
+      _regenerateHashTable()
+      _checkInvariants()
+    }
     try _elements.removeAll(where: shouldBeRemoved)
   }
 }

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial SetAlgebra+Operations.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial SetAlgebra+Operations.swift
@@ -165,6 +165,7 @@ extension OrderedSet {
         result._appendNew(item)
       }
     }
+    result._checkInvariants()
     return result
   }
 
@@ -244,7 +245,9 @@ extension OrderedSet {
           bitset.insert(index)
         }
       }
-      return self._extractSubset(using: bitset)
+      let result = self._extractSubset(using: bitset)
+      result._checkInvariants()
+      return result
     }
   }
 
@@ -304,6 +307,7 @@ extension OrderedSet {
         for offset in bitset2 {
           result._appendNew(other._elements[offset])
         }
+        result._checkInvariants()
         return result
       }
     }
@@ -411,6 +415,7 @@ extension OrderedSet {
       for item in new._elements {
         result._appendNew(item)
       }
+      result._checkInvariants()
       return result
     }
   }
@@ -574,7 +579,9 @@ extension OrderedSet {
         }
       }
       assert(difference.count > 0)
-      return _extractSubset(using: difference)
+      let result = _extractSubset(using: difference)
+      result._checkInvariants()
+      return result
     }
   }
 }

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Testing.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Testing.swift
@@ -86,6 +86,7 @@ extension OrderedSet._UnstableInternals {
       }
     }
     base._table = new
+    base._checkInvariants()
   }
 
   @_spi(Testing)
@@ -95,6 +96,7 @@ extension OrderedSet._UnstableInternals {
     persistent: Bool
   ) {
     base._reserveCapacity(minimumCapacity, persistent: persistent)
+    base._checkInvariants()
   }
 }
 
@@ -121,5 +123,6 @@ extension OrderedSet {
       scale < _HashTable.minimumScale ? nil : table)
     precondition(self._scale == scale)
     precondition(self._bias == bias)
+    _checkInvariants()
   }
 }

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
@@ -250,7 +250,7 @@ public struct OrderedSet<Element> where Element: Hashable
     _ table: _HashTable? = nil
   ) {
     self.__storage = table?._storage
-    self._elements = ContiguousArray(_uniqueElements)
+    self._elements = _uniqueElements
   }
 
   @inlinable


### PR DESCRIPTION
It seems useful to be able to manually call `_checkInvariants` while debugging a package issue. This is public as in `public`, not public as in Public API -- it's underscored.

This also adds more `_checkInvariants` invocations in functions that return newly created ordered sets.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
