### PR TITLE
+OrderedSet add filter #158

### DIFF
--- a/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
@@ -514,6 +514,7 @@ extension OrderedSet {
     for element in self where try isIncluded(element) {
       result._appendNew(element)
     }
+    result._checkInvariants()
     return result
   }
 }

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
@@ -494,3 +494,26 @@ extension OrderedSet {
     return _elements.remove(at: index)
   }
 }
+
+extension OrderedSet {
+  /// Returns a new ordered set containing the values pairs of the ordered set
+  /// that satisfy the given predicate.
+  ///
+  /// - Parameter isIncluded: A closure that takes a value as its
+  ///   argument and returns a Boolean value indicating whether the value
+  ///   should be included in the returned dictionary.
+  ///
+  /// - Returns: An ordered set of the values that `isIncluded` allows.
+  ///
+  /// - Complexity: O(`count`)
+  @inlinable
+  public func filter(
+          _ isIncluded: (Element) throws -> Bool
+  ) rethrows -> Self {
+    var result: OrderedSet = Self(minimumCapacity: _minimumCapacity)
+    for element in self where try isIncluded(element) {
+      result._appendNew(element)
+    }
+    return result
+  }
+}

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
@@ -508,7 +508,7 @@ extension OrderedSet {
   /// - Complexity: O(`count`)
   @inlinable
   public func filter(
-          _ isIncluded: (Element) throws -> Bool
+    _ isIncluded: (Element) throws -> Bool
   ) rethrows -> Self {
     var result: OrderedSet = Self(minimumCapacity: _minimumCapacity)
     for element in self where try isIncluded(element) {

--- a/Sources/_CollectionsTestSupport/AssertionContexts/Assertions.swift
+++ b/Sources/_CollectionsTestSupport/AssertionContexts/Assertions.swift
@@ -402,3 +402,7 @@ public func expectThrows<T>(
     errorHandler(error)
   }
 }
+
+public func expectType<T>(_ actual: T, _ expectedType: Any.Type) {
+  expectTrue(type(of: actual) == expectedType)
+}

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -1360,4 +1360,22 @@ class OrderedSetTests: CollectionTestCase {
       }
     }
   }
+
+
+  func test_filter() {
+    let items = (0 ..< 100)
+    let s = OrderedSet(items)
+
+    var c = 0
+    let s2 = s.filter { item in
+      c += 1
+      return item.isMultiple(of: 2)
+    }
+    expectEqual(c, 100)
+    expectEqualElements(s, items)
+
+    expectEqualElements(s2, (0 ..< 50).compactMap { key in
+      return (2 * key)
+    })
+  }
 }

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -1361,21 +1361,16 @@ class OrderedSetTests: CollectionTestCase {
     }
   }
 
-
   func test_filter() {
-    let items = (0 ..< 100)
-    let s = OrderedSet(items)
+    withOrderedSetLayouts(scales: [0, 5, 6]) { layout in
+      withEvery("factor", in: [1, 2, 3, 5, 10]) { factor in
+        let count = layout.count
+        let input = OrderedSet(layout: layout, contents: 0 ..< count)
+        let expected = (0 ..< count).filter { $0 % factor == 0 }
+        let actual = input.filter { $0 % factor == 0 }
 
-    var c = 0
-    let s2 = s.filter { item in
-      c += 1
-      return item.isMultiple(of: 2)
+        expectEqualElements(actual, expected)
+      }
     }
-    expectEqual(c, 100)
-    expectEqualElements(s, items)
-
-    expectEqualElements(s2, (0 ..< 50).compactMap { key in
-      return (2 * key)
-    })
   }
 }

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -1373,4 +1373,11 @@ class OrderedSetTests: CollectionTestCase {
       }
     }
   }
+  func test_filter_type() {
+    let s = Set([1, 2, 3, 4]).filter { $0.isMultiple(of: 2) }
+    expectType(s, Set<Int>.self)
+
+    let os = OrderedSet([1, 2, 3, 4]).filter { $0.isMultiple(of: 2) }
+    expectType(os, OrderedSet<Int>.self)
+  }
 }


### PR DESCRIPTION
Resolves #158

This adds a missing operation on `OrderedSet`: filter that keeps the return type an `OrderedSet`.
The dictionary in this package already had such operation, so I followed its prior art.

One could debate if we want to preallocate the size as "same" of the current set before filtering or if not etc... Open to suggestions, it's a bit tricky to know if the result of the filter will be almost empty, or almost full after all.


### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
    - dictionary filter didn't seem to have one either
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
   - docc