### PR TITLE
[Utils] run-full-tests.sh: Add support for testing on Swift 5.3 without manual editing

### DIFF
--- a/Utils/run-full-tests.sh
+++ b/Utils/run-full-tests.sh
@@ -36,10 +36,14 @@ if [ "$(uname)" = "Darwin" ]; then
 else
     swift="swift"
     spm_flags="$spm_flags -j 1"
+
+    if $swift --version | grep 'Swift version 5\.3\.' > /dev/null; then
+        spm_flags="$spm_flags --enable-test-discovery"
+    fi
 fi
 
 echo "Build output logs are saved in $bold_on$build_dir$bold_off"
-swift --version
+$swift --version
 
 _count=0
 try() {


### PR DESCRIPTION
The version check is a bit of a hack, but this enables test discovery on 5.3 so the script can be used to test the package on that release without manual tweaking.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
