### PR TITLE
build: repair the ability to build with build tree artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows OR CMAKE_SYSTEM_NAME STREQUAL Darwin)
   option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
 endif()
 
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  find_package(dispatch CONFIG QUIET)
+  find_package(Foundation CONFIG QUIET)
+endif()
+
 include(CTest)
 include(SwiftSupport)
 

--- a/Sources/PriorityQueueModule/CMakeLists.txt
+++ b/Sources/PriorityQueueModule/CMakeLists.txt
@@ -16,6 +16,11 @@ add_library(PriorityQueueModule
   Heap+UnsafeHandle.swift)
 set_target_properties(PriorityQueueModule PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+if(Foundation_FOUND AND dispatch_FOUND)
+  target_link_libraries(PriorityQueueModule PUBLIC
+    $<$<NOT:$<PLATFORM_ID:Darwin>>:dispatch>
+    $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
+endif()
 
 _install_target(PriorityQueueModule)
 set_property(GLOBAL APPEND PROPERTY SWIFT_COLLECTIONS_EXPORTS PriorityQueueModule)


### PR DESCRIPTION
This restores the ability to build swift-collections with build tree
artifacts for the toolchain.  The newly introduced dependency on
Foundation in PriorityQueueModule requires linking against Foundation
and dispatch in the case that the system does not provide the libraries
and you do not have a complete toolchain on hand.

<!--
    Thanks for contributing to Swift Collections!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [ ] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [ ] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [ ] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
