### PR TITLE
[OrderedDictionary] Tiny documentation fix

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
@@ -451,7 +451,7 @@ extension OrderedDictionary {
   /// of each letter in a string:
   ///
   ///     let message = "Hello, Elle!"
-  ///     var letterCounts: [Character: Int] = [:]
+  ///     var letterCounts: OrderedDictionary<Character, Int> = [:]
   ///     for letter in message {
   ///         letterCounts[letter, default: 0] += 1
   ///     }


### PR DESCRIPTION
Fix a code sample that was referring to the standard `Dictionary` instead of `OrderedDictionary`.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [X] I've updated the documentation if necessary.
