### PR TITLE
Persistent collections updates (part 7)

### DIFF
--- a/Benchmarks/Sources/CppBenchmarks/src/MapBenchmarks.cpp
+++ b/Benchmarks/Sources/CppBenchmarks/src/MapBenchmarks.cpp
@@ -12,7 +12,7 @@
 #include "MapBenchmarks.h"
 #include <map>
 #include <cstdlib>
-#include "utils.h"
+#include "Utils.h"
 
 typedef std::map<intptr_t, intptr_t> custom_map;
 

--- a/Package.swift
+++ b/Package.swift
@@ -96,9 +96,10 @@ let package = Package(
 
     // BitSet, BitArray
     .target(
-        name: "BitCollections",
-        path: "Sources/BitCollections",
-        swiftSettings: settings),
+      name: "BitCollections",
+      dependencies: ["_CollectionsUtilities"],
+      path: "Sources/BitCollections",
+      swiftSettings: settings),
     .testTarget(
       name: "BitCollectionsTests",
       dependencies: ["BitCollections", "_CollectionsTestSupport"],
@@ -118,6 +119,7 @@ let package = Package(
     // Heap<Value>
     .target(
         name: "PriorityQueueModule",
+        dependencies: ["_CollectionsUtilities"],
         exclude: ["CMakeLists.txt"],
         swiftSettings: settings),
     .testTarget(
@@ -149,6 +151,7 @@ let package = Package(
     // SortedSet<Element>, SortedDictionary<Key, Value>
     .target(
       name: "SortedCollections",
+      dependencies: ["_CollectionsUtilities"],
       swiftSettings: settings),
     .testTarget(
       name: "SortedCollectionsTests",

--- a/Sources/BitCollections/BitSet/BitSet.Counted.swift
+++ b/Sources/BitCollections/BitSet/BitSet.Counted.swift
@@ -29,9 +29,8 @@ extension BitSet.Counted {
   @inline(never)
   @_effects(releasenone)
   public func _checkInvariants() {
-    precondition(_count == _bits.count, "Invalid count")
-    precondition(_storage.isEmpty || !_storage.last!.isEmpty,
-                 "Extraneous tail slot")
+    _bits._checkInvariants()
+    precondition(_count == _bits.count)
   }
 #else
   @inline(__always) @inlinable

--- a/Sources/PersistentCollections/Node/_AncestorSlots.swift
+++ b/Sources/PersistentCollections/Node/_AncestorSlots.swift
@@ -52,7 +52,7 @@ extension _AncestorSlots {
       return _Slot((path &>> level.shift) & _Bucket.bitMask)
     }
     set {
-      assert(newValue._value < UInt.bitWidth)
+      assert(newValue._value < _Bitmap.capacity)
       assert(self[level] == .zero)
       path |= (UInt(truncatingIfNeeded: newValue._value) &<< level.shift)
     }

--- a/Sources/PersistentCollections/Node/_Bitmap.swift
+++ b/Sources/PersistentCollections/Node/_Bitmap.swift
@@ -117,8 +117,13 @@ extension _Bitmap {
 
 extension _Bitmap {
   @inlinable @inline(__always)
+  internal func isSubset(of other: Self) -> Bool {
+    _value & ~other._value == 0
+  }
+
+  @inlinable @inline(__always)
   internal func isDisjoint(with other: Self) -> Bool {
-    _value & other._value != 0
+    _value & other._value == 0
   }
 
   @inlinable @inline(__always)

--- a/Sources/PersistentCollections/Node/_HashTreeIterator.swift
+++ b/Sources/PersistentCollections/Node/_HashTreeIterator.swift
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@usableFromInline
+@frozen
+internal struct _HashTreeIterator {
+  @usableFromInline
+  internal struct _Opaque {
+    internal var ancestorSlots: _AncestorSlots
+    internal var ancestorNodes: _Stack<_UnmanagedNode>
+    internal var level: _Level
+    internal var isAtEnd: Bool
+
+    @usableFromInline
+    @_effects(releasenone)
+    internal init(_ root: _UnmanagedNode) {
+      self.ancestorSlots = .empty
+      self.ancestorNodes = _Stack(filledWith: root)
+      self.level = .top
+      self.isAtEnd = false
+    }
+  }
+
+  @usableFromInline
+  internal let root: _RawStorage
+
+  @usableFromInline
+  internal var node: _UnmanagedNode
+
+  @usableFromInline
+  internal var slot: _Slot
+
+  @usableFromInline
+  internal var endSlot: _Slot
+
+  @usableFromInline
+  internal var _o: _Opaque
+
+  @usableFromInline
+  @_effects(releasenone)
+  internal init(root: __shared _RawNode) {
+    self.root = root.storage
+    self.node = root.unmanaged
+    self.slot = .zero
+    self.endSlot = node.itemsEndSlot
+    self._o = _Opaque(self.node)
+
+    if node.hasItems { return }
+    if node.hasChildren {
+      _descendToLeftmostItem(ofChildAtSlot: .zero)
+    } else {
+      self._o.isAtEnd = true
+    }
+  }
+}
+
+extension _HashTreeIterator: IteratorProtocol {
+  @inlinable
+  internal mutating func next() -> (node: _UnmanagedNode, slot: _Slot)? {
+    guard slot < endSlot else {
+      return _next()
+    }
+    defer { slot = slot.next() }
+    return (node, slot)
+  }
+
+  @usableFromInline
+  @_effects(releasenone)
+  internal mutating func _next() -> (node: _UnmanagedNode, slot: _Slot)? {
+    if _o.isAtEnd { return nil }
+    if node.hasChildren {
+      _descendToLeftmostItem(ofChildAtSlot: .zero)
+      slot = slot.next()
+      return (node, .zero)
+    }
+    while !_o.level.isAtRoot {
+      let nextChild = _ascend().next()
+      if nextChild < node.childrenEndSlot {
+        _descendToLeftmostItem(ofChildAtSlot: nextChild)
+        slot = slot.next()
+        return (node, .zero)
+      }
+    }
+    // At end
+    endSlot = node.itemsEndSlot
+    slot = endSlot
+    _o.isAtEnd = true
+    return nil
+  }
+}
+
+extension _HashTreeIterator {
+  internal mutating func _descend(toChildSlot childSlot: _Slot) {
+    assert(childSlot < node.childrenEndSlot)
+    _o.ancestorSlots[_o.level] = childSlot
+    _o.ancestorNodes.push(node)
+    _o.level = _o.level.descend()
+    node = node.unmanagedChild(at: childSlot)
+    slot = .zero
+    endSlot = node.itemsEndSlot
+  }
+
+  internal mutating func _ascend() -> _Slot {
+    assert(!_o.level.isAtRoot)
+    node = _o.ancestorNodes.pop()
+    _o.level = _o.level.ascend()
+    let childSlot = _o.ancestorSlots[_o.level]
+    _o.ancestorSlots.clear(_o.level)
+    return childSlot
+  }
+
+  internal mutating func _descendToLeftmostItem(
+    ofChildAtSlot childSlot: _Slot
+  ) {
+    _descend(toChildSlot: childSlot)
+    while endSlot == .zero {
+      assert(node.hasChildren)
+      _descend(toChildSlot: .zero)
+    }
+  }
+}

--- a/Sources/PersistentCollections/Node/_Level.swift
+++ b/Sources/PersistentCollections/Node/_Level.swift
@@ -32,6 +32,12 @@ internal struct _Level {
     assert(shift <= UInt8.max)
     self._shift = UInt8(truncatingIfNeeded: shift)
   }
+
+  @inlinable @inline(__always)
+  init(depth: Int) {
+    assert(depth > 0 && depth < _Level.limit)
+    self.init(shift: UInt(bitPattern: depth * _Bitmap.bitWidth))
+  }
 }
 
 extension _Level {

--- a/Sources/PersistentCollections/Node/_Node+Invariants.swift
+++ b/Sources/PersistentCollections/Node/_Node+Invariants.swift
@@ -55,7 +55,7 @@ extension _Node {
       if $0.isCollisionNode {
         precondition(count == $0.itemCount)
         precondition(count > 0)
-        let key = $0[item: .zero].key
+        let key = $0.collisionHash
         let hash = _Hash(key)
         precondition(
           hash.isEqual(to: path, upTo: level),

--- a/Sources/PersistentCollections/Node/_Node+Subtree Modify.swift
+++ b/Sources/PersistentCollections/Node/_Node+Subtree Modify.swift
@@ -121,8 +121,9 @@ extension _Node {
       _finalizeRemoval(.top, state.hash, at: state.path)
     case (false, true):
       // Insertion
-      _ = updateValue(
-        state.value.unsafelyUnwrapped, forKey: state.key, .top, state.hash)
+      let inserted = insert(
+        (state.key, state.value.unsafelyUnwrapped), .top, state.hash)
+      assert(inserted)
     case (false, false):
       // Noop
       break

--- a/Sources/PersistentCollections/Node/_Node+Subtree Removals.swift
+++ b/Sources/PersistentCollections/Node/_Node+Subtree Removals.swift
@@ -218,7 +218,7 @@ extension _Node {
     assert(isCollisionNode && hasSingletonItem)
     assert(isUnique())
     update {
-      let hash = _Hash($0[item: .zero].key)
+      let hash = $0.collisionHash
       $0.itemMap = _Bitmap(hash[.top])
       $0.childMap = .empty
     }

--- a/Sources/PersistentCollections/Node/_Node+UnsafeHandle.swift
+++ b/Sources/PersistentCollections/Node/_Node+UnsafeHandle.swift
@@ -156,6 +156,12 @@ extension _Node.UnsafeHandle {
     nonmutating set { _header.pointee.collisionCount = newValue }
   }
 
+  @inlinable
+  internal var collisionHash: _Hash {
+    assert(isCollisionNode)
+    return _Hash(self[item: .zero].key)
+  }
+
   @inlinable @inline(__always)
   internal var _childrenStart: UnsafeMutablePointer<_Node> {
     _memory.assumingMemoryBound(to: _Node.self)

--- a/Sources/PersistentCollections/Node/_Node+isDisjoint.swift
+++ b/Sources/PersistentCollections/Node/_Node+isDisjoint.swift
@@ -76,6 +76,20 @@ extension _Node {
   ) -> Bool {
     // Beware, self might be on a compressed path
     assert(isCollisionNode)
+    if other.isCollisionNode {
+      return read { l in
+        other.read { r in
+          let lh = l.collisionHash
+          let rh = r.collisionHash
+          guard lh == rh else { return true }
+          let litems = l.reverseItems
+          let ritems = r.reverseItems
+          return litems.allSatisfy { li in
+            !ritems.contains { ri in li.key == ri.key }
+          }
+        }
+      }
+    }
     return read {
       let items = $0.reverseItems
       let hash = $0.collisionHash

--- a/Sources/PersistentCollections/Node/_Node+isDisjoint.swift
+++ b/Sources/PersistentCollections/Node/_Node+isDisjoint.swift
@@ -35,7 +35,7 @@ extension _Node {
         for bucket in l.itemMap.intersection(r.itemMap) {
           let lslot = l.itemMap.slot(of: bucket)
           let rslot = r.itemMap.slot(of: bucket)
-          guard l[item: lslot].key == r[item: rslot].key else { return false }
+          guard l[item: lslot].key != r[item: rslot].key else { return false }
         }
         for bucket in l.itemMap.intersection(r.childMap) {
           let lslot = l.itemMap.slot(of: bucket)

--- a/Sources/PersistentCollections/Node/_Node+isDisjoint.swift
+++ b/Sources/PersistentCollections/Node/_Node+isDisjoint.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension _Node {
+  /// Returns true if `self` contains a disjoint set of keys than `other`.
+  /// Otherwise, returns false.
+  @inlinable @inline(never)
+  internal func isDisjoint<Value2>(
+    _ level: _Level,
+    with other: _Node<Key, Value2>
+  ) -> Bool {
+    if self.raw.storage === other.raw.storage { return count == 0 }
+
+    if self.isCollisionNode {
+      return _isDisjointCollision(level, with: other)
+    }
+    if other.isCollisionNode {
+      return other._isDisjointCollision(level, with: other)
+    }
+
+    return self.read { l in
+      other.read { r in
+        let lmap = l.itemMap.union(l.childMap)
+        let rmap = r.itemMap.union(r.childMap)
+        if lmap.isDisjoint(with: rmap) { return true }
+
+        for bucket in l.itemMap.intersection(r.itemMap) {
+          let lslot = l.itemMap.slot(of: bucket)
+          let rslot = r.itemMap.slot(of: bucket)
+          guard l[item: lslot].key == r[item: rslot].key else { return false }
+        }
+        for bucket in l.itemMap.intersection(r.childMap) {
+          let lslot = l.itemMap.slot(of: bucket)
+          let hash = _Hash(l[item: lslot].key)
+          let rslot = r.childMap.slot(of: bucket)
+          let found = r[child: rslot].containsKey(
+            level.descend(),
+            l[item: lslot].key,
+            hash)
+          if found { return false }
+        }
+        for bucket in l.childMap.intersection(r.itemMap) {
+          let lslot = l.childMap.slot(of: bucket)
+          let rslot = r.itemMap.slot(of: bucket)
+          let hash = _Hash(r[item: rslot].key)
+          let found = l[child: lslot].containsKey(
+            level.descend(),
+            r[item: rslot].key,
+            hash)
+          if found { return false }
+        }
+        for bucket in l.childMap.intersection(r.childMap) {
+          let lslot = l.childMap.slot(of: bucket)
+          let rslot = r.childMap.slot(of: bucket)
+          guard
+            l[child: lslot].isDisjoint(level.descend(), with: r[child: rslot])
+          else { return false }
+        }
+        return true
+      }
+    }
+  }
+
+  @inlinable @inline(never)
+  internal func _isDisjointCollision<Value2>(
+    _ level: _Level,
+    with other: _Node<Key, Value2>
+  ) -> Bool {
+    // Beware, self might be on a compressed path
+    assert(isCollisionNode)
+    return read {
+      let items = $0.reverseItems
+      let hash = $0.collisionHash
+      return items.indices.allSatisfy {
+        !other.containsKey(level, items[$0].key, hash)
+      }
+    }
+  }
+}

--- a/Sources/PersistentCollections/Node/_Node+isSubset.swift
+++ b/Sources/PersistentCollections/Node/_Node+isSubset.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension _Node {
+  /// Returns true if `self` contains a subset of the keys in `other`.
+  /// Otherwise, returns false.
+  @inlinable @inline(never)
+  internal func isSubset<Value2>(
+    _ level: _Level,
+    of other: _Node<Key, Value2>
+  ) -> Bool {
+    if self.raw.storage === other.raw.storage { return true }
+    guard self.count <= other.count else { return false }
+
+    if self.isCollisionNode {
+      // Beware, self might be on a compressed path
+      return read {
+        let items = $0.reverseItems
+        let hash = $0.collisionHash
+        return items.indices.allSatisfy {
+          // FIXME: This will repeatedly & unnecessarily call `collisionHash`
+          other.containsKey(level, items[$0].key, hash)
+        }
+      }
+    }
+
+    guard !other.isCollisionNode else { return false }
+
+    return self.read { l in
+      other.read { r in
+        guard l.childMap.isSubset(of: r.childMap) else { return false }
+        guard l.itemMap.isSubset(of: r.itemMap.union(r.childMap)) else {
+          return false
+        }
+        for bucket in l.itemMap {
+          if r.itemMap.contains(bucket) {
+            let lslot = l.itemMap.slot(of: bucket)
+            let rslot = r.itemMap.slot(of: bucket)
+            guard l[item: lslot].key == r[item: rslot].key else { return false }
+          } else {
+            let lslot = l.itemMap.slot(of: bucket)
+            let hash = _Hash(l[item: lslot].key)
+            let rslot = r.childMap.slot(of: bucket)
+            guard
+              r[child: rslot].containsKey(
+                level.descend(),
+                l[item: lslot].key,
+                hash)
+            else { return false }
+          }
+        }
+
+        for bucket in l.childMap {
+          let lslot = l.childMap.slot(of: bucket)
+          let rslot = r.childMap.slot(of: bucket)
+          guard l[child: lslot].isSubset(level.descend(), of: r[child: rslot])
+          else { return false }
+        }
+        return true
+      }
+    }
+  }
+}

--- a/Sources/PersistentCollections/Node/_Node.swift
+++ b/Sources/PersistentCollections/Node/_Node.swift
@@ -119,3 +119,15 @@ extension _Node {
     read { $0.isAtrophiedNode }
   }
 }
+
+extension _Node {
+  @inlinable
+  internal var initialVersionNumber: UInt {
+    // Ideally we would simply just generate a true random number, but the
+    // memory address of the root node is a reasonable substitute.
+    // Alternatively, we could use a per-thread counter along with a thread
+    // id, or some sort of global banks of atomic integer counters.
+    let address = Unmanaged.passUnretained(raw.storage).toOpaque()
+    return UInt(bitPattern: address)
+  }
+}

--- a/Sources/PersistentCollections/Node/_Stack.swift
+++ b/Sources/PersistentCollections/Node/_Stack.swift
@@ -1,0 +1,115 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A fixed-size array of just enough size to hold an ancestor path in a
+/// `PersistentDictionary`.
+@usableFromInline
+@frozen
+internal struct _Stack<Element> {
+#if arch(x86_64) || arch(arm64)
+  @inlinable
+  @inline(__always)
+  internal static var capacity: Int { 13 }
+
+  @usableFromInline
+  internal var _contents: (
+    Element, Element, Element, Element,
+    Element, Element, Element, Element,
+    Element, Element, Element, Element,
+    Element
+  )
+#else
+  @inlinable
+  @inline(__always)
+  internal static var capacity: Int { 7 }
+
+  // xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xx
+  @usableFromInline
+  internal var _contents: (
+    Element, Element, Element, Element,
+    Element, Element, Element
+  )
+#endif
+
+  @usableFromInline
+  internal var _count: UInt8
+
+  @inlinable
+  internal init(filledWith value: Element) {
+    assert(Self.capacity == _Level.limit)
+#if arch(x86_64) || arch(arm64)
+    _contents = (
+      value, value, value, value,
+      value, value, value, value,
+      value, value, value, value,
+      value
+    )
+#else
+    _contents = (
+      value, value, value, value,
+      value, value, value
+    )
+#endif
+    self._count = 0
+  }
+
+  @inlinable
+  @inline(__always)
+  internal var capacity: Int { Self.capacity }
+
+  @inlinable
+  @inline(__always)
+  internal var count: Int { Int(truncatingIfNeeded: _count) }
+
+  @inlinable
+  @inline(__always)
+  internal var isEmpty: Bool { _count == 0 }
+
+  @inlinable
+  subscript(level: UInt8) -> Element {
+    mutating get {
+      assert(level < _count)
+      return withUnsafeBytes(of: &_contents) { buffer in
+        // Homogeneous tuples are layout compatible with their element type
+        let start = buffer.baseAddress!.assumingMemoryBound(to: Element.self)
+        return start[Int(truncatingIfNeeded: level)]
+      }
+    }
+    set {
+      assert(level < capacity)
+      withUnsafeMutableBytes(of: &_contents) { buffer in
+        // Homogeneous tuples are layout compatible with their element type
+        let start = buffer.baseAddress!.assumingMemoryBound(to: Element.self)
+        start[Int(truncatingIfNeeded: level)] = newValue
+      }
+    }
+  }
+
+  @inlinable
+  mutating func push(_ item: Element) {
+    assert(_count < capacity)
+    self[_count] = item
+    _count &+= 1
+  }
+
+  @inlinable
+  mutating func pop() -> Element {
+    assert(_count > 0)
+    defer { _count &-= 1 }
+    return self[_count &- 1]
+  }
+
+  @inlinable
+  mutating func peek() -> Element {
+    assert(count > 0)
+    return self[_count &- 1]
+  }
+}

--- a/Sources/PersistentCollections/Node/_Stack.swift
+++ b/Sources/PersistentCollections/Node/_Stack.swift
@@ -19,6 +19,7 @@ internal struct _Stack<Element> {
   @inline(__always)
   internal static var capacity: Int { 13 }
 
+  // xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxx
   @usableFromInline
   internal var _contents: (
     Element, Element, Element, Element,

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Debugging.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Debugging.swift
@@ -16,6 +16,11 @@ extension PersistentDictionary {
     _isCollectionsInternalCheckingEnabled
   }
 
+  @inlinable
+  public func _invariantCheck() {
+    _root._fullInvariantCheck(.top, _Hash(_value: 0))
+  }
+
   public func _dump(iterationOrder: Bool = false) {
     _root.dump(iterationOrder: iterationOrder)
   }

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Equatable.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Equatable.swift
@@ -12,6 +12,6 @@
 extension PersistentDictionary: Equatable where Value: Equatable {
   @inlinable
   public static func == (left: Self, right: Self) -> Bool {
-    left._root == right._root
+    left._root.isEqual(to: right._root, by: { $0 == $1 })
   }
 }

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Initializers.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Initializers.swift
@@ -27,8 +27,8 @@ extension PersistentDictionary {
     self.init()
     for (key, value) in keysAndValues {
       let hash = _Hash(key)
-      let unique = nil == _root.updateValue(value, forKey: key, .top, hash)
-      precondition(unique, "Duplicate key: '\(key)'")
+      let inserted = _root.insert((key, value), .top, hash)
+      precondition(inserted, "Duplicate key: '\(key)'")
     }
     _invariantCheck()
   }

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+MapValues.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+MapValues.swift
@@ -22,17 +22,13 @@ extension PersistentDictionary {
   public func compactMapValues<T>(
     _ transform: (Value) throws -> T?
   ) rethrows -> PersistentDictionary<Key, T> {
+    // FIXME: We could do this as a structural transformation.
     var result: PersistentDictionary<Key, T> = [:]
-    for (key, value) in self {
-      guard let value = try transform(value) else { continue }
-      // FIXME: We could recover the key's hash from self.
-      // (As many bits of it as we need to insert it into the new tree.)
-      // However, this requires a series of `UInt32._bit(ranked:)` invocations
-      // that may or may not be meaningfully better than simply rehashing the
-      // key.
+    for (key, v) in self {
+      guard let value = try transform(v) else { continue }
       let hash = _Hash(key)
-      let r = result._root.updateValue(value, forKey: key, .top, hash)
-      assert(r == nil)
+      let inserted = result._root.insert((key, value), .top, hash)
+      assert(inserted)
     }
     return result
   }

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Merge.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Merge.swift
@@ -15,6 +15,7 @@ extension PersistentDictionary {
     _ keysAndValues: __owned S,
     uniquingKeysWith combine: (Value, Value) throws -> Value
   ) rethrows where S.Element == (Key, Value) {
+    // FIXME: Do a structural merge
     for (key, value) in keysAndValues {
       try self.updateValue(forKey: key) { target in
         if let old = target {

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Sequence.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Sequence.swift
@@ -12,43 +12,21 @@
 extension PersistentDictionary: Sequence {
   public typealias Element = (key: Key, value: Value)
 
+  @frozen
   public struct Iterator {
     // Fixed-stack iterator for traversing a hash tree.
     // The iterator performs a pre-order traversal, with items at a node visited
     // before any items within children.
 
     @usableFromInline
-    typealias _ItemBuffer = ReversedCollection<UnsafeMutableBufferPointer<Element>>
+    internal typealias _UnsafeHandle = _Node.UnsafeHandle
 
     @usableFromInline
-    typealias _ChildBuffer = UnsafeBufferPointer<_Node>
-
-    @usableFromInline
-    internal var _root: _Node
-
-    @usableFromInline
-    internal var _itemIterator: _ItemBuffer.Iterator?
-
-    @usableFromInline
-    internal var _pathTop: _ChildBuffer.Iterator?
-
-    @usableFromInline
-    internal var _pathRest: [_ChildBuffer.Iterator]
+    internal var _it: _HashTreeIterator
 
     @inlinable
-    internal init(_root: _Node) {
-      self._root = _root
-      self._pathRest = []
-      self._pathRest.reserveCapacity(_Level.limit)
-
-      // FIXME: This is illegal, as it escapes pointers to _root contents
-      // outside the closure passed to `read`. :-(
-      self._itemIterator = _root.read {
-        $0.hasItems ? $0.reverseItems.reversed().makeIterator() : nil
-      }
-      self._pathTop = _root.read {
-        $0.hasChildren ? $0.children.makeIterator() : nil
-      }
+    internal init(_root: _RawNode) {
+      self._it = _HashTreeIterator(root: _root)
     }
   }
 
@@ -59,7 +37,7 @@ extension PersistentDictionary: Sequence {
 
   @inlinable
   public __consuming func makeIterator() -> Iterator {
-    return Iterator(_root: _root)
+    return Iterator(_root: _root.raw)
   }
 }
 
@@ -68,30 +46,7 @@ extension PersistentDictionary.Iterator: IteratorProtocol {
 
   @inlinable
   public mutating func next() -> Element? {
-    if let item = _itemIterator?.next() {
-      return item
-    }
-
-    _itemIterator = nil
-
-    while _pathTop != nil {
-      guard let nextNode = _pathTop!.next() else {
-        _pathTop = _pathRest.popLast()
-        continue
-      }
-      if nextNode.read({ $0.hasChildren }) {
-        _pathRest.append(_pathTop!)
-        _pathTop = nextNode.read { $0.children.makeIterator() } // 💥ILLEGAL
-      }
-      if nextNode.read({ $0.hasItems }) {
-        _itemIterator = nextNode.read { $0.reverseItems.reversed().makeIterator() } // 💥ILLEGAL
-        return _itemIterator!.next()
-      }
-    }
-
-    assert(_itemIterator == nil)
-    assert(_pathTop == nil)
-    assert(_pathRest.isEmpty)
-    return nil
+    guard let (node, slot) = _it.next() else { return nil }
+    return _UnsafeHandle.read(node) { $0[item: slot] }
   }
 }

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct PersistentDictionary<Key, Value> where Key: Hashable {
+public struct PersistentDictionary<Key: Hashable, Value> {
   @usableFromInline
   internal typealias _Node = PersistentCollections._Node<Key, Value>
 
@@ -30,19 +30,11 @@ public struct PersistentDictionary<Key, Value> where Key: Hashable {
 
   @inlinable
   internal init(_new: _Node) {
-    // Ideally we would simply just generate a true random number, but the
-    // memory address of the root node is a reasonable substitute.
-    let address = Unmanaged.passUnretained(_new.raw.storage).toOpaque()
-    self.init(_root: _new, version: UInt(bitPattern: address))
+    self.init(_root: _new, version: _new.initialVersionNumber)
   }
 }
 
 extension PersistentDictionary {
-  @inlinable
-  public func _invariantCheck() {
-    _root._fullInvariantCheck(.top, _Hash(_value: 0))
-  }
-
   /// Accesses the value associated with the given key for reading and writing.
   ///
   /// This *key-based* subscript returns the value for the given key if the key

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+Collection.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+Collection.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet {
   @frozen
   public struct Index {
     @usableFromInline
@@ -32,39 +32,40 @@ extension PersistentDictionary {
   }
 }
 
-extension PersistentDictionary.Index: Equatable {
+extension PersistentSet.Index: Equatable {
   @inlinable
   public static func ==(left: Self, right: Self) -> Bool {
     precondition(
       left._root == right._root && left._version == right._version,
-      "Indices from different dictionary values aren't comparable")
+      "Indices from different set values aren't comparable")
     return left._path == right._path
   }
 }
 
-extension PersistentDictionary.Index: Hashable {
+extension PersistentSet.Index: Comparable {
+  @inlinable
+  public static func <(left: Self, right: Self) -> Bool {
+    precondition(
+      left._root == right._root && left._version == right._version,
+      "Indices from different set values aren't comparable")
+    return left._path < right._path
+  }
+}
+
+extension PersistentSet.Index: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {
     hasher.combine(_path)
   }
 }
 
-extension PersistentDictionary.Index: Comparable {
-  public static func <(left: Self, right: Self) -> Bool {
-    precondition(
-      left._root == right._root && left._version == right._version,
-      "Indices from different dictionary values aren't comparable")
-    return left._path < right._path
-  }
-}
-
-extension PersistentDictionary.Index: CustomStringConvertible {
+extension PersistentSet.Index: CustomStringConvertible {
   public var description: String {
     _path.description
   }
 }
 
-extension PersistentDictionary: BidirectionalCollection {
+extension PersistentSet: BidirectionalCollection {
   @inlinable
   public var isEmpty: Bool {
     _root.count == 0
@@ -75,7 +76,6 @@ extension PersistentDictionary: BidirectionalCollection {
     _root.count
   }
 
-  @inlinable
   public var startIndex: Index {
     var path = _UnsafePath(root: _root.raw)
     path.descendToLeftMostItem()
@@ -105,7 +105,7 @@ extension PersistentDictionary: BidirectionalCollection {
     precondition(_isValid(i), "Invalid index")
     precondition(i._path.isOnItem, "Can't get element at endIndex")
     return _Node.UnsafeHandle.read(i._path.node) {
-      $0[item: i._path.currentItemSlot]
+      $0[item: i._path.currentItemSlot].key
     }
   }
 

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+Equatable.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+Equatable.swift
@@ -12,6 +12,6 @@
 extension PersistentSet: Equatable {
   @inlinable
   public static func == (left: Self, right: Self) -> Bool {
-    left._root.isEqual(to: right._root, by: { $0.key == $1.key })
+    left._root.isEqual(to: right._root, by: { _, _ in true })
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+Equatable.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+Equatable.swift
@@ -9,19 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet: Equatable {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
-    }
-    return result
+  public static func == (left: Self, right: Self) -> Bool {
+    left._root.isEqual(to: right._root, by: { $0.key == $1.key })
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+Hashable.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+Hashable.swift
@@ -9,19 +9,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet: Hashable {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
+  public func hash(into hasher: inout Hasher) {
+    let copy = hasher
+    let seed = copy.finalize()
+
+    var hash = 0
+    for member in self {
+      hash ^= member._rawHashValue(seed: seed)
     }
-    return result
+    hasher.combine(hash)
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+Sequence.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+Sequence.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension PersistentSet: Sequence {
+  @frozen
+  public struct Iterator: IteratorProtocol {
+    @usableFromInline
+    internal typealias _UnsafeHandle = _Node.UnsafeHandle
+
+    @usableFromInline
+    internal var _it: _HashTreeIterator
+
+    @inlinable
+    internal init(_root: _RawNode) {
+      _it = _HashTreeIterator(root: _root)
+    }
+
+    public mutating func next() -> Element? {
+      guard let (node, slot) = _it.next() else { return nil }
+      return _UnsafeHandle.read(node) { $0[item: slot].key }
+    }
+  }
+
+  @inlinable
+  public func makeIterator() -> Iterator {
+    Iterator(_root: _root.raw)
+  }
+
+  @inlinable
+  public func _customContainsEquatableElement(_ element: Element) -> Bool? {
+    _root.containsKey(.top, element, _Hash(element))
+  }
+}

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra Initializers.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra Initializers.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension PersistentSet {
+  @inlinable
+  public init() {
+    self.init(_new: _Node(storage: _emptySingleton, count: 0))
+  }
+
+  @inlinable
+  public init<S: Sequence>(_ items: __owned S) where S.Element == Element {
+    if S.self == Self.self {
+      self = items as! Self
+      return
+    }
+    self.init()
+    for item in items {
+      self._insert(item)
+    }
+  }
+
+  @inlinable
+  public init(_ items: __owned Self) {
+    self = items
+  }
+
+  @inlinable
+  public init<Value>(
+    _ item: __owned PersistentDictionary<Element, Value>.Keys
+  ) {
+    self.init(_new: item._base._root.mapValues { _ in () })
+  }
+}

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra basics.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra basics.swift
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension PersistentSet: SetAlgebra {
+  @discardableResult
+  @inlinable
+  public mutating func insert(
+    _ newMember: __owned Element
+  ) -> (inserted: Bool, memberAfterInsert: Element) {
+    let hash = _Hash(newMember)
+    _invalidateIndices()
+    let r = _root.update(newMember, .top, hash)
+    return _Node.UnsafeHandle.update(r.leaf) {
+      let p = $0.itemPtr(at: r.slot)
+      if r.inserted {
+        p.initialize(to: (newMember, ()))
+        return (true, newMember)
+      }
+      return (false, p.pointee.key)
+    }
+  }
+
+  @discardableResult
+  @inlinable
+  internal mutating func _insert(_ newMember: __owned Element) -> Bool {
+    let hash = _Hash(newMember)
+    let r = _root.update(newMember, .top, hash)
+    guard r.inserted else { return false }
+    _Node.UnsafeHandle.update(r.leaf) {
+      let p = $0.itemPtr(at: r.slot)
+      p.initialize(to: (newMember, ()))
+    }
+    return true
+  }
+
+
+  @discardableResult
+  @inlinable
+  public mutating func remove(_ member: Element) -> Element? {
+    let hash = _Hash(member)
+    _invalidateIndices()
+    return _root.remove(member, .top, hash)?.key
+  }
+
+  @discardableResult
+  @inlinable
+  public mutating func update(with newMember: __owned Element) -> Element? {
+    let hash = _Hash(newMember)
+    let r = _root.update(newMember, .top, hash)
+    return _Node.UnsafeHandle.update(r.leaf) {
+      let p = $0.itemPtr(at: r.slot)
+      if r.inserted {
+        p.initialize(to: (newMember, ()))
+        return nil
+      }
+      let old = p.pointee.key
+      p.pointee = (newMember, ())
+      return old
+    }
+  }
+}

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra formIntersection.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra formIntersection.swift
@@ -9,19 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
-    }
-    return result
+  public mutating func formIntersection(_ other: Self) {
+    fatalError("FIXME")
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra formSymmetricDifference.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra formSymmetricDifference.swift
@@ -9,19 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
-    }
-    return result
+  public mutating func formSymmetricDifference(_ other: __owned Self) {
+    fatalError("FIXME")
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra formUnion.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra formUnion.swift
@@ -9,19 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
-    }
-    return result
+  public mutating func formUnion(_ other: __owned Self) {
+    fatalError("FIXME")
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra intersection.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra intersection.swift
@@ -9,19 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
-    }
-    return result
+  public func intersection(_ other: Self) -> Self {
+    fatalError("FIXME")
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isDisjoint.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isDisjoint.swift
@@ -9,19 +9,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
-    }
-    return result
+  public func isDisjoint(with other: Self) -> Bool {
+    self._root.isDisjoint(.top, with: other._root)
+  }
+
+  @inlinable
+  public func isDisjoint<Value>(
+    with other: PersistentDictionary<Element, Value>
+  ) -> Bool {
+    self._root.isDisjoint(.top, with: other._root)
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isStrictSubset.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isStrictSubset.swift
@@ -9,19 +9,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
-    }
-    return result
+  public func isStrictSubset(of other: Self) -> Bool {
+    guard self.count < other.count else { return false }
+    return isSubset(of: other)
+  }
+
+  @inlinable
+  public func isStrictSubset<Value>(
+    of other: PersistentDictionary<Element, Value>
+  ) -> Bool {
+    guard self.count < other.count else { return false }
+    return isSubset(of: other)
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isStrictSuperset.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isStrictSuperset.swift
@@ -9,19 +9,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
-    }
-    return result
+  public func isStrictSuperset(of other: Self) -> Bool {
+    guard self.count > other.count else { return false }
+    return other._root.isSubset(.top, of: self._root)
+  }
+
+  @inlinable
+  public func isStrictSuperset<Value>(
+    of other: PersistentDictionary<Element, Value>
+  ) -> Bool {
+    guard self.count > other.count else { return false }
+    return other._root.isSubset(.top, of: self._root)
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isSubset.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isSubset.swift
@@ -9,19 +9,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
-    }
-    return result
+  public func isSubset(of other: Self) -> Bool {
+    self._root.isSubset(.top, of: other._root)
+  }
+
+  @inlinable
+  public func isSubset<Value>(
+    of other: PersistentDictionary<Element, Value>
+  ) -> Bool {
+    self._root.isSubset(.top, of: other._root)
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isSuperset.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isSuperset.swift
@@ -9,19 +9,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
-    }
-    return result
+  public func isSuperset(of other: Self) -> Bool {
+    other._root.isSubset(.top, of: self._root)
+  }
+
+  @inlinable
+  public func isSuperset<Value>(
+    of other: PersistentDictionary<Element, Value>
+  ) -> Bool {
+    return other._root.isSubset(.top, of: self._root)
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra subtract.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra subtract.swift
@@ -9,19 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
-    }
-    return result
+  public mutating func subtract(_ other: Self) {
+    fatalError("FIXME")
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra subtracting.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra subtracting.swift
@@ -9,19 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
-    }
-    return result
+  public __consuming func subtracting(_ other: Self) -> Self {
+    fatalError("FIXME")
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra symmetricDifference.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra symmetricDifference.swift
@@ -9,19 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
-    }
-    return result
+  public func symmetricDifference(_ other: __owned Self) -> Self {
+    fatalError("FIXME")
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra union.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra union.swift
@@ -9,19 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension PersistentDictionary {
+extension PersistentSet {
   @inlinable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    var result: PersistentDictionary = [:]
-    for item in self {
-      guard try isIncluded(item) else { continue }
-      // FIXME: We could do this as a structural transformation.
-      let hash = _Hash(item.key)
-      let inserted = result._root.insert(item, .top, hash)
-      assert(inserted)
-    }
-    return result
+  public func union(_ other: __owned Self) -> Self {
+    fatalError("FIXME")
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+public struct PersistentSet<Element: Hashable> {
+  @usableFromInline
+  internal typealias _Node = PersistentCollections._Node<Element, Void>
+
+  @usableFromInline
+  internal var _root: _Node
+
+  @usableFromInline
+  internal var _version: UInt
+
+  @inlinable
+  internal init(_root: _Node, version: UInt) {
+    self._root = _root
+    self._version = version
+  }
+
+  @inlinable
+  internal init(_new: _Node) {
+    self.init(_root: _new, version: _new.initialVersionNumber)
+  }
+}
+
+
+extension PersistentSet {
+  @inlinable
+  public func _invariantCheck() {
+    _root._fullInvariantCheck(.top, _Hash(_value: 0))
+  }
+}

--- a/Sources/_CollectionsUtilities/UnsafeRawPointer extensions.swift
+++ b/Sources/_CollectionsUtilities/UnsafeRawPointer extensions.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(<5.7) // SE-0334
+#if compiler(<5.7) || (os(macOS) && compiler(<5.8)) // SE-0334
 extension UnsafeRawPointer {
   /// Obtain the next pointer properly aligned to store a value of type `T`.
   ///

--- a/Tests/PersistentCollectionsTests/PersistentCollections Smoke Tests.swift
+++ b/Tests/PersistentCollectionsTests/PersistentCollections Smoke Tests.swift
@@ -13,6 +13,26 @@ import _CollectionsTestSupport
 @testable import PersistentCollections
 
 final class PersistentDictionarySmokeTests: CollectionTestCase {
+  func testDummy() {
+    let map = PersistentDictionary(
+      uniqueKeysWithValues: (0 ..< 100).map { ($0, 2 * $0) })
+    var it = map.makeIterator()
+    var seen: Set<Int> = []
+    while let item = it.next() {
+      if !seen.insert(item.key).inserted {
+        print(item)
+      }
+    }
+    expectEqual(seen.count, 100)
+    print("---")
+    for item in map {
+      if seen.remove(item.key) == nil {
+        print(item)
+      }
+    }
+    expectEqual(seen.count, 0)
+  }
+
   func testSubscriptAdd() {
     var map: PersistentDictionary<Int, String> = [1: "a", 2: "b"]
 

--- a/Tests/PersistentCollectionsTests/PersistentCollections Smoke Tests.swift
+++ b/Tests/PersistentCollectionsTests/PersistentCollections Smoke Tests.swift
@@ -129,12 +129,7 @@ final class PersistentDictionarySmokeTests: CollectionTestCase {
     var map3: PersistentDictionary<Collider, String> = map2
     for index in 0..<upperBound {
       map3[Collider(index)] = nil
-
       expectEqual(map3.count, inferSize(map3))
-      if map3.count != inferSize(map3) {
-        assertionFailure()
-      }
-
     }
 
     expectEqual(map3.count, 0)

--- a/Tests/PersistentCollectionsTests/Utilities.swift
+++ b/Tests/PersistentCollectionsTests/Utilities.swift
@@ -155,10 +155,10 @@ func expectEqualDictionaries<Key: Hashable, Value: Equatable>(
   var dict = dict
   var seen: Set<Key> = []
   var mismatches: [(key: Key, map: Value?, dict: Value?)] = []
-
+  var dupes: [(key: Key, map: Value)] = []
   for (key, value) in map {
     if !seen.insert(key).inserted {
-      mismatches.append((key, value, nil))
+      dupes.append((key, value))
     } else {
       let expected = dict.removeValue(forKey: key)
       if value != expected {
@@ -169,12 +169,15 @@ func expectEqualDictionaries<Key: Hashable, Value: Equatable>(
   for (key, value) in dict {
     mismatches.append((key, nil, value))
   }
-  if !mismatches.isEmpty {
-    let msg = mismatches.lazy.map { k, m, d in
+  if !mismatches.isEmpty || !dupes.isEmpty {
+    let msg1 = mismatches.lazy.map { k, m, d in
       "\n  \(k): \(m == nil ? "nil" : "\(m!)") vs \(d == nil ? "nil" : "\(d!)")"
     }.joined(separator: "")
+    let msg2 = dupes.lazy.map { k, v in
+      "\n  \(k): \(v) (duped)"
+    }.joined(separator: "")
     _expectFailure(
-      "\n\(mismatches.count) mismatches (actual vs expected):\(msg)",
+      "\n\(mismatches.count) mismatches (actual vs expected):\(msg1)\(msg2)",
       message, trapping: trapping, file: file, line: line)
   }
 }


### PR DESCRIPTION
This fixes the `Iterator` type (slowing it down by 35% or so, unfortunately), and starts work on `PersistentSet`. (Including (untested) structural isSubset and isDisjoint tests, but no structural merges yet.)

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
