### PR TITLE
[OrderedDictionary] Resolve call-site ambiguities

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Initializers.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Initializers.swift
@@ -75,6 +75,7 @@ extension OrderedDictionary {
   ///
   /// - Complexity: Expected O(*n*) on average, where *n* is the count if
   ///    key-value pairs, if `Key` implements high-quality hashing.
+  @_disfavoredOverload // https://github.com/apple/swift-collections/issues/125
   @inlinable
   public init<S: Sequence>(
     uniqueKeysWithValues keysAndValues: S
@@ -195,6 +196,7 @@ extension OrderedDictionary {
   ///
   /// - Complexity: Expected O(*n*) on average, where *n* is the count of
   ///    key-value pairs, if `Key` implements high-quality hashing.
+  @_disfavoredOverload // https://github.com/apple/swift-collections/issues/125
   @inlinable
   @inline(__always)
   public init<S: Sequence>(
@@ -368,6 +370,7 @@ extension OrderedDictionary {
   ///
   /// - Complexity: Expected O(*n*) on average, where *n* is the count if
   ///    key-value pairs, if `Key` implements high-quality hashing.
+  @_disfavoredOverload // https://github.com/apple/swift-collections/issues/125
   @inlinable
   public init<S: Sequence>(
     uncheckedUniqueKeysWithValues keysAndValues: S

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
@@ -785,6 +785,7 @@ extension OrderedDictionary {
   ///
   /// - Complexity: Expected to be O(*n*) on average, where *n* is the number of
   ///    elements in `keysAndValues`, if `Key` implements high-quality hashing.
+  @_disfavoredOverload // https://github.com/apple/swift-collections/issues/125
   @inlinable
   public mutating func merge<S: Sequence>(
     _ keysAndValues: __owned S,
@@ -880,6 +881,7 @@ extension OrderedDictionary {
   /// - Complexity: Expected to be O(`count` + *n*) on average, where *n* is the
   ///    number of elements in `keysAndValues`, if `Key` implements high-quality
   ///    hashing.
+  @_disfavoredOverload // https://github.com/apple/swift-collections/issues/125
   @inlinable
   public __consuming func merging<S: Sequence>(
     _ other: __owned S,

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
@@ -1290,5 +1290,75 @@ class OrderedDictionaryTests: CollectionTestCase {
     }
   }
 
+  func test_uniqueKeysWithValues_initializer_ambiguity() {
+    // https://github.com/apple/swift-collections/issues/125
+
+    let names = ["dylan", "bob", "aaron", "carol"]
+    let expected = names.map { (key: $0, value: 0) }
+
+    let d1 = OrderedDictionary(uniqueKeysWithValues: names.map { ($0, 0) })
+    expectEqualElements(d1, expected)
+
+    let d2 = OrderedDictionary(
+      uniqueKeysWithValues: ["dylan", "bob", "aaron", "carol"].map { ($0, 0) })
+    expectEqualElements(d2, expected)
+
+    let d3 = OrderedDictionary(
+      uniqueKeysWithValues: names.map { (key: $0, value: 0) })
+    expectEqualElements(d3, expected)
+
+    let d4 = OrderedDictionary(
+      uniqueKeysWithValues: ["dylan", "bob", "aaron", "carol"].map { (key: $0, value: 0) })
+    expectEqualElements(d4, expected)
+  }
+
+  func test_uniquingKeysWith_initializer_ambiguity() {
+    // https://github.com/apple/swift-collections/issues/125
+    let d1 = OrderedDictionary(
+      ["a", "b", "a"].map { ($0, 1) },
+      uniquingKeysWith: +)
+    expectEqualElements(d1, ["a": 2, "b": 1] as KeyValuePairs)
+
+    let d2 = OrderedDictionary(
+      ["a", "b", "a"].map { (key: $0, value: 1) },
+      uniquingKeysWith: +)
+    expectEqualElements(d2, ["a": 2, "b": 1] as KeyValuePairs)
+  }
+
+  func test_merge_ambiguity() {
+    // https://github.com/apple/swift-collections/issues/125
+
+    var d1: OrderedDictionary = ["a": 1, "b": 2]
+    d1.merge(
+      ["c", "a"].map { ($0, 1) },
+      uniquingKeysWith: +
+    )
+    expectEqualElements(d1, ["a": 2, "b": 2, "c": 1] as KeyValuePairs)
+
+    var d2: OrderedDictionary = ["a": 1, "b": 2]
+    d2.merge(
+      ["c", "a"].map { (key: $0, value: 1) },
+      uniquingKeysWith: +
+    )
+    expectEqualElements(d2, ["a": 2, "b": 2, "c": 1] as KeyValuePairs)
+  }
+
+  func test_merging_ambiguity() {
+    // https://github.com/apple/swift-collections/issues/125
+
+    let d1: OrderedDictionary = ["a": 1, "b": 2]
+    let d1m = d1.merging(
+      ["c", "a"].map { ($0, 1) },
+      uniquingKeysWith: +
+    )
+    expectEqualElements(d1m, ["a": 2, "b": 2, "c": 1] as KeyValuePairs)
+
+    let d2: OrderedDictionary = ["a": 1, "b": 2]
+    let d2m = d2.merging(
+      ["c", "a"].map { (key: $0, value: 1) },
+      uniquingKeysWith: +
+    )
+    expectEqualElements(d2m, ["a": 2, "b": 2, "c": 1] as KeyValuePairs)
+  }
 }
 


### PR DESCRIPTION
Add `@_disfavoredOverload` attributes to resolve edge-case ambiguities with overloads that only differ between tuple labels. In some situations, the compiler seems to be of two minds about whether `(Key, Value)` is compatible with `(key: Key, value: Value)` or vice versa.

`@_disfavoredOverload` is not a stable attribute; using it involves some risk in case future compilers remove it or change its behavior. In the worst case, we may have to publish a new release to fix such issues.

Resolves #125.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
