### PR TITLE
[OrderedSet] Don't let the unchecked init create large sets with no hash table

### DIFF
--- a/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
@@ -247,7 +247,7 @@ public struct OrderedSet<Element> where Element: Hashable
   @inlinable
   internal init(
     _uniqueElements: ContiguousArray<Element>,
-    _ table: _HashTable? = nil
+    _ table: _HashTable?
   ) {
     self.__storage = table?._storage
     self._elements = _uniqueElements


### PR DESCRIPTION
In debug builds, the `OrderedSet.init(uncheckedUniqueElements:)` initializer always created a set with no hash table, even if it had an element count >15. This is technically an invariant violation (caught by `_checkInvariants()`), although it generally only triggers (very) slow performance. (The set reverts to linear searching.)

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
