### PR TITLE
Better `Sequence` support for `Heap`

### DIFF
--- a/Sources/PriorityQueueModule/Heap+OrderedViews.swift
+++ b/Sources/PriorityQueueModule/Heap+OrderedViews.swift
@@ -32,6 +32,11 @@ extension Heap {
     public var underestimatedCount: Int {
       _base.count
     }
+
+    @inlinable @inline(__always)
+    public func _customContainsEquatableElement(_ element: Element) -> Bool? {
+      return _base.contains(element)
+    }
   }
 
   /// A view of a `Heap`'s elements, as a `Sequence` from the largest to
@@ -55,6 +60,11 @@ extension Heap {
     @inlinable @inline(__always)
     public var underestimatedCount: Int {
       _base.count
+    }
+
+    @inlinable @inline(__always)
+    public func _customContainsEquatableElement(_ element: Element) -> Bool? {
+      return _base.contains(element)
     }
   }
 

--- a/Sources/PriorityQueueModule/Heap+OrderedViews.swift
+++ b/Sources/PriorityQueueModule/Heap+OrderedViews.swift
@@ -27,6 +27,11 @@ extension Heap {
     public mutating func next() -> Element? {
       return _base.popMin()
     }
+
+    @inlinable @inline(__always)
+    public var underestimatedCount: Int {
+      _base.count
+    }
   }
 
   /// A view of a `Heap`'s elements, as a `Sequence` from the largest to
@@ -45,6 +50,11 @@ extension Heap {
     @inlinable
     public mutating func next() -> Element? {
       return _base.popMax()
+    }
+
+    @inlinable @inline(__always)
+    public var underestimatedCount: Int {
+      _base.count
     }
   }
 

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -52,6 +52,15 @@ extension Heap {
     _storage.count
   }
 
+  /// A view of a `Heap`'s underlying storage of elements.
+  ///
+  /// The correspondence between an element's storage position and its order
+  /// ranking is private to `Heap`, and may change between revisions.
+  ///
+  /// - Warning: If `Element` is a reference type, do not mutate elements such
+  ///   that their relative order rankings change.
+  public typealias UnorderedView = [Element]
+
   /// A read-only view into the underlying array.
   ///
   /// Note: The elements aren't _arbitrarily_ ordered (it is, after all, a
@@ -60,7 +69,7 @@ extension Heap {
   ///
   /// - Complexity: O(1)
   @inlinable
-  public var unordered: [Element] {
+  public var unordered: UnorderedView {
     Array(_storage)
   }
 

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -221,3 +221,30 @@ extension Heap {
     }
   }
 }
+
+// MARK: -
+
+extension Heap {
+  /// Returns a Boolean value indicating whether the heap contains the given
+  /// element.
+  ///
+  /// This example checks to see whether a favorite actor is in a heap storing a
+  /// movie's cast.
+  ///
+  ///     let cast: Heap = ["Vivien", "Marlon", "Kim", "Karl"]
+  ///     print(cast.contains("Marlon"))
+  ///     // Prints "true"
+  ///     print(cast.contains("James"))
+  ///     // Prints "false"
+  ///
+  /// - Parameter element: The element to find in the heap.
+  /// - Returns: `true` if the element was found in the heap; otherwise,
+  ///   `false`.
+  ///
+  /// - Complexity: O(log `count`).
+  @inlinable
+  public func contains(_ element: Element) -> Bool {
+    // Obviously, change this to take advantage of the heap properties.
+    return _storage.contains(element)
+  }
+}

--- a/Tests/PriorityQueueTests/HeapTests.swift
+++ b/Tests/PriorityQueueTests/HeapTests.swift
@@ -415,6 +415,10 @@ final class HeapTests: XCTestCase {
     XCTAssertFalse(cast.contains("James"))
     XCTAssertFalse(cast.contains("Timmie"))
     XCTAssertFalse(cast.contains("Zoe"))
+
+    // Check empty container
+    let empty = Heap<Double>()
+    XCTAssertFalse(empty.contains(5.0))
   }
 
   func test_sequenceConformance() {

--- a/Tests/PriorityQueueTests/HeapTests.swift
+++ b/Tests/PriorityQueueTests/HeapTests.swift
@@ -404,6 +404,19 @@ final class HeapTests: XCTestCase {
     XCTAssertEqual(heap.popMax(), 1)
   }
 
+  func test_containment() {
+    let cast: Heap = ["Vivien", "Marlon", "Kim", "Karl"]
+    XCTAssertTrue(cast.contains("Karl"))
+    XCTAssertTrue(cast.contains("Kim"))
+    XCTAssertTrue(cast.contains("Marlon"))
+    XCTAssertTrue(cast.contains("Vivien"))
+
+    // Misses; before, within, and after the contained elements
+    XCTAssertFalse(cast.contains("James"))
+    XCTAssertFalse(cast.contains("Timmie"))
+    XCTAssertFalse(cast.contains("Zoe"))
+  }
+
   func test_sequenceConformance() {
     let heap = Heap<Int>((0...50).shuffled())
     let sorted = heap.ascending, reverseSorted = heap.descending
@@ -414,6 +427,8 @@ final class HeapTests: XCTestCase {
       increment += 1
     }
     XCTAssertLessThanOrEqual(sorted.underestimatedCount, 51)
+    XCTAssertTrue(sorted.contains(25))
+    XCTAssertFalse(sorted.contains(-3))
 
     increment = 50
     for val in reverseSorted {
@@ -421,6 +436,8 @@ final class HeapTests: XCTestCase {
       increment -= 1
     }
     XCTAssertLessThanOrEqual(reverseSorted.underestimatedCount, 51)
+    XCTAssertTrue(reverseSorted.contains(25))
+    XCTAssertFalse(reverseSorted.contains(60))
   }
 }
 #endif

--- a/Tests/PriorityQueueTests/HeapTests.swift
+++ b/Tests/PriorityQueueTests/HeapTests.swift
@@ -406,18 +406,21 @@ final class HeapTests: XCTestCase {
 
   func test_sequenceConformance() {
     let heap = Heap<Int>((0...50).shuffled())
+    let sorted = heap.ascending, reverseSorted = heap.descending
 
     var increment = 0
-    for val in heap.ascending {
+    for val in sorted {
       XCTAssertEqual(increment, val)
       increment += 1
     }
+    XCTAssertLessThanOrEqual(sorted.underestimatedCount, 51)
 
     increment = 50
-    for val in heap.descending {
+    for val in reverseSorted {
       XCTAssertEqual(increment, val)
       increment -= 1
     }
+    XCTAssertLessThanOrEqual(reverseSorted.underestimatedCount, 51)
   }
 }
 #endif


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Collections!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This request expands on `Sequence` support for `Heap`s.

- To match the ordered views, the property for the unordered view has a type-alias.
- The ordered views fully implement `underestimatedCount`.
- The ordered views fully implement element search.  This is due from...
- `Heap` now has an element-search method.

That last method has two implementations inside, breadth- and depth-first search.  Those need to be benchmarked against each other.  They also need to be compared against copying an unordered view and running a (linear) search on that.  We need various sizes and search target locations (before all actual values, after them, between them, an actual match).  The complexity level is a guesstimate; it could be worst-case linear, at least for breath-first.  But those are just the time complexities, the scratch space may be significant.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
