### PR TITLE
[OrderedSet] Tiny doc fixes for isSuperset.

### DIFF
--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial SetAlgebra+Predicates.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial SetAlgebra+Predicates.swift
@@ -143,7 +143,7 @@ extension OrderedSet {
   ///
   /// - Parameter other: Another set.
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
   ///
   /// - Complexity: Expected to be O(`other.count`) on average, if `Element`
   ///    implements high-quality hashing.
@@ -166,7 +166,7 @@ extension OrderedSet {
   ///
   /// - Parameter other: Another set.
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
   ///
   /// - Complexity: Expected to be O(`other.count`) on average, if `Element`
   ///    implements high-quality hashing.
@@ -193,7 +193,7 @@ extension OrderedSet {
   ///
   /// - Parameter other: A finite sequence of elements.
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
   ///
   /// - Complexity: Expected to be O(*n*) on average, where *n* is the number of
   ///    elements in `other`, if `Element` implements high-quality hashing.


### PR DESCRIPTION
`OrderedSet`'s documentation mistakenly refers to the subset relation when explaining what `isSuperset` is doing.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [X] I've updated the documentation if necessary.
