### PR TITLE
Force-inline _modify accessors to work around a performance issue

### DIFF
--- a/Benchmarks/Benchmarks/DequeBenchmarks.swift
+++ b/Benchmarks/Benchmarks/DequeBenchmarks.swift
@@ -172,6 +172,36 @@ extension Benchmark {
     }
 
     self.add(
+      title: "Deque<Int> modify through subscript (contiguous)",
+      input: ([Int], [Int]).self
+    ) { input, lookups in
+      return { timer in
+        var deque = Deque(input)
+        timer.measure {
+          for i in lookups {
+            deque[i] += 1
+          }
+        }
+        blackHole(deque)
+      }
+    }
+
+    self.add(
+      title: "Deque<Int> modify through subscript (discontiguous)",
+      input: ([Int], [Int]).self
+    ) { input, lookups in
+      return { timer in
+        var deque = Deque(discontiguous: input)
+        timer.measure {
+          for i in lookups {
+            deque[i] += 1
+          }
+        }
+        blackHole(deque)
+      }
+    }
+
+    self.add(
       title: "Deque<Int> random swaps (contiguous)",
       input: [Int].self
     ) { input in

--- a/Sources/OrderedCollections/HashTable/_HashTable.swift
+++ b/Sources/OrderedCollections/HashTable/_HashTable.swift
@@ -170,6 +170,7 @@ extension _HashTable {
   @inlinable
   internal var header: Header {
     get { _storage.header }
+    @inline(__always) // https://github.com/apple/swift-collections/issues/164
     nonmutating _modify { yield &_storage.header }
   }
 

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
@@ -35,6 +35,7 @@ extension OrderedDictionary {
     get {
       Elements(_base: self)
     }
+    @inline(__always) // https://github.com/apple/swift-collections/issues/164
     _modify {
       var elements = Elements(_base: self)
       self = Self()
@@ -63,6 +64,7 @@ extension OrderedDictionary.Elements {
     get {
       _base.values
     }
+    @inline(__always) // https://github.com/apple/swift-collections/issues/164
     _modify {
       var values = OrderedDictionary.Values(_base: _base)
       self = Self(_base: .init())

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
@@ -283,6 +283,7 @@ extension OrderedDictionary.Values: MutableCollection {
     get {
       _base._values[position]
     }
+    @inline(__always) // https://github.com/apple/swift-collections/issues/164
     _modify {
       yield &_base._values[position]
     }

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
@@ -52,7 +52,7 @@ extension OrderedSet {
     get {
       UnorderedView(_base: self)
     }
-    @inline(__always)
+    @inline(__always) // https://github.com/apple/swift-collections/issues/164
     _modify {
       var view = UnorderedView(_base: self)
       self = OrderedSet()

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnstableInternals.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnstableInternals.swift
@@ -37,7 +37,7 @@ extension OrderedSet {
       _UnstableInternals(self)
     }
 
-    @inline(__always)
+    @inline(__always) // https://github.com/apple/swift-collections/issues/164
     _modify {
       var view = _UnstableInternals(self)
       self = OrderedSet()

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
@@ -286,6 +286,7 @@ extension OrderedSet {
     set {
       self = .init(newValue)
     }
+    @inline(__always) // https://github.com/apple/swift-collections/issues/164
     _modify {
       var members = Array(_elements)
       _elements = []

--- a/Utils/swift-collections.xcworkspace/xcshareddata/xcschemes/DequeModule.xcscheme
+++ b/Utils/swift-collections.xcworkspace/xcshareddata/xcschemes/DequeModule.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:..">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DequeTests"
+               BuildableName = "DequeTests"
+               BlueprintName = "DequeTests"
+               ReferencedContainer = "container:..">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,6 +42,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DequeTests"
+               BuildableName = "DequeTests"
+               BlueprintName = "DequeTests"
+               ReferencedContainer = "container:..">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
As @Lukasa discovered in #164, the `_modify` accessor in `Deque`'s index subscript tends to call malloc unless it happens to get inlined into the caller. Try to prevent this performance bottleneck by force-inlining this accessor.

To mitigate potential code size issues, move the preparation/finalization steps into separate functions that aren't force-inlined.

Resolves #164.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
