### PR TITLE
[Heap] Change value of minimum or maximum element

### DIFF
--- a/Sources/PriorityQueueModule/Heap+Invariants.swift
+++ b/Sources/PriorityQueueModule/Heap+Invariants.swift
@@ -19,16 +19,36 @@ extension Heap {
   @inlinable
   @inline(never)
   internal func _checkInvariants() {
-    if let (value, node, boundary) = _someHeapViolation() {
-      switch boundary {
-      case .lessThan(let min):
-        preconditionFailure(
-          "Element \(value) at \(node) is less than min \(min)"
-        )
-      case .greaterThan(let max):
-        preconditionFailure(
-          "Element \(value) at \(node) is greater than max \(max)"
-        )
+    guard count > 1 else { return }
+    _checkInvariants(node: .root, min: nil, max: nil)
+  }
+
+  @inlinable
+  internal func _checkInvariants(node: _Node, min: Element?, max: Element?) {
+    let value = _storage[node.offset]
+    if let min = min {
+      precondition(value >= min,
+                   "Element \(value) at \(node) is less than min \(min)")
+    }
+    if let max = max {
+      precondition(value <= max,
+                   "Element \(value) at \(node) is greater than max \(max)")
+    }
+    let left = node.leftChild()
+    let right = node.rightChild()
+    if node.isMinLevel {
+      if left.offset < count {
+        _checkInvariants(node: left, min: value, max: max)
+      }
+      if right.offset < count {
+        _checkInvariants(node: right, min: value, max: max)
+      }
+    } else {
+      if left.offset < count {
+        _checkInvariants(node: left, min: min, max: value)
+      }
+      if right.offset < count {
+        _checkInvariants(node: right, min: min, max: value)
       }
     }
   }
@@ -37,58 +57,4 @@ extension Heap {
   @inline(__always)
   public func _checkInvariants() {}
   #endif  // COLLECTIONS_INTERNAL_CHECKS
-
-  /// Returns any violation of the min-max heap property.
-  @inlinable
-  internal func _someHeapViolation()
-  -> (value: Element, node: _Node, kind: _BoundaryViolation)? {
-    guard !_storage.isEmpty else { return nil }
-
-    /// Returns any violation of the min-max heap property within the sub-heap
-    /// whose root is at the given node for the given value bounds.
-    func _someSubHeapViolation(node: _Node, min: Element?, max: Element?)
-    -> (value: Element, node: _Node, kind: _BoundaryViolation)? {
-      // Check the sub-heap's root's bounds.
-      let value = _storage[node.offset]
-      if let min = min, value < min {
-        return (value, node, .lessThan(min: min))
-      }
-      if let max = max, value > max {
-        return (value, node, .greaterThan(max: max))
-      }
-
-      // Check the child sub-heaps.
-      var nextMin = min, nextMax = max
-      if node.isMinLevel {
-        nextMin = value
-      } else {
-        nextMax = value
-      }
-
-      if case let leftNode = node.leftChild(),
-         leftNode.offset < count,
-         let result = _someSubHeapViolation(node: leftNode, min: nextMin,
-                                            max: nextMax) {
-        return result
-      }
-      if case let rightNode = node.rightChild(),
-         rightNode.offset < count,
-         let result = _someSubHeapViolation(node: rightNode, min: nextMin,
-                                            max: nextMax) {
-        return result
-      }
-      return nil
-    }
-
-    return _someSubHeapViolation(node: .root, min: nil, max: nil)
-  }
-
-  /// The manner the min-max heap property is violated.
-  @usableFromInline
-  internal enum _BoundaryViolation {
-    /// An element had a value less than the supplied lower bound.
-    case lessThan(min: Element)
-    /// An element had a value greater than the supplied upper bound.
-    case greaterThan(max: Element)
-  }
 }

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -29,22 +29,20 @@ public struct Heap<Element: Comparable> {
   internal var _storage: ContiguousArray<Element>
 
   /// Creates a heap from the given sequence, assuming said sequence is already
-  /// an implicit data structure for a binary min-max heap, failing otherwise.
+  /// an implicit data structure for a binary min-max heap.
   ///
-  /// - Precondition: `storage` is finite.
+  /// - Precondition: `storage` is finite, and it already matches the implicit
+  ///   data structure for a binary min-max heap.
   ///
   /// - Parameter storage: The elements of the heap.
-  /// - Postcondition: If the initializer doesn't fail:
-  ///   `unordered.elementsEqual(s)`, where *s* is a sequence with the same
-  ///   elements as pre-call `storage`.
+  /// - Postcondition: `unordered.elementsEqual(s)`, where *s* is a sequence
+  ///   with the same elements as pre-call `storage`.
   ///
   /// - Complexity: O(*n*), where *n* is the length of `storage`.
   @_alwaysEmitIntoClient
-  internal init?<S: Sequence>(_raw storage: S) where S.Element == Element {
+  internal init<S: Sequence>(_raw storage: S) where S.Element == Element {
     _storage = .init(storage)
-    if _someHeapViolation() != nil {
-      return nil
-    }
+    _checkInvariants()
   }
 
   /// Creates an empty heap.

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -39,8 +39,8 @@ public struct Heap<Element: Comparable> {
   ///   elements as pre-call `storage`.
   ///
   /// - Complexity: O(*n*), where *n* is the length of `storage`.
-  @inlinable
-  public init?<S: Sequence>(raw storage: S) where S.Element == Element {
+  @_alwaysEmitIntoClient
+  internal init?<S: Sequence>(_raw storage: S) where S.Element == Element {
     _storage = .init(storage)
     if _someHeapViolation() != nil {
       return nil

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -204,7 +204,7 @@ extension Heap {
   /// - Complexity: O(log `count`)
   @inlinable @discardableResult
   public mutating func replaceMin(with replacement: Element) -> Element {
-    guard !isEmpty else { preconditionFailure("No element to replace") }
+    precondition(!isEmpty, "No element to replace")
 
     var removed = replacement
     _update { handle in
@@ -233,7 +233,7 @@ extension Heap {
   /// - Complexity: O(log `count`)
   @inlinable @discardableResult
   public mutating func replaceMax(with replacement: Element) -> Element {
-    guard !isEmpty else { preconditionFailure("No element to replace") }
+    precondition(!isEmpty, "No element to replace")
 
     var removed = replacement
     _update { handle in

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -28,23 +28,6 @@ public struct Heap<Element: Comparable> {
   @usableFromInline
   internal var _storage: ContiguousArray<Element>
 
-  /// Creates a heap from the given sequence, whether said sequence conforms to
-  /// an implicit data structure for a min-max heap or not.
-  ///
-  /// - Warning: This initializer is meant only as a shared implementation for
-  ///   the public initializers.  Those initializers need to either ensure the
-  ///   input is already valid, condition the input to be valid afterwards, or
-  ///   flag an error if the input is invalid.  No other code should call this
-  ///   initializer.
-  ///
-  /// - Precondition: `s` is finite.
-  ///
-  /// - Complexity: O(*n*), where *n* is the length of `s`.
-  @inlinable @inline(__always)
-  internal init<S: Sequence>(unchecked s: S) where S.Element == Element {
-    _storage = .init(s)
-  }
-
   /// Creates a heap from the given sequence, assuming said sequence is already
   /// an implicit data structure for a binary min-max heap, failing otherwise.
   ///
@@ -58,7 +41,7 @@ public struct Heap<Element: Comparable> {
   /// - Complexity: O(*n*), where *n* is the length of `storage`.
   @inlinable
   public init?<S: Sequence>(raw storage: S) where S.Element == Element {
-    self.init(unchecked: storage)
+    _storage = .init(storage)
     if _someHeapViolation() != nil {
       return nil
     }

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -28,6 +28,42 @@ public struct Heap<Element: Comparable> {
   @usableFromInline
   internal var _storage: ContiguousArray<Element>
 
+  /// Creates a heap from the given sequence, whether said sequence conforms to
+  /// an implicit data structure for a min-max heap or not.
+  ///
+  /// - Warning: This initializer is meant only as a shared implementation for
+  ///   the public initializers.  Those initializers need to either ensure the
+  ///   input is already valid, condition the input to be valid afterwards, or
+  ///   flag an error if the input is invalid.  No other code should call this
+  ///   initializer.
+  ///
+  /// - Precondition: `s` is finite.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of `s`.
+  @inlinable @inline(__always)
+  internal init<S: Sequence>(unchecked s: S) where S.Element == Element {
+    _storage = .init(s)
+  }
+
+  /// Creates a heap from the given sequence, assuming said sequence is already
+  /// an implicit data structure for a binary min-max heap, failing otherwise.
+  ///
+  /// - Precondition: `storage` is finite.
+  ///
+  /// - Parameter storage: The elements of the heap.
+  /// - Postcondition: If the initializer doesn't fail:
+  ///   `unordered.elementsEqual(s)`, where *s* is a sequence with the same
+  ///   elements as pre-call `storage`.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of `storage`.
+  @inlinable
+  public init?<S: Sequence>(raw storage: S) where S.Element == Element {
+    self.init(unchecked: storage)
+    if _someHeapViolation() != nil {
+      return nil
+    }
+  }
+
   /// Creates an empty heap.
   @inlinable
   public init() {

--- a/Tests/PriorityQueueTests/HeapTests.swift
+++ b/Tests/PriorityQueueTests/HeapTests.swift
@@ -273,6 +273,93 @@ final class HeapTests: XCTestCase {
     XCTAssertEqual(heap.removeMax(), 1)
   }
 
+  func test_minimumReplacement() {
+    var heap = Heap(stride(from: 0, through: 27, by: 3).shuffled())
+    XCTAssertEqual(Array(heap.ascending), [0, 3, 6, 9, 12, 15, 18, 21, 24, 27])
+    XCTAssertEqual(heap.min(), 0)
+
+    // No change
+    heap.replaceMin(with: 0)
+    XCTAssertEqual(Array(heap.ascending), [0, 3, 6, 9, 12, 15, 18, 21, 24, 27])
+    XCTAssertEqual(heap.min(), 0)
+
+    // Even smaller
+    heap.replaceMin(with: -1)
+    XCTAssertEqual(Array(heap.ascending), [-1, 3, 6, 9, 12, 15, 18, 21, 24, 27])
+    XCTAssertEqual(heap.min(), -1)
+
+    // Larger, but not enough to usurp
+    heap.replaceMin(with: 2)
+    XCTAssertEqual(Array(heap.ascending), [2, 3, 6, 9, 12, 15, 18, 21, 24, 27])
+    XCTAssertEqual(heap.min(), 2)
+
+    // Larger, moving another element to be the smallest
+    heap.replaceMin(with: 5)
+    XCTAssertEqual(Array(heap.ascending), [3, 5, 6, 9, 12, 15, 18, 21, 24, 27])
+    XCTAssertEqual(heap.min(), 3)
+  }
+
+  func test_maximumReplacement() {
+    var heap = Heap(stride(from: 0, through: 27, by: 3).shuffled())
+    XCTAssertEqual(Array(heap.ascending), [0, 3, 6, 9, 12, 15, 18, 21, 24, 27])
+    XCTAssertEqual(heap.max(), 27)
+
+    // No change
+    heap.replaceMax(with: 27)
+    XCTAssertEqual(Array(heap.ascending), [0, 3, 6, 9, 12, 15, 18, 21, 24, 27])
+    XCTAssertEqual(heap.max(), 27)
+
+    // Even larger
+    heap.replaceMax(with: 28)
+    XCTAssertEqual(Array(heap.ascending), [0, 3, 6, 9, 12, 15, 18, 21, 24, 28])
+    XCTAssertEqual(heap.max(), 28)
+
+    // Smaller, but not enough to usurp
+    heap.replaceMax(with: 26)
+    XCTAssertEqual(Array(heap.ascending), [0, 3, 6, 9, 12, 15, 18, 21, 24, 26])
+    XCTAssertEqual(heap.max(), 26)
+
+    // Smaller, moving another element to be the largest
+    heap.replaceMax(with: 23)
+    XCTAssertEqual(Array(heap.ascending), [0, 3, 6, 9, 12, 15, 18, 21, 23, 24])
+    XCTAssertEqual(heap.max(), 24)
+
+    // Check the finer details.  As these peek into the stored structure, they
+    // may need to be updated whenever the internal format changes.
+    var heap2 = Heap(raw: [1])!
+    XCTAssertEqual(heap2.max(), 1)
+    XCTAssertEqual(Array(heap2.unordered), [1])
+    XCTAssertEqual(heap2.replaceMax(with: 2), 1)
+    XCTAssertEqual(heap2.max(), 2)
+    XCTAssertEqual(Array(heap2.unordered), [2])
+
+    heap2 = Heap(raw: [1, 2])!
+    XCTAssertEqual(heap2.max(), 2)
+    XCTAssertEqual(Array(heap2.unordered), [1, 2])
+    XCTAssertEqual(heap2.replaceMax(with: 3), 2)
+    XCTAssertEqual(heap2.max(), 3)
+    XCTAssertEqual(Array(heap2.unordered), [1, 3])
+    XCTAssertEqual(heap2.replaceMax(with: 0), 3)
+    XCTAssertEqual(heap2.max(), 1)
+    XCTAssertEqual(Array(heap2.unordered), [0, 1])
+
+    heap2 = Heap(raw: [5, 20, 31, 16, 8, 7, 18])!
+    XCTAssertEqual(heap2.max(), 31)
+    XCTAssertEqual(Array(heap2.unordered), [5, 20, 31, 16, 8, 7, 18])
+    XCTAssertEqual(heap2.replaceMax(with: 29), 31)
+    XCTAssertEqual(Array(heap2.unordered), [5, 20, 29, 16, 8, 7, 18])
+    XCTAssertEqual(heap2.max(), 29)
+    XCTAssertEqual(heap2.replaceMax(with: 19), 29)
+    XCTAssertEqual(Array(heap2.unordered), [5, 20, 19, 16, 8, 7, 18])
+    XCTAssertEqual(heap2.max(), 20)
+    XCTAssertEqual(heap2.replaceMax(with: 15), 20)
+    XCTAssertEqual(Array(heap2.unordered), [5, 16, 19, 15, 8, 7, 18])
+    XCTAssertEqual(heap2.max(), 19)
+    XCTAssertEqual(heap2.replaceMax(with: 4), 19)
+    XCTAssertEqual(Array(heap2.unordered), [4, 16, 18, 15, 8, 7, 5])
+    XCTAssertEqual(heap2.max(), 18)
+  }
+
   // MARK: -
 
   func test_min_struct() {

--- a/Tests/PriorityQueueTests/HeapTests.swift
+++ b/Tests/PriorityQueueTests/HeapTests.swift
@@ -326,14 +326,14 @@ final class HeapTests: XCTestCase {
 
     // Check the finer details.  As these peek into the stored structure, they
     // may need to be updated whenever the internal format changes.
-    var heap2 = Heap(raw: [1])!
+    var heap2 = Heap(_raw: [1])!
     XCTAssertEqual(heap2.max(), 1)
     XCTAssertEqual(Array(heap2.unordered), [1])
     XCTAssertEqual(heap2.replaceMax(with: 2), 1)
     XCTAssertEqual(heap2.max(), 2)
     XCTAssertEqual(Array(heap2.unordered), [2])
 
-    heap2 = Heap(raw: [1, 2])!
+    heap2 = Heap(_raw: [1, 2])!
     XCTAssertEqual(heap2.max(), 2)
     XCTAssertEqual(Array(heap2.unordered), [1, 2])
     XCTAssertEqual(heap2.replaceMax(with: 3), 2)
@@ -343,7 +343,7 @@ final class HeapTests: XCTestCase {
     XCTAssertEqual(heap2.max(), 1)
     XCTAssertEqual(Array(heap2.unordered), [0, 1])
 
-    heap2 = Heap(raw: [5, 20, 31, 16, 8, 7, 18])!
+    heap2 = Heap(_raw: [5, 20, 31, 16, 8, 7, 18])!
     XCTAssertEqual(heap2.max(), 31)
     XCTAssertEqual(Array(heap2.unordered), [5, 20, 31, 16, 8, 7, 18])
     XCTAssertEqual(heap2.replaceMax(with: 29), 31)
@@ -478,33 +478,6 @@ final class HeapTests: XCTestCase {
   func test_initializer_fromSequence() {
     let heap = Heap((1...).prefix(20))
     XCTAssertEqual(heap.count, 20)
-  }
-
-  func test_initializer_withChecking() {
-    XCTAssertNotNil(Heap(raw: EmptyCollection<Int>()))
-    XCTAssertNotNil(Heap(raw: CollectionOfOne("a")))
-    XCTAssertNotNil(Heap(raw: repeatElement(2.0, count: 15)))
-
-    // As these test non-identical multi-element sources, they may need to be
-    // updated whenever the internal storage format changes.
-
-    let twoElements = Heap(raw: [1, 2])
-    XCTAssertEqual(twoElements?.unordered, [1, 2])
-    XCTAssertNil(Heap(raw: [2, 1]))
-
-    let threeElements = Heap(raw: 1...3)
-    XCTAssertEqual(threeElements?.unordered, [1, 2, 3])
-
-    let otherThreeElements = Heap(raw: [1, 3, 2])
-    XCTAssertEqual(otherThreeElements?.unordered, [1, 3, 2])
-    XCTAssertNil(Heap(raw: [2, 1, 3]))
-    XCTAssertNil(Heap(raw: [2, 3, 1]))
-    XCTAssertNil(Heap(raw: [3, 1, 2]))
-    XCTAssertNil(Heap(raw: [3, 2, 1]))
-
-    // Errors past the first two layers.
-    XCTAssertNil(Heap(raw: [1, 2, 3, 0, 2, 3, 2]))  // 0 >= 1 is false
-    XCTAssertNil(Heap(raw: [1, 2, 3, 1, 4, 3, 1]))  // 4 <= 2 is false
   }
 
   func test_initializer_fromArrayLiteral() {

--- a/Tests/PriorityQueueTests/HeapTests.swift
+++ b/Tests/PriorityQueueTests/HeapTests.swift
@@ -393,6 +393,33 @@ final class HeapTests: XCTestCase {
     XCTAssertEqual(heap.count, 20)
   }
 
+  func test_initializer_withChecking() {
+    XCTAssertNotNil(Heap(raw: EmptyCollection<Int>()))
+    XCTAssertNotNil(Heap(raw: CollectionOfOne("a")))
+    XCTAssertNotNil(Heap(raw: repeatElement(2.0, count: 15)))
+
+    // As these test non-identical multi-element sources, they may need to be
+    // updated whenever the internal storage format changes.
+
+    let twoElements = Heap(raw: [1, 2])
+    XCTAssertEqual(twoElements?.unordered, [1, 2])
+    XCTAssertNil(Heap(raw: [2, 1]))
+
+    let threeElements = Heap(raw: 1...3)
+    XCTAssertEqual(threeElements?.unordered, [1, 2, 3])
+
+    let otherThreeElements = Heap(raw: [1, 3, 2])
+    XCTAssertEqual(otherThreeElements?.unordered, [1, 3, 2])
+    XCTAssertNil(Heap(raw: [2, 1, 3]))
+    XCTAssertNil(Heap(raw: [2, 3, 1]))
+    XCTAssertNil(Heap(raw: [3, 1, 2]))
+    XCTAssertNil(Heap(raw: [3, 2, 1]))
+
+    // Errors past the first two layers.
+    XCTAssertNil(Heap(raw: [1, 2, 3, 0, 2, 3, 2]))  // 0 >= 1 is false
+    XCTAssertNil(Heap(raw: [1, 2, 3, 1, 4, 3, 1]))  // 4 <= 2 is false
+  }
+
   func test_initializer_fromArrayLiteral() {
     var heap: Heap = [1, 3, 5, 7, 9]
     XCTAssertEqual(heap.count, 5)

--- a/Tests/PriorityQueueTests/HeapTests.swift
+++ b/Tests/PriorityQueueTests/HeapTests.swift
@@ -326,14 +326,14 @@ final class HeapTests: XCTestCase {
 
     // Check the finer details.  As these peek into the stored structure, they
     // may need to be updated whenever the internal format changes.
-    var heap2 = Heap(_raw: [1])!
+    var heap2 = Heap(_raw: [1])
     XCTAssertEqual(heap2.max(), 1)
     XCTAssertEqual(Array(heap2.unordered), [1])
     XCTAssertEqual(heap2.replaceMax(with: 2), 1)
     XCTAssertEqual(heap2.max(), 2)
     XCTAssertEqual(Array(heap2.unordered), [2])
 
-    heap2 = Heap(_raw: [1, 2])!
+    heap2 = Heap(_raw: [1, 2])
     XCTAssertEqual(heap2.max(), 2)
     XCTAssertEqual(Array(heap2.unordered), [1, 2])
     XCTAssertEqual(heap2.replaceMax(with: 3), 2)
@@ -343,7 +343,7 @@ final class HeapTests: XCTestCase {
     XCTAssertEqual(heap2.max(), 1)
     XCTAssertEqual(Array(heap2.unordered), [0, 1])
 
-    heap2 = Heap(_raw: [5, 20, 31, 16, 8, 7, 18])!
+    heap2 = Heap(_raw: [5, 20, 31, 16, 8, 7, 18])
     XCTAssertEqual(heap2.max(), 31)
     XCTAssertEqual(Array(heap2.unordered), [5, 20, 31, 16, 8, 7, 18])
     XCTAssertEqual(heap2.replaceMax(with: 29), 31)


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Collections!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Adds two methods to change either the minimum or maximum element of a `Heap` instance.  If the value changes enough that the previous second-place element now surpasses it, that former second-place element will take over for the heap's min/max element.

For testing purposes, I needed a way to precisely define a heap's pre-test state.  Therefore, I also added a new initializer that receives an exact storage layout as input.  It's a fail-able initializer.  This requires a testing function.  There is such a procedure locked in the debug-only invariant code.  I moved that code to a new unconditional method that both the new initializer and the invariant-test code both reference.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
