### PR TITLE
Add Sendable conformances to all public types

### DIFF
--- a/Sources/BitCollections/BitArray/BitArray.swift
+++ b/Sources/BitCollections/BitArray/BitArray.swift
@@ -41,6 +41,10 @@ public struct BitArray {
   }
 }
 
+#if swift(>=5.5)
+extension BitArray: Sendable {}
+#endif
+
 extension BitArray {
   @inline(__always)
   internal func _read<R>(

--- a/Sources/BitCollections/BitSet/BitSet+BidirectionalCollection.swift
+++ b/Sources/BitCollections/BitSet/BitSet+BidirectionalCollection.swift
@@ -88,6 +88,10 @@ extension BitSet: Sequence {
   }
 }
 
+#if swift(>=5.5)
+extension BitSet.Iterator: Sendable {}
+#endif
+
 extension BitSet: Collection, BidirectionalCollection {
   /// A Boolean value indicating whether the collection is empty.
   ///

--- a/Sources/BitCollections/BitSet/BitSet.Counted.swift
+++ b/Sources/BitCollections/BitSet/BitSet.Counted.swift
@@ -24,6 +24,10 @@ extension BitSet {
   }
 }
 
+#if swift(>=5.5)
+extension BitSet.Counted: Sendable {}
+#endif
+
 extension BitSet.Counted {
 #if COLLECTIONS_INTERNAL_CHECKS
   @inline(never)

--- a/Sources/BitCollections/BitSet/BitSet.Index.swift
+++ b/Sources/BitCollections/BitSet/BitSet.Index.swift
@@ -39,6 +39,10 @@ extension BitSet {
   }
 }
 
+#if swift(>=5.5)
+extension BitSet.Index: Sendable {}
+#endif
+
 extension BitSet.Index: CustomStringConvertible {
   // A textual representation of this instance.
   public var description: String {

--- a/Sources/BitCollections/BitSet/BitSet.swift
+++ b/Sources/BitCollections/BitSet/BitSet.swift
@@ -29,6 +29,10 @@ public struct BitSet {
   }
 }
 
+#if swift(>=5.5)
+extension BitSet: Sendable {}
+#endif
+
 extension BitSet {
   @inline(__always)
   internal func _read<R>(

--- a/Sources/DequeModule/Deque+Collection.swift
+++ b/Sources/DequeModule/Deque+Collection.swift
@@ -160,6 +160,10 @@ extension Deque: Sequence {
   }
 }
 
+#if swift(>=5.5)
+extension Deque.Iterator: Sendable where Element: Sendable {}
+#endif
+
 extension Deque: RandomAccessCollection {
   public typealias Index = Int
   public typealias SubSequence = Slice<Self>

--- a/Sources/DequeModule/Deque+Sendable.swift
+++ b/Sources/DequeModule/Deque+Sendable.swift
@@ -1,0 +1,14 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if swift(>=5.5)
+extension Deque: @unchecked Sendable where Element: Sendable {}
+#endif

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements+SubSequence.swift
@@ -30,6 +30,11 @@ extension OrderedDictionary.Elements {
   }
 }
 
+#if swift(>=5.5)
+extension OrderedDictionary.Elements.SubSequence: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
+
 extension OrderedDictionary.Elements.SubSequence {
   /// A read-only collection view containing the keys in this slice.
   ///
@@ -121,6 +126,11 @@ extension OrderedDictionary.Elements.SubSequence: Sequence {
     Iterator(_base: self)
   }
 }
+
+#if swift(>=5.5)
+extension OrderedDictionary.Elements.SubSequence.Iterator: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
 
 extension OrderedDictionary.Elements.SubSequence: RandomAccessCollection {
   /// The index type for an ordered dictionary: `Int`.

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sendable.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sendable.swift
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if swift(>=5.5)
+extension OrderedDictionary: @unchecked Sendable
+where Key: Sendable, Value: Sendable {}
+#endif

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sequence.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sequence.swift
@@ -61,3 +61,8 @@ extension OrderedDictionary: Sequence {
     Iterator(_base: self)
   }
 }
+
+#if swift(>=5.5)
+extension OrderedDictionary.Iterator: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
@@ -24,6 +24,11 @@ extension OrderedDictionary {
   }
 }
 
+#if swift(>=5.5)
+extension OrderedDictionary.Values: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
+
 extension OrderedDictionary.Values {
   /// A read-only view of the contents of this collection as an array value.
   ///

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.Elements.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.Elements.swift
@@ -27,6 +27,11 @@ extension OrderedDictionary {
   }
 }
 
+#if swift(>=5.5)
+extension OrderedDictionary.Elements: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
+
 extension OrderedDictionary {
   /// A view of the contents of this dictionary as a random-access collection.
   ///

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Sendable.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Sendable.swift
@@ -1,0 +1,12 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension OrderedSet: @unchecked Sendable where Element: Sendable {}

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
@@ -33,6 +33,10 @@ extension OrderedSet {
   }
 }
 
+#if swift(>=5.5)
+extension OrderedSet.SubSequence: Sendable where Element: Sendable {}
+#endif
+
 extension OrderedSet.SubSequence {
   @inlinable
   internal var _slice: Array<Element>.SubSequence {

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
@@ -64,6 +64,10 @@ extension OrderedSet {
   }
 }
 
+#if swift(>=5.5)
+extension OrderedSet.UnorderedView: Sendable where Element: Sendable {}
+#endif
+
 extension OrderedSet.UnorderedView: CustomStringConvertible {
   /// A textual representation of this instance.
   public var description: String {

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnstableInternals.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnstableInternals.swift
@@ -46,3 +46,8 @@ extension OrderedSet {
     }
   }
 }
+
+#if swift(>=5.5)
+extension OrderedSet._UnstableInternals: Sendable
+where Element: Sendable {}
+#endif

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Collection.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Collection.swift
@@ -32,6 +32,11 @@ extension PersistentDictionary {
   }
 }
 
+#if swift(>=5.5)
+extension PersistentDictionary.Index: @unchecked Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
+
 extension PersistentDictionary.Index: Equatable {
   @inlinable
   public static func ==(left: Self, right: Self) -> Bool {

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Keys.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Keys.swift
@@ -34,6 +34,10 @@ extension PersistentDictionary {
   }
 }
 
+#if swift(>=5.5)
+extension PersistentDictionary.Keys: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
 
 extension PersistentDictionary.Keys: Sequence {
   public typealias Element = Key
@@ -73,6 +77,11 @@ extension PersistentDictionary.Keys: Sequence {
     _base._root.containsKey(.top, element, _Hash(element))
   }
 }
+
+#if swift(>=5.5)
+extension PersistentDictionary.Keys.Iterator: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
 
 extension PersistentDictionary.Keys: BidirectionalCollection {
   public typealias Index = PersistentDictionary.Index

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Sendable.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Sendable.swift
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if swift(>=5.5)
+extension PersistentDictionary: @unchecked Sendable
+where Key: Sendable, Value: Sendable {}
+#endif

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Sequence.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Sequence.swift
@@ -41,6 +41,11 @@ extension PersistentDictionary: Sequence {
   }
 }
 
+#if swift(>=5.5)
+extension PersistentDictionary.Iterator: @unchecked Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
+
 extension PersistentDictionary.Iterator: IteratorProtocol {
   public typealias Element = (key: Key, value: Value)
 

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Values.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Values.swift
@@ -45,6 +45,11 @@ extension PersistentDictionary {
   }
 }
 
+#if swift(>=5.5)
+extension PersistentDictionary.Values: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
+
 extension PersistentDictionary.Values: Sequence {
   public typealias Element = Value
 
@@ -71,6 +76,11 @@ extension PersistentDictionary.Values: Sequence {
     Iterator(_base: _base.makeIterator())
   }
 }
+
+#if swift(>=5.5)
+extension PersistentDictionary.Values.Iterator: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
 
 // Note: This cannot be a MutableCollection because its subscript setter
 // needs to invalidate indices.

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+Collection.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+Collection.swift
@@ -32,6 +32,11 @@ extension PersistentSet {
   }
 }
 
+#if swift(>=5.5)
+extension PersistentSet.Index: @unchecked Sendable
+where Element: Sendable {}
+#endif
+
 extension PersistentSet.Index: Equatable {
   @inlinable
   public static func ==(left: Self, right: Self) -> Bool {

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+Sendable.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+Sendable.swift
@@ -1,0 +1,14 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if swift(>=5.5)
+extension PersistentSet: @unchecked Sendable where Element: Sendable {}
+#endif

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+Sequence.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+Sequence.swift
@@ -39,3 +39,8 @@ extension PersistentSet: Sequence {
     _root.containsKey(.top, element, _Hash(element))
   }
 }
+
+#if swift(>=5.5)
+extension PersistentSet.Iterator: @unchecked Sendable
+where Element: Sendable {}
+#endif

--- a/Sources/PriorityQueueModule/Heap.swift
+++ b/Sources/PriorityQueueModule/Heap.swift
@@ -35,6 +35,10 @@ public struct Heap<Element: Comparable> {
   }
 }
 
+#if swift(>=5.5)
+extension Heap: Sendable where Element: Sendable {}
+#endif
+
 extension Heap {
   /// A Boolean value indicating whether or not the heap is empty.
   ///

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary+Keys.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary+Keys.swift
@@ -23,6 +23,11 @@ extension SortedDictionary {
   }
 }
 
+#if swift(>=5.5)
+extension SortedDictionary.Keys: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
+
 extension SortedDictionary.Keys: Sequence {
   /// The element type of the collection.
   public typealias Element = Key
@@ -51,6 +56,11 @@ extension SortedDictionary.Keys: Sequence {
     Iterator(_base.makeIterator())
   }
 }
+
+#if swift(>=5.5)
+extension SortedDictionary.Keys.Iterator: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
 
 extension SortedDictionary.Keys: BidirectionalCollection {
   /// The index type for a dictionary's keys view.

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary+Sendable.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary+Sendable.swift
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if swift(>=5.5)
+extension SortedDictionary: @unchecked Sendable
+where Key: Sendable, Value: Sendable {}
+#endif

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary+Sequence.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary+Sequence.swift
@@ -45,3 +45,8 @@ extension SortedDictionary: Sequence {
     return Iterator(_base: self)
   }
 }
+
+#if swift(>=5.5)
+extension SortedDictionary.Iterator: @unchecked Sendable
+where Key: Sendable, Value: Sendable {}
+#endif

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary+SubSequence.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary+SubSequence.swift
@@ -30,6 +30,11 @@ extension SortedDictionary {
   }
 }
 
+#if swift(>=5.5)
+extension SortedDictionary.SubSequence: @unchecked Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
+
 extension SortedDictionary.SubSequence: Sequence {
   public typealias Element = SortedDictionary.Element
   
@@ -65,6 +70,11 @@ extension SortedDictionary.SubSequence: Sequence {
     Iterator(_subSequence.makeIterator())
   }
 }
+
+#if swift(>=5.5)
+extension SortedDictionary.SubSequence.Iterator: @unchecked Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
 
 extension SortedDictionary.SubSequence: BidirectionalCollection {
   public typealias Index = SortedDictionary.Index

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary+Values.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary+Values.swift
@@ -23,6 +23,11 @@ extension SortedDictionary {
   }
 }
 
+#if swift(>=5.5)
+extension SortedDictionary.Values: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
+
 extension SortedDictionary.Values: Sequence {
   /// The element type of the collection.
   public typealias Element = Value
@@ -51,6 +56,11 @@ extension SortedDictionary.Values: Sequence {
     Iterator(_base.makeIterator())
   }
 }
+
+#if swift(>=5.5)
+extension SortedDictionary.Values.Iterator: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
 
 extension SortedDictionary.Values: BidirectionalCollection {
   /// The index type for a dictionary's values view.

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary.Index.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary.Index.swift
@@ -34,6 +34,11 @@ extension SortedDictionary {
   }
 }
 
+#if swift(>=5.5)
+extension SortedDictionary.Index: @unchecked Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
+
 // MARK: Equatable
 extension SortedDictionary.Index: Equatable {
   @inlinable

--- a/Sources/SortedCollections/SortedSet/SortedSet+Sendable.swift
+++ b/Sources/SortedCollections/SortedSet/SortedSet+Sendable.swift
@@ -1,0 +1,14 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if swift(>=5.5)
+extension SortedSet: @unchecked Sendable where Element: Sendable {}
+#endif

--- a/Sources/SortedCollections/SortedSet/SortedSet+Sequence.swift
+++ b/Sources/SortedCollections/SortedSet/SortedSet+Sequence.swift
@@ -49,3 +49,8 @@ extension SortedSet: Sequence {
     return Iterator(_base: self)
   }
 }
+
+#if swift(>=5.5)
+extension SortedSet.Iterator: @unchecked Sendable
+where Element: Sendable {}
+#endif

--- a/Sources/SortedCollections/SortedSet/SortedSet+SubSequence.swift
+++ b/Sources/SortedCollections/SortedSet/SortedSet+SubSequence.swift
@@ -30,6 +30,11 @@ extension SortedSet {
   }
 }
 
+#if swift(>=5.5)
+extension SortedSet.SubSequence: @unchecked Sendable
+where Element: Sendable {}
+#endif
+
 extension SortedSet.SubSequence: Sequence {
   public typealias Element = SortedSet.Element
   
@@ -65,6 +70,11 @@ extension SortedSet.SubSequence: Sequence {
     Iterator(_subSequence.makeIterator())
   }
 }
+
+#if swift(>=5.5)
+extension SortedSet.SubSequence.Iterator: @unchecked Sendable
+where Element: Sendable {}
+#endif
 
 extension SortedSet.SubSequence: BidirectionalCollection {
   public typealias Index = SortedSet.Index

--- a/Sources/SortedCollections/SortedSet/SortedSet.Index.swift
+++ b/Sources/SortedCollections/SortedSet/SortedSet.Index.swift
@@ -34,6 +34,11 @@ extension SortedSet {
   }
 }
 
+#if swift(>=5.5)
+extension SortedSet.Index: @unchecked Sendable
+where Element: Sendable {}
+#endif
+
 // MARK: Equatable
 extension SortedSet.Index: Equatable {
   @inlinable


### PR DESCRIPTION
Resolves #166.

List of conformances added:

(The conformances are currently protected by `#if swift(>=5.5)` clauses that may get removed if we bump the minimum toolchain version to 5.5 in the 1.1.0 tag.)

```swift
extension BitArray: Sendable {}

extension BitSet: Sendable {}
extension BitSet.Iterator: Sendable {}
extension BitSet.Index: Sendable {}
extension BitSet.Counted: Sendable {}

extension Deque: @unchecked Sendable where Element: Sendable {}
extension Deque.Iterator: Sendable where Element: Sendable {}

extension Heap: Sendable where Element: Sendable {}

extension OrderedSet: @unchecked Sendable where Element: Sendable {}
extension OrderedSet.SubSequence: Sendable where Element: Sendable {}
extension OrderedSet.UnorderedView: Sendable where Element: Sendable {}
extension OrderedSet._UnstableInternals: Sendable where Element: Sendable {}

extension OrderedDictionary: @unchecked Sendable where Key: Sendable, Value: Sendable {}
extension OrderedDictionary.Iterator: Sendable where Key: Sendable, Value: Sendable {}
extension OrderedDictionary.Values: Sendable where Key: Sendable, Value: Sendable {}
extension OrderedDictionary.Elements: Sendable where Key: Sendable, Value: Sendable {}
extension OrderedDictionary.Elements.SubSequence: Sendable where Key: Sendable, Value: Sendable {}
extension OrderedDictionary.Elements.SubSequence.Iterator: Sendable where Key: Sendable, Value: Sendable {}

extension PersistentSet: @unchecked Sendable where Element: Sendable {}
extension PersistentSet.Iterator: @unchecked Sendable where Element: Sendable {}
extension PersistentSet.Index: @unchecked Sendable where Element: Sendable {}

extension PersistentDictionary: @unchecked Sendable where Key: Sendable, Value: Sendable {}
extension PersistentDictionary.Iterator: @unchecked Sendable where Key: Sendable, Value: Sendable {}
extension PersistentDictionary.Index: @unchecked Sendable where Key: Sendable, Value: Sendable {}
extension PersistentDictionary.Keys: Sendable where Key: Sendable, Value: Sendable {}
extension PersistentDictionary.Keys.Iterator: Sendable where Key: Sendable, Value: Sendable {}
extension PersistentDictionary.Values: Sendable where Key: Sendable, Value: Sendable {}
extension PersistentDictionary.Values.Iterator: Sendable where Key: Sendable, Value: Sendable {}

// The ones below are provisional -- SortedSet/SortedDictionary aren't quite ready yet, 
// and they may or may not make it into the 1.1.0 release.
extension SortedSet: @unchecked Sendable where Element: Sendable {}
extension SortedSet.Iterator: @unchecked Sendable where Element: Sendable {}
extension SortedSet.Index: @unchecked Sendable where Element: Sendable {}
extension SortedSet.SubSequence: @unchecked Sendable where Element: Sendable {}
extension SortedSet.SubSequence.Iterator: @unchecked Sendable where Element: Sendable {}

extension SortedDictionary: @unchecked Sendable where Key: Sendable, Value: Sendable {}
extension SortedDictionary.Iterator: @unchecked Sendable where Key: Sendable, Value: Sendable {}
extension SortedDictionary.Index: @unchecked Sendable where Key: Sendable, Value: Sendable {}
extension SortedDictionary.SubSequence: @unchecked Sendable where Key: Sendable, Value: Sendable {}
extension SortedDictionary.SubSequence.Iterator: @unchecked Sendable where Key: Sendable, Value: Sendable {}
extension SortedDictionary.Keys: Sendable where Key: Sendable, Value: Sendable {}
extension SortedDictionary.Keys.Iterator: Sendable where Key: Sendable, Value: Sendable {}
extension SortedDictionary.Values: Sendable where Key: Sendable, Value: Sendable {}
extension SortedDictionary.Values.Iterator: Sendable where Key: Sendable, Value: Sendable {}
```

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
