### PR TITLE
Fix `rethrows` position

### DIFF
--- a/Documentation/OrderedDictionary.md
+++ b/Documentation/OrderedDictionary.md
@@ -135,7 +135,7 @@ existing members:
 ```swift
 // Permutation operations from MutableCollection:
 func swapAt(_ i: Index, _ j: Index)
-func partition(by predicate: (Element) throws -> Bool) -> rethrows Index
+func partition(by predicate: (Element) throws -> Bool) rethrows -> Index
 func sort() where Element: Comparable
 func sort(by predicate: (Element, Element) throws -> Bool) rethrows
 func shuffle()


### PR DESCRIPTION
Minor typo fix: Move `rethrows` before allow.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
