### PR TITLE
[Deque] `append(contentsOf:):` Use exponential capacity reservation

### DIFF
--- a/Sources/DequeModule/Deque+Collection.swift
+++ b/Sources/DequeModule/Deque+Collection.swift
@@ -672,7 +672,7 @@ extension Deque: RangeReplaceableCollection {
     }
 
     let underestimatedCount = newElements.underestimatedCount
-    reserveCapacity(count + underestimatedCount)
+    _storage.ensureUnique(minimumCapacity: count + underestimatedCount)
     var it: S.Iterator = _storage.update { target in
       let gaps = target.availableSegments()
       let (it, copied) = gaps.initialize(fromSequencePrefix: newElements)
@@ -713,7 +713,7 @@ extension Deque: RangeReplaceableCollection {
 
     let c = newElements.count
     guard c > 0 else { return }
-    reserveCapacity(count + c)
+    _storage.ensureUnique(minimumCapacity: count + c)
     _storage.update { target in
       let gaps = target.availableSegments().prefix(c)
       gaps.initialize(from: newElements)


### PR DESCRIPTION
Depending on the supplied sequence, `Deque.append(contentsOf:)` currently reserves just enough capacity as it needs to perform the append. This isn't right -- it can result in O(n) reallocs instead of O(log(n)) when items are incrementally appended in constant-sized `append(contents:)` batches.


### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
