### PR TITLE
[Heap] Enable heap tests in optimized builds (#101)

### DIFF
--- a/Tests/PriorityQueueTests/HeapTests.swift
+++ b/Tests/PriorityQueueTests/HeapTests.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-@_spi(Testing) import PriorityQueueModule
+import PriorityQueueModule
 
 final class HeapTests: XCTestCase {
   func test_isEmpty() {

--- a/Tests/PriorityQueueTests/NodeTests.swift
+++ b/Tests/PriorityQueueTests/NodeTests.swift
@@ -11,7 +11,7 @@
 
 #if DEBUG // These unit tests need access to PriorityQueueModule internals
 import XCTest
-@_spi(Testing) @testable import PriorityQueueModule
+@testable import PriorityQueueModule
 
 class NodeTests: XCTestCase {
   func test_levelCalculation() {


### PR DESCRIPTION
@testable import is replaced with @_spi(Testing) import.
A test for _Node is moved to another file because this test needs access to internals of PriorityQueueModule and this test will not work in optimized builds.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
