### PR TITLE
[OrderedDictionary] Fix type inference issue with `OrderedDictionary.init(grouping:by:)`

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Initializers.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Initializers.swift
@@ -279,6 +279,50 @@ extension OrderedDictionary {
     grouping values: S,
     by keyForValue: (S.Element) throws -> Key
   ) rethrows where Value: RangeReplaceableCollection, Value.Element == S.Element {
+    try self.init(_grouping: values, by: keyForValue)
+  }
+
+  /// Creates a new dictionary whose keys are the groupings returned by the
+  /// given closure and whose values are arrays of the elements that returned
+  /// each key.
+  ///
+  /// The arrays in the "values" position of the new dictionary each contain at
+  /// least one element, with the elements in the same order as the source
+  /// sequence.
+  ///
+  /// The following example declares an array of names, and then creates a
+  /// dictionary from that array by grouping the names by first letter:
+  ///
+  ///     let students = ["Kofi", "Abena", "Efua", "Kweku", "Akosua"]
+  ///     let studentsByLetter = OrderedDictionary(grouping: students, by: { $0.first! })
+  ///     // ["K": ["Kofi", "Kweku"], "A": ["Abena", "Akosua"], "E": ["Efua"]]
+  ///
+  /// The new `studentsByLetter` dictionary has three entries, with students'
+  /// names grouped by the keys `"E"`, `"K"`, and `"A"`.
+  ///
+  /// - Parameters:
+  ///   - values: A sequence of values to group into a dictionary.
+  ///   - keyForValue: A closure that returns a key for each element in
+  ///     `values`.
+  ///
+  /// - Complexity: Expected O(*n*) on average, where *n* is the count of
+  ///    values, if `Key` implements high-quality hashing.
+  @inlinable
+  public init<S: Sequence>(
+    grouping values: S,
+    by keyForValue: (S.Element) throws -> Key
+  ) rethrows where Value == [S.Element] {
+    // Note: this extra overload is necessary to make type inference work
+    // for the `Value` type -- we want it to default to `[S.Element`].
+    // (https://github.com/apple/swift-collections/issues/139)
+    try self.init(_grouping: values, by: keyForValue)
+  }
+
+  @inlinable
+  internal init<S: Sequence>(
+    _grouping values: S,
+    by keyForValue: (S.Element) throws -> Key
+  ) rethrows where Value: RangeReplaceableCollection, Value.Element == S.Element {
     self.init()
     for value in values {
       let key = try keyForValue(value)

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
@@ -123,13 +123,39 @@ class OrderedDictionaryTests: CollectionTestCase {
       "one", "two", "three", "four", "five",
       "six", "seven", "eight", "nine", "ten"
     ]
-    let d = OrderedDictionary<Int, [String]>(grouping: items, by: { $0.count })
+    let d = OrderedDictionary<Int, ContiguousArray<String>>(
+      grouping: items, by: { $0.count })
     expectEqualElements(d, [
       (key: 3, value: ["one", "two", "six", "ten"]),
       (key: 5, value: ["three", "seven", "eight"]),
       (key: 4, value: ["four", "five", "nine"]),
-    ])
+    ] as [(key: Int, value: ContiguousArray<String>)])
   }
+
+  func test_grouping_initializer_inference() {
+    struct StatEvent: Equatable {
+       var name: String
+       var date: String
+       var hours: Int
+    }
+
+    let statEvents = [
+       StatEvent(name: "lunch", date: "01-01-2015", hours: 1),
+       StatEvent(name: "dinner", date: "01-01-2015", hours: 1),
+       StatEvent(name: "dinner", date: "01-01-2015", hours: 1),
+       StatEvent(name: "lunch", date: "01-01-2015", hours: 1),
+       StatEvent(name: "dinner", date: "01-01-2015", hours: 1)
+    ]
+
+    // We expect this to be inferred to `OrderedDictionary<String, [StatEvent]>`
+    let d = OrderedDictionary(grouping: statEvents, by: { $0.name })
+    let expected = [
+      (key: "lunch", value: [statEvents[0], statEvents[3]]),
+      (key: "dinner", value: [statEvents[1], statEvents[2], statEvents[4]]),
+    ]
+    expectEqualElements(d, expected)
+  }
+
 
   func test_uncheckedUniqueKeysWithValues_labeled_tuples() {
     let items: KeyValuePairs<String, Int> = [


### PR DESCRIPTION
This adds a new overload to help the type checker infer `[S.Element]` as the default `Value` type.

Resolves #139.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
