### PR TITLE
[OrderedSet] Add missing uniqueness check

### DIFF
--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
@@ -129,6 +129,7 @@ extension OrderedSet {
       return
     }
 
+    _ensureUnique()
     _table!.update { hashTable in
       assert(!hashTable.isOccupied(bucket))
       hashTable.adjustContents(preparingForInsertionOfElementAtOffset: index, in: _elements)

--- a/Sources/_CollectionsTestSupport/AssertionContexts/Combinatorics.swift
+++ b/Sources/_CollectionsTestSupport/AssertionContexts/Combinatorics.swift
@@ -132,10 +132,12 @@ public func withSomeRanges<T: Strideable>(
 /// - Parameters:
 ///    - `enabled`: if `false`, then no copies are made -- the values are passed to `body` with no processing.
 ///    - `value`: The collection value that is being tested.
+///    - `checker`: An optional function that is used to check the consistency of the hidden copy.
 ///    - `body`: A closure performing a mutation on `value`.
 public func withHiddenCopies<S: Sequence, R>(
   if enabled: Bool,
   of value: inout S,
+  checker: (S) -> Void = { _ in },
   file: StaticString = #file, line: UInt = #line,
   _ body: (inout S) throws -> R
 ) rethrows -> R where S.Element: Equatable {
@@ -144,6 +146,7 @@ public func withHiddenCopies<S: Sequence, R>(
   let expected = Array(value)
   let result = try body(&value)
   expectEqualElements(copy, expected, file: file, line: line)
+  checker(copy)
   return result
 }
 
@@ -156,6 +159,7 @@ public func withHiddenCopies<S: Sequence, R>(
 /// - Parameters:
 ///    - `enabled`: if `false`, then no copies are made -- the values are passed to `body` with no processing.
 ///    - `value`: The collection value that is being tested.
+///    - `checker`: An optional function that is used to check the consistency of the hidden copy.
 ///    - `body`: A closure performing a mutation on `value`.
 public func withHiddenCopies<
   S: Sequence,
@@ -165,6 +169,7 @@ public func withHiddenCopies<
 >(
   if enabled: Bool,
   of value: inout S,
+  checker: (S) -> Void = { _ in },
   file: StaticString = #file, line: UInt = #line,
   _ body: (inout S) throws -> R
 ) rethrows -> R where S.Element == (key: Key, value: Value) {
@@ -173,5 +178,6 @@ public func withHiddenCopies<
   let expected = Array(value)
   let result = try body(&value)
   expectEqualElements(copy, expected, file: file, line: line)
+  checker(copy)
   return result
 }

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
@@ -233,7 +233,7 @@ class OrderedDictionaryTests: CollectionTestCase {
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
             let replacement = tracker.instance(for: -1)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d[reference[offset].key] = replacement
               reference[offset].value = replacement
               expectEqualElements(d, reference)
@@ -250,7 +250,7 @@ class OrderedDictionaryTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d[reference[offset].key] = nil
               reference.remove(at: offset)
               expectEqualElements(d, reference)
@@ -270,7 +270,7 @@ class OrderedDictionaryTests: CollectionTestCase {
           let reference = zip(keys, values).map { (key: $0.0, value: $0.1) }
           var d: OrderedDictionary<LifetimeTracked<Int>, LifetimeTracked<Int>> = [:]
           withEvery("offset", in: 0 ..< count) { offset in
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d[keys[offset]] = values[offset]
               expectEqualElements(d, reference.prefix(offset + 1))
             }
@@ -286,7 +286,7 @@ class OrderedDictionaryTests: CollectionTestCase {
         withLifetimeTracking { tracker in
           var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
           let key = tracker.instance(for: -1)
-          withHiddenCopies(if: isShared, of: &d) { d in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
             d[key] = nil
           }
           expectEqualElements(d, reference)
@@ -309,7 +309,7 @@ class OrderedDictionaryTests: CollectionTestCase {
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
             let replacement = tracker.instance(for: -1)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               mutate(&d[reference[offset].key]) { $0 = replacement }
               reference[offset].value = replacement
               expectEqualElements(d, reference)
@@ -326,7 +326,7 @@ class OrderedDictionaryTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let key = reference[offset].key
               mutate(&d[key]) { v in
                 expectEqual(v, reference[offset].value)
@@ -349,7 +349,7 @@ class OrderedDictionaryTests: CollectionTestCase {
           let reference = zip(keys, values).map { (key: $0.0, value: $0.1) }
           var d: OrderedDictionary<LifetimeTracked<Int>, LifetimeTracked<Int>> = [:]
           withEvery("offset", in: 0 ..< count) { offset in
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               mutate(&d[keys[offset]]) { v in
                 expectNil(v)
                 v = values[offset]
@@ -369,7 +369,7 @@ class OrderedDictionaryTests: CollectionTestCase {
         withLifetimeTracking { tracker in
           var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
           let key = tracker.instance(for: -1)
-          withHiddenCopies(if: isShared, of: &d) { d in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
             mutate(&d[key]) { v in
               expectNil(v)
               v = nil
@@ -410,7 +410,7 @@ class OrderedDictionaryTests: CollectionTestCase {
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
             let replacement = tracker.instance(for: -1)
             let fallback = tracker.instance(for: -1)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let key = reference[offset].key
               mutate(&d[key, default: fallback]) { v in
                 expectEqual(v, reference[offset].value)
@@ -435,7 +435,7 @@ class OrderedDictionaryTests: CollectionTestCase {
           var d: OrderedDictionary<LifetimeTracked<Int>, LifetimeTracked<Int>> = [:]
           let fallback = tracker.instance(for: -1)
           withEvery("offset", in: 0 ..< count) { offset in
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let key = keys[offset]
               mutate(&d[key, default: fallback]) { v in
                 expectEqual(v, fallback)
@@ -457,7 +457,7 @@ class OrderedDictionaryTests: CollectionTestCase {
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
             let replacement = tracker.instance(for: -1)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let key = reference[offset].key
               let old = d.updateValue(replacement, forKey: key)
               expectEqual(old, reference[offset].value)
@@ -479,7 +479,7 @@ class OrderedDictionaryTests: CollectionTestCase {
           let reference = zip(keys, values).map { (key: $0.0, value: $0.1) }
           var d: OrderedDictionary<LifetimeTracked<Int>, LifetimeTracked<Int>> = [:]
           withEvery("offset", in: 0 ..< count) { offset in
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let key = keys[offset]
               let old = d.updateValue(values[offset], forKey: key)
               expectNil(old)
@@ -499,7 +499,7 @@ class OrderedDictionaryTests: CollectionTestCase {
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
             let replacement = tracker.instance(for: -1)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let key = reference[offset].key
               let (old, index) =
                 d.updateValue(replacement, forKey: key, insertingAt: 0)
@@ -523,7 +523,7 @@ class OrderedDictionaryTests: CollectionTestCase {
           let reference = zip(keys, values).map { (key: $0.0, value: $0.1) }
           var d: OrderedDictionary<LifetimeTracked<Int>, LifetimeTracked<Int>> = [:]
           withEvery("offset", in: 0 ..< count) { offset in
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let key = keys[count - 1 - offset]
               let value = values[count - 1 - offset]
               let (old, index) =
@@ -547,7 +547,7 @@ class OrderedDictionaryTests: CollectionTestCase {
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
             let replacement = tracker.instance(for: -1)
             let fallback = tracker.instance(for: -2)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let key = reference[offset].key
               d.updateValue(forKey: key, default: fallback) { value in
                 expectEqual(value, reference[offset].value)
@@ -572,7 +572,7 @@ class OrderedDictionaryTests: CollectionTestCase {
           var d: OrderedDictionary<LifetimeTracked<Int>, LifetimeTracked<Int>> = [:]
           let fallback = tracker.instance(for: -2)
           withEvery("offset", in: 0 ..< count) { offset in
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let key = keys[offset]
               d.updateValue(forKey: key, default: fallback) { value in
                 expectEqual(value, fallback)
@@ -595,7 +595,7 @@ class OrderedDictionaryTests: CollectionTestCase {
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
             let replacement = tracker.instance(for: -1)
             let fallback = tracker.instance(for: -2)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let (key, value) = reference[offset]
               d.updateValue(forKey: key, insertingDefault: fallback, at: 0) { v in
                 expectEqual(v, value)
@@ -620,7 +620,7 @@ class OrderedDictionaryTests: CollectionTestCase {
           var d: OrderedDictionary<LifetimeTracked<Int>, LifetimeTracked<Int>> = [:]
           let fallback = tracker.instance(for: -2)
           withEvery("offset", in: 0 ..< count) { offset in
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let (key, value) = reference[count - 1 - offset]
               d.updateValue(forKey: key, insertingDefault: fallback, at: 0) { v in
                 expectEqual(v, fallback)
@@ -641,7 +641,7 @@ class OrderedDictionaryTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let (key, value) = reference.remove(at: offset)
               let actual = d.removeValue(forKey: key)
               expectEqual(actual, value)
@@ -952,7 +952,7 @@ class OrderedDictionaryTests: CollectionTestCase {
             withLifetimeTracking { tracker in
               var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
               reference.swapAt(i, j)
-              withHiddenCopies(if: isShared, of: &d) { d in
+              withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
                 d.swapAt(i, j)
                 expectEqualElements(d, reference)
                 expectEqual(d[reference[i].key], reference[i].value)
@@ -974,7 +974,7 @@ class OrderedDictionaryTests: CollectionTestCase {
             var (d, reference) = tracker.orderedDictionary(
               keys: (0 ..< count).shuffled(using: &rng))
             let expectedPivot = reference.partition { $0.key.payload < count / 2 }
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let actualPivot = d.partition { $0.key.payload < count / 2 }
               expectEqual(actualPivot, expectedPivot)
               expectEqualElements(d, reference)
@@ -994,7 +994,7 @@ class OrderedDictionaryTests: CollectionTestCase {
             var (d, reference) = tracker.orderedDictionary(
               keys: (0 ..< count).shuffled(using: &rng))
             reference.sort(by: { $0.key < $1.key })
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d.sort()
               expectEqualElements(d, reference)
             }
@@ -1013,7 +1013,7 @@ class OrderedDictionaryTests: CollectionTestCase {
             var (d, reference) = tracker.orderedDictionary(
               keys: (0 ..< count).shuffled(using: &rng))
             reference.sort(by: { $0.key > $1.key })
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d.sort(by: { $0.key > $1.key })
               expectEqualElements(d, reference)
             }
@@ -1031,7 +1031,7 @@ class OrderedDictionaryTests: CollectionTestCase {
             uniqueKeys: 0 ..< count,
             values: 100 ..< 100 + count)
           var items = (0 ..< count).map { (key: $0, value: 100 + $0) }
-          withHiddenCopies(if: isShared, of: &d) { d in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
             expectEqualElements(d, items)
 
             var rng1 = RepeatableRandomNumberGenerator(seed: seed)
@@ -1073,7 +1073,7 @@ class OrderedDictionaryTests: CollectionTestCase {
       withEvery("isShared", in: [false, true]) { isShared in
         withLifetimeTracking { tracker in
           var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-          withHiddenCopies(if: isShared, of: &d) { d in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
             reference.reverse()
             d.reverse()
             expectEqualElements(d, reference)
@@ -1088,7 +1088,7 @@ class OrderedDictionaryTests: CollectionTestCase {
       withEvery("isShared", in: [false, true]) { isShared in
         withLifetimeTracking { tracker in
           var (d, _) = tracker.orderedDictionary(keys: 0 ..< count)
-          withHiddenCopies(if: isShared, of: &d) { d in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
             d.removeAll()
             expectEqual(d.keys.__unstable.scale, 0)
             expectEqualElements(d, [])
@@ -1104,7 +1104,7 @@ class OrderedDictionaryTests: CollectionTestCase {
         withLifetimeTracking { tracker in
           var (d, _) = tracker.orderedDictionary(keys: 0 ..< count)
           let origScale = d.keys.__unstable.scale
-          withHiddenCopies(if: isShared, of: &d) { d in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
             d.removeAll(keepingCapacity: true)
             expectEqual(d.keys.__unstable.scale, origScale)
             expectEqualElements(d, [])
@@ -1120,7 +1120,7 @@ class OrderedDictionaryTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let actual = d.remove(at: offset)
               let expectedItem = reference.remove(at: offset)
               expectEqual(actual.key, expectedItem.key)
@@ -1139,7 +1139,7 @@ class OrderedDictionaryTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d.removeSubrange(range)
               reference.removeSubrange(range)
               expectEqualElements(d, reference)
@@ -1172,7 +1172,7 @@ class OrderedDictionaryTests: CollectionTestCase {
       withLifetimeTracking { tracker in
         var (d, reference) = tracker.orderedDictionary(keys: 0 ..< 30)
         withEvery("i", in: 0 ..< d.count) { i in
-          withHiddenCopies(if: isShared, of: &d) { d in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
             let actual = d.removeLast()
             let ref = reference.removeLast()
             expectEqual(actual.key, ref.key)
@@ -1189,7 +1189,7 @@ class OrderedDictionaryTests: CollectionTestCase {
       withLifetimeTracking { tracker in
         var (d, reference) = tracker.orderedDictionary(keys: 0 ..< 30)
         withEvery("i", in: 0 ..< d.count) { i in
-          withHiddenCopies(if: isShared, of: &d) { d in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
             let actual = d.removeFirst()
             let expected = reference.removeFirst()
             expectEqual(actual.key, expected.key)
@@ -1207,7 +1207,7 @@ class OrderedDictionaryTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d.removeLast(suffix)
               reference.removeLast(suffix)
               expectEqualElements(d, reference)
@@ -1224,7 +1224,7 @@ class OrderedDictionaryTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d.removeFirst(prefix)
               reference.removeFirst(prefix)
               expectEqualElements(d, reference)
@@ -1241,7 +1241,7 @@ class OrderedDictionaryTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d.removeAll(where: { !$0.key.payload.isMultiple(of: n) })
               reference.removeAll(where: { !$0.key.payload.isMultiple(of: n) })
               expectEqualElements(d, reference)

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Elements Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Elements Tests.swift
@@ -148,7 +148,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
             withLifetimeTracking { tracker in
               var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
               reference.swapAt(i, j)
-              withHiddenCopies(if: isShared, of: &d) { d in
+              withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
                 d.elements.swapAt(i, j)
                 expectEquivalentElements(
                   d, reference,
@@ -172,7 +172,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
             var (d, reference) = tracker.orderedDictionary(
               keys: (0 ..< count).shuffled(using: &rng))
             let expectedPivot = reference.partition { $0.key.payload < count / 2 }
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let actualPivot = d.elements.partition { $0.key.payload < count / 2 }
               expectEqual(actualPivot, expectedPivot)
               expectEqualElements(d, reference)
@@ -192,7 +192,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
             var (d, reference) = tracker.orderedDictionary(
               keys: (0 ..< count).shuffled(using: &rng))
             reference.sort(by: { $0.key < $1.key })
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d.elements.sort()
               expectEqualElements(d, reference)
             }
@@ -211,7 +211,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
             var (d, reference) = tracker.orderedDictionary(
               keys: (0 ..< count).shuffled(using: &rng))
             reference.sort(by: { $0.key > $1.key })
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d.elements.sort(by: { $0.key > $1.key })
               expectEqualElements(d, reference)
             }
@@ -229,7 +229,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
             uniqueKeys: 0 ..< count,
             values: 100 ..< 100 + count)
           var items = (0 ..< count).map { (key: $0, value: 100 + $0) }
-          withHiddenCopies(if: isShared, of: &d) { d in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
             expectEqualElements(d.elements, items)
 
             var rng1 = RepeatableRandomNumberGenerator(seed: seed)
@@ -271,7 +271,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
       withEvery("isShared", in: [false, true]) { isShared in
         withLifetimeTracking { tracker in
           var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-          withHiddenCopies(if: isShared, of: &d) { d in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
             reference.reverse()
             d.elements.reverse()
             expectEqualElements(d, reference)
@@ -286,7 +286,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
       withEvery("isShared", in: [false, true]) { isShared in
         withLifetimeTracking { tracker in
           var (d, _) = tracker.orderedDictionary(keys: 0 ..< count)
-          withHiddenCopies(if: isShared, of: &d) { d in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
             d.elements.removeAll()
             expectEqual(d.keys.__unstable.scale, 0)
             expectEqualElements(d, [])
@@ -302,7 +302,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
         withLifetimeTracking { tracker in
           var (d, _) = tracker.orderedDictionary(keys: 0 ..< count)
           let origScale = d.keys.__unstable.scale
-          withHiddenCopies(if: isShared, of: &d) { d in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
             d.elements.removeAll(keepingCapacity: true)
             expectEqual(d.keys.__unstable.scale, origScale)
             expectEqualElements(d, [])
@@ -318,7 +318,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let actual = d.elements.remove(at: offset)
               let expected = reference.remove(at: offset)
               expectEqual(actual.key, expected.key)
@@ -337,7 +337,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d.elements.removeSubrange(range)
               reference.removeSubrange(range)
               expectEqualElements(d, reference)
@@ -370,7 +370,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
       withLifetimeTracking { tracker in
         var (d, reference) = tracker.orderedDictionary(keys: 0 ..< 30)
         withEvery("i", in: 0 ..< d.count) { i in
-          withHiddenCopies(if: isShared, of: &d) { d in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
             let actual = d.elements.removeLast()
             let expected = reference.removeLast()
             expectEqual(actual.key, expected.key)
@@ -387,7 +387,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
       withLifetimeTracking { tracker in
         var (d, reference) = tracker.orderedDictionary(keys: 0 ..< 30)
         withEvery("i", in: 0 ..< d.count) { i in
-          withHiddenCopies(if: isShared, of: &d) { d in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
             let actual = d.elements.removeFirst()
             let expected = reference.removeFirst()
             expectEqual(actual.key, expected.key)
@@ -405,7 +405,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d.elements.removeLast(suffix)
               reference.removeLast(suffix)
               expectEqualElements(d, reference)
@@ -422,7 +422,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d.elements.removeFirst(prefix)
               reference.removeFirst(prefix)
               expectEqualElements(d, reference)
@@ -439,7 +439,7 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d.elements.removeAll(where: { !$0.key.payload.isMultiple(of: n) })
               reference.removeAll(where: { !$0.key.payload.isMultiple(of: n) })
               expectEqualElements(d, reference)

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Values Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Values Tests.swift
@@ -41,7 +41,7 @@ class OrderedDictionaryValueTests: CollectionTestCase {
           withLifetimeTracking { tracker in
             var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
             let replacement = tracker.instance(for: -1)
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               d.values[offset] = replacement
               reference[offset].value = replacement
               expectEqualElements(d.values, reference.map { $0.value })
@@ -95,7 +95,7 @@ class OrderedDictionaryValueTests: CollectionTestCase {
               let t = reference[i].value
               reference[i].value = reference[j].value
               reference[j].value = t
-              withHiddenCopies(if: isShared, of: &d) { d in
+              withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
                 d.values.swapAt(i, j)
                 expectEqualElements(d.values, reference.map { $0.value })
                 expectEqual(d[reference[i].key], reference[i].value)
@@ -118,7 +118,7 @@ class OrderedDictionaryValueTests: CollectionTestCase {
               keys: (0 ..< count).shuffled(using: &rng))
             var values = reference.map { $0.value }
             let expectedPivot = values.partition { $0.payload < 100 + count / 2 }
-            withHiddenCopies(if: isShared, of: &d) { d in
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
               let actualPivot = d.values.partition { $0.payload < 100 + count / 2 }
               expectEqual(actualPivot, expectedPivot)
               expectEqualElements(d.values, values)
@@ -139,7 +139,7 @@ class OrderedDictionaryValueTests: CollectionTestCase {
           var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
           typealias R = [LifetimeTracked<Int>]
           let actual =
-            withHiddenCopies(if: isShared, of: &d) { d -> R in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d -> R in
               d.values.withUnsafeBufferPointer { buffer -> R in
                 Array(buffer)
               }
@@ -158,7 +158,7 @@ class OrderedDictionaryValueTests: CollectionTestCase {
           let replacement = tracker.instances(for: (0 ..< count).map { -$0 })
           typealias R = [LifetimeTracked<Int>]
           let actual =
-            withHiddenCopies(if: isShared, of: &d) { d -> R in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d -> R in
               d.values.withUnsafeMutableBufferPointer { buffer -> R in
                 let result = Array(buffer)
                 expectEqual(buffer.count, replacement.count, trapping: true)
@@ -186,7 +186,7 @@ class OrderedDictionaryValueTests: CollectionTestCase {
           let replacement = tracker.instances(for: (0 ..< count).map { -$0 })
           typealias R = [LifetimeTracked<Int>]
           let actual =
-            withHiddenCopies(if: isShared, of: &d) { d -> R? in
+          withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d -> R? in
               d.values.withContiguousMutableStorageIfAvailable { buffer -> R in
                 let result = Array(buffer)
                 expectEqual(buffer.count, replacement.count, trapping: true)

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -356,7 +356,7 @@ class OrderedSetTests: CollectionTestCase {
         let count = layout.count
         withEvery("offset", in: 0 ... count) { offset in
           var set = OrderedSet<Int>(layout: layout)
-          withHiddenCopies(if: isShared, of: &set) { set in
+          withHiddenCopies(if: isShared, of: &set, checker: { $0._checkInvariants() }) { set in
             let i = set.index(set.startIndex, offsetBy: offset)
             let (inserted, index) = set.insert(count, at: i)
             expectTrue(inserted)
@@ -511,7 +511,7 @@ class OrderedSetTests: CollectionTestCase {
         let count = layout.count
         withEvery("a", in: 0 ..< count) { a in
           var set = OrderedSet(layout: layout)
-          withHiddenCopies(if: isShared, of: &set) { set in
+          withHiddenCopies(if: isShared, of: &set, checker: { $0._checkInvariants() }) { set in
             let b = count - a - 1
             let ai = set._index(at: a)
             let bi = set._index(at: b)
@@ -535,7 +535,7 @@ class OrderedSetTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           let count = layout.count
           var set = OrderedSet(layout: layout)
-          withHiddenCopies(if: isShared, of: &set) { set in
+          withHiddenCopies(if: isShared, of: &set, checker: { $0._checkInvariants() }) { set in
             let pivot = set.partition(by: { $0.isMultiple(of: 2) })
             withEvery("item", in: 0 ..< count) { item in
               expectNotNil(set.firstIndex(of: item)) { index in
@@ -559,7 +559,7 @@ class OrderedSetTests: CollectionTestCase {
         withEvery("isShared", in: [false, true]) { isShared in
           let count = layout.count
           var set = OrderedSet(layout: layout)
-          withHiddenCopies(if: isShared, of: &set) { set in
+          withHiddenCopies(if: isShared, of: &set, checker: { $0._checkInvariants() }) { set in
             do {
               let pivot = set.partition(by: { _ in false })
               expectEqual(pivot, set.endIndex)
@@ -585,7 +585,7 @@ class OrderedSetTests: CollectionTestCase {
           var rng = RepeatableRandomNumberGenerator(seed: seed)
           let contents = (0 ..< count).shuffled(using: &rng)
           var set = OrderedSet(layout: layout, contents: contents)
-          withHiddenCopies(if: isShared, of: &set) { set in
+          withHiddenCopies(if: isShared, of: &set, checker: { $0._checkInvariants() }) { set in
             set.sort()
             expectEqualElements(set, 0 ..< count)
 
@@ -605,7 +605,7 @@ class OrderedSetTests: CollectionTestCase {
           let count = layout.count
           var contents = Array(0 ..< count)
           var set = OrderedSet(layout: layout, contents: 0 ..< count)
-          withHiddenCopies(if: isShared, of: &set) { set in
+          withHiddenCopies(if: isShared, of: &set, checker: { $0._checkInvariants() }) { set in
             var rng1 = RepeatableRandomNumberGenerator(seed: seed)
             contents.shuffle(using: &rng1)
 
@@ -637,7 +637,7 @@ class OrderedSetTests: CollectionTestCase {
         let count = layout.count
         var contents = Array(0 ..< count)
         var set = OrderedSet(layout: layout, contents: 0 ..< count)
-        withHiddenCopies(if: isShared, of: &set) { set in
+        withHiddenCopies(if: isShared, of: &set, checker: { $0._checkInvariants() }) { set in
           contents.reverse()
           set.reverse()
           expectEqualElements(set, contents)
@@ -651,7 +651,7 @@ class OrderedSetTests: CollectionTestCase {
       withEvery("offset", in: 0 ..< layout.count) { offset in
         withEvery("isShared", in: [false, true]) { isShared in
           var set = OrderedSet(layout: layout)
-          withHiddenCopies(if: isShared, of: &set) { set in
+          withHiddenCopies(if: isShared, of: &set, checker: { $0._checkInvariants() }) { set in
             let count = layout.count
             let index = set._index(at: offset)
             let old = set.remove(at: index)
@@ -698,7 +698,7 @@ class OrderedSetTests: CollectionTestCase {
       withEvery("item", in: 0 ..< layout.count) { item in
         withEvery("isShared", in: [false, true]) { isShared in
           var set = OrderedSet(layout: layout)
-          withHiddenCopies(if: isShared, of: &set) { set in
+          withHiddenCopies(if: isShared, of: &set, checker: { $0._checkInvariants() }) { set in
             let count = layout.count
             let old = set.remove(item)
             expectEqual(old, item)
@@ -738,7 +738,7 @@ class OrderedSetTests: CollectionTestCase {
           var set = OrderedSet(layout: layout)
           let low = offsetRange.lowerBound
           let high = offsetRange.upperBound
-          withHiddenCopies(if: isShared, of: &set) { set in
+          withHiddenCopies(if: isShared, of: &set, checker: { $0._checkInvariants() }) { set in
             let count = layout.count
             let removedRange = set._indexRange(at: low ..< high)
             set.removeSubrange(removedRange)


### PR DESCRIPTION
`OrderedSet.insert(_:at:)` and `.updateOrInsert(_:at:)` accidentally violate value semantics by failing to check for uniqueness before updating the hash table. (`OrderedDictionary` is also affected, as it builds upon `OrderedSet`.)

Add the missing `_ensureUnique()` call and improve unit test coverage in this area.

Resolves #104.

Huge thanks to @KaiOelfke for providing a sample project that led to isolating the issue! 💙