### PR TITLE
Fleshing out `PersistentSet`

### DIFF
--- a/Sources/PersistentCollections/Node/_Node+Builder.swift
+++ b/Sources/PersistentCollections/Node/_Node+Builder.swift
@@ -59,9 +59,9 @@ extension _Node.Builder {
     assert(level.isAtRoot)
     switch self {
     case .empty:
-      return _Node(storage: _emptySingleton, count: 0)
+      return ._empty()
     case .item(let item, let h):
-      return _Node._regularNode(item, h[level])
+      return ._regularNode(item, h[level])
     case .node(let node, _):
       return node
     }

--- a/Sources/PersistentCollections/Node/_Node+Initializers.swift
+++ b/Sources/PersistentCollections/Node/_Node+Initializers.swift
@@ -10,6 +10,11 @@
 //===----------------------------------------------------------------------===//
 
 extension _Node {
+  @inlinable @inline(__always)
+  internal static func _empty() -> _Node {
+    _Node(storage: _emptySingleton, count: 0)
+  }
+
   @inlinable
   internal static func _collisionNode(
     _ hash: _Hash,

--- a/Sources/PersistentCollections/Node/_Node+Structural intersection.swift
+++ b/Sources/PersistentCollections/Node/_Node+Structural intersection.swift
@@ -11,10 +11,10 @@
 
 extension _Node {
   @inlinable
-  internal func intersection(
+  internal func intersection<Value2>(
     _ level: _Level,
     _ hashPrefix: _Hash,
-    _ other: _Node
+    _ other: _Node<Key, Value2>
   ) -> Builder? {
     if self.raw.storage === other.raw.storage { return nil }
 
@@ -102,10 +102,10 @@ extension _Node {
   }
 
   @inlinable @inline(never)
-  internal func _intersection_slow(
+  internal func _intersection_slow<Value2>(
     _ level: _Level,
     _ hashPrefix: _Hash,
-    _ other: _Node
+    _ other: _Node<Key, Value2>
   ) -> Builder? {
     let lc = self.isCollisionNode
     let rc = other.isCollisionNode

--- a/Sources/PersistentCollections/Node/_Node+Structural subtracting.swift
+++ b/Sources/PersistentCollections/Node/_Node+Structural subtracting.swift
@@ -11,10 +11,10 @@
 
 extension _Node {
   @inlinable
-  internal func subtracting(
+  internal func subtracting<Value2>(
     _ level: _Level,
     _ hashPrefix: _Hash,
-    _ other: _Node
+    _ other: _Node<Key, Value2>
   ) -> Builder? {
     if self.raw.storage === other.raw.storage { return .empty }
 
@@ -107,10 +107,10 @@ extension _Node {
   }
 
   @inlinable @inline(never)
-  internal func _subtracting_slow(
+  internal func _subtracting_slow<Value2>(
     _ level: _Level,
     _ hashPrefix: _Hash,
-    _ other: _Node
+    _ other: _Node<Key, Value2>
   ) -> Builder? {
     let lc = self.isCollisionNode
     let rc = other.isCollisionNode

--- a/Sources/PersistentCollections/Node/_Node+Subtree Insertions.swift
+++ b/Sources/PersistentCollections/Node/_Node+Subtree Insertions.swift
@@ -15,6 +15,15 @@ extension _Node {
   @inlinable
   internal mutating func insert(
     _ level: _Level,
+    _ item: Element,
+    _ hash: _Hash
+  ) -> (inserted: Bool, leaf: _UnmanagedNode, slot: _Slot) {
+    insert(level, item.key, hash) { $0.initialize(to: item) }
+  }
+
+  @inlinable
+  internal mutating func insert(
+    _ level: _Level,
     _ key: Key,
     _ hash: _Hash,
     _ inserter: (UnsafeMutablePointer<Element>) -> Void

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Collection.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Collection.swift
@@ -109,7 +109,7 @@ extension PersistentDictionary: BidirectionalCollection {
   public subscript(i: Index) -> Element {
     precondition(_isValid(i), "Invalid index")
     precondition(i._path.isOnItem, "Can't get element at endIndex")
-    return _Node.UnsafeHandle.read(i._path.node) {
+    return _UnsafeHandle.read(i._path.node) {
       $0[item: i._path.currentItemSlot]
     }
   }

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Initializers.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Initializers.swift
@@ -12,7 +12,7 @@
 extension PersistentDictionary {
   @inlinable
   public init() {
-    self.init(_new: _Node(storage: _emptySingleton, count: 0))
+    self.init(_new: ._empty())
   }
 
   @inlinable
@@ -37,9 +37,7 @@ extension PersistentDictionary {
     self.init()
     for item in keysAndValues {
       let hash = _Hash(item.0)
-      let r = _root.insert(.top, item.0, hash) {
-        $0.initialize(to: item)
-      }
+      let r = _root.insert(.top, item, hash)
       precondition(r.inserted, "Duplicate key: '\(item.0)'")
     }
     _invariantCheck()

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Values.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary+Values.swift
@@ -17,6 +17,9 @@ extension PersistentDictionary {
     internal typealias _Node = PersistentCollections._Node<Key, Value>
 
     @usableFromInline
+    internal typealias _UnsafeHandle = _Node.UnsafeHandle
+
+    @usableFromInline
     internal var _base: PersistentDictionary
 
     @inlinable
@@ -108,14 +111,14 @@ extension PersistentDictionary.Values: BidirectionalCollection {
       precondition(_base._isValid(index), "Invalid index")
       precondition(index._path.isOnItem, "Cannot set value at end index")
       let (leaf, slot) = _base._root.ensureUnique(level: .top, at: index._path)
-      _Node.UnsafeHandle.update(leaf) { $0[item: slot].value = newValue }
+      _UnsafeHandle.update(leaf) { $0[item: slot].value = newValue }
       _base._invalidateIndices()
     }
     _modify { // FIXME: Consider removing
       precondition(_base._isValid(index), "Invalid index")
       precondition(index._path.isOnItem, "Cannot set value at end index")
       let (leaf, slot) = _base._root.ensureUnique(level: .top, at: index._path)
-      var item = _Node.UnsafeHandle.update(leaf) { $0.itemPtr(at: slot).move() }
+      var item = _UnsafeHandle.update(leaf) { $0.itemPtr(at: slot).move() }
       defer {
         _Node.UnsafeHandle.update(leaf) {
           $0.itemPtr(at: slot).initialize(to: item)

--- a/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary.swift
+++ b/Sources/PersistentCollections/PersistentDictionary/PersistentDictionary.swift
@@ -14,6 +14,9 @@ public struct PersistentDictionary<Key: Hashable, Value> {
   internal typealias _Node = PersistentCollections._Node<Key, Value>
 
   @usableFromInline
+  internal typealias _UnsafeHandle = _Node.UnsafeHandle
+
+  @usableFromInline
   var _root: _Node
 
   /// The version number of this instance, used for quick index validation.
@@ -284,7 +287,7 @@ extension PersistentDictionary {
     }
     _invalidateIndices()
     if r.inserted { return nil }
-    return _Node.UnsafeHandle.update(r.leaf) {
+    return _UnsafeHandle.update(r.leaf) {
       let p = $0.itemPtr(at: r.slot)
       let old = p.pointee.value
       p.pointee.value = value
@@ -302,7 +305,7 @@ extension PersistentDictionary {
       $0.initialize(to: (key, value))
     }
     if r.inserted { return true }
-    _Node.UnsafeHandle.update(r.leaf) {
+    _UnsafeHandle.update(r.leaf) {
       $0[item: r.slot].value = value
     }
     return false
@@ -335,7 +338,7 @@ extension PersistentDictionary {
     let r = _root.updateValue(.top, forKey: key, hash) {
       $0.initialize(to: (key, defaultValue()))
     }
-    return try _Node.UnsafeHandle.update(r.leaf) {
+    return try _UnsafeHandle.update(r.leaf) {
       try body(&$0[item: r.slot].value)
     }
   }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+Collection.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+Collection.swift
@@ -109,7 +109,7 @@ extension PersistentSet: BidirectionalCollection {
   public subscript(i: Index) -> Element {
     precondition(_isValid(i), "Invalid index")
     precondition(i._path.isOnItem, "Can't get element at endIndex")
-    return _Node.UnsafeHandle.read(i._path.node) {
+    return _UnsafeHandle.read(i._path.node) {
       $0[item: i._path.currentItemSlot].key
     }
   }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+Collection.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+Collection.swift
@@ -173,4 +173,43 @@ extension PersistentSet: BidirectionalCollection {
     precondition(limited, "Index offset out of bounds")
     return nil
   }
+
+  @inlinable @inline(__always)
+  public func _customIndexOfEquatableElement(
+    _ element: Element
+  ) -> Index?? {
+    _index(of: element)
+  }
+
+  @inlinable @inline(__always)
+  public func _customLastIndexOfEquatableElement(
+    _ element: Element
+  ) -> Index?? {
+    _index(of: element)
+  }
+
+  @inlinable
+  internal func _index(of element: Element) -> Index? {
+    let hash = _Hash(element)
+    guard let path = _root.path(to: element, hash) else { return nil }
+    return Index(_root: _root.unmanaged, version: _version, path: path)
+  }
+
+  public func _failEarlyRangeCheck(
+    _ index: Index, bounds: Range<Index>
+  ) {
+    precondition(_isValid(index))
+  }
+
+  public func _failEarlyRangeCheck(
+    _ index: Index, bounds: ClosedRange<Index>
+  ) {
+    precondition(_isValid(index))
+  }
+
+  public func _failEarlyRangeCheck(
+    _ range: Range<Index>, bounds: Range<Index>
+  ) {
+    precondition(_isValid(range.lowerBound) && _isValid(range.upperBound))
+  }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+Extras.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+Extras.swift
@@ -9,11 +9,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _CollectionsUtilities
-
-extension PersistentSet: Equatable {
-  @inlinable @inline(__always)
-  public static func == (left: Self, right: Self) -> Bool {
-    left.isEqual(to: right)
+extension PersistentSet {
+  @discardableResult
+  public mutating func remove(at position: Index) -> Element {
+    precondition(_isValid(position))
+    _invalidateIndices()
+    return _root.remove(.top, at: position._path).key
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra Initializers.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra Initializers.swift
@@ -12,7 +12,7 @@
 extension PersistentSet {
   @inlinable
   public init() {
-    self.init(_new: _Node(storage: _emptySingleton, count: 0))
+    self.init(_new: ._empty())
   }
 
   @inlinable

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra basics.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra basics.swift
@@ -23,14 +23,12 @@ extension PersistentSet: SetAlgebra {
     _ newMember: __owned Element
   ) -> (inserted: Bool, memberAfterInsert: Element) {
     let hash = _Hash(newMember)
-    let r = _root.insert(.top, newMember, hash) {
-      $0.initialize(to: (newMember, ()))
-    }
+    let r = _root.insert(.top, (newMember, ()), hash)
     if r.inserted {
       _invalidateIndices()
       return (true, newMember)
     }
-    return _Node.UnsafeHandle.read(r.leaf) {
+    return _UnsafeHandle.read(r.leaf) {
       (false, $0[item: r.slot].key)
     }
   }
@@ -39,9 +37,7 @@ extension PersistentSet: SetAlgebra {
   @inlinable
   internal mutating func _insert(_ newMember: __owned Element) -> Bool {
     let hash = _Hash(newMember)
-    let r = _root.insert(.top, newMember, hash) {
-      $0.initialize(to: (newMember, ()))
-    }
+    let r = _root.insert(.top, (newMember, ()), hash)
     return r.inserted
   }
 
@@ -61,7 +57,7 @@ extension PersistentSet: SetAlgebra {
       $0.initialize(to: (newMember, ()))
     }
     if r.inserted { return nil }
-    return _Node.UnsafeHandle.update(r.leaf) {
+    return _UnsafeHandle.update(r.leaf) {
       let p = $0.itemPtr(at: r.slot)
       let old = p.move().key
       p.initialize(to: (newMember, ()))

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra formIntersection.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra formIntersection.swift
@@ -31,4 +31,18 @@ extension PersistentSet {
   public mutating func formIntersection(_ other: Self) {
     self = intersection(other)
   }
+
+  @inlinable
+  public mutating func formIntersection<Value>(
+    _ other: PersistentDictionary<Element, Value>.Keys
+  ) {
+    self = intersection(other)
+  }
+
+  @inlinable
+  public mutating func formIntersection<S: Sequence>(
+    _ other: S
+  ) where S.Element == Element {
+    self = intersection(other)
+  }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra formSymmetricDifference.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra formSymmetricDifference.swift
@@ -28,4 +28,10 @@ extension PersistentSet {
   public mutating func formSymmetricDifference(_ other: __owned Self) {
     self = symmetricDifference(other)
   }
+
+  @inlinable
+  public mutating func formSymmetricDifference<S: Sequence>(_ other: __owned S)
+  where S.Element == Element {
+    self = symmetricDifference(other)
+  }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra formUnion.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra formUnion.swift
@@ -32,4 +32,10 @@ extension PersistentSet {
   public mutating func formUnion(_ other: __owned Self) {
     self = union(other)
   }
+
+  @inlinable
+  public mutating func formUnion<S: Sequence>(_ other: __owned S)
+  where S.Element == Element {
+    self = union(other)
+  }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra intersection.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra intersection.swift
@@ -28,12 +28,68 @@ extension PersistentSet {
   ///     However, the implementation is careful to make the best use of
   ///     hash tree structure to minimize work when possible, e.g. by linking
   ///     parts of the input trees directly into the result.
-  @inlinable
+  @inlinable @inline(__always)
   public func intersection(_ other: Self) -> Self {
-    let builder = _root.intersection(.top, .emptyPrefix, other._root)
+    _intersection(other._root)
+  }
+
+  @inlinable @inline(__always)
+  public func intersection<Value>(
+    _ other: PersistentDictionary<Element, Value>.Keys
+  ) -> Self {
+    _intersection(other._base._root)
+  }
+
+  @inlinable
+  internal func _intersection<V>(
+    _ other: PersistentCollections._Node<Element, V>
+  ) -> Self {
+    let builder = _root.intersection(.top, .emptyPrefix, other)
     guard let builder = builder else { return self }
     let root = builder.finalize(.top)
     root._fullInvariantCheck(.top, .emptyPrefix)
     return Self(_new: root)
+  }
+
+  /// Returns a new set with the elements that are common to both this set and
+  /// the provided sequence.
+  ///
+  ///     var a: PersistentSet = [1, 2, 3, 4]
+  ///     let b = [0, 2, 4, 6]
+  ///     let c = a.intersection(b)
+  ///     // `c` is some permutation of `[2, 4]`
+  ///
+  /// The result will only contain instances that were originally in `self`.
+  /// (This matters if equal members can be distinguished by comparing their
+  /// identities, or by some other means.)
+  ///
+  /// - Parameter other: An arbitrary sequence of items, possibly containing
+  ///    duplicate values.
+  @inlinable
+  public func intersection<S: Sequence>(
+    _ other: S
+  ) -> Self
+  where S.Element == Element {
+    if S.self == Self.self {
+      return intersection(other as! Self)
+    }
+
+    guard let first = self.first else { return Self() }
+    if other._customContainsEquatableElement(first) != nil {
+      // Fast path: the sequence has fast containment checks.
+      return self.filter { other.contains($0) }
+    }
+
+    var result: _Node = ._empty()
+    for item in other {
+      let hash = _Hash(item)
+      if let r = self._root.lookup(.top, item, hash) {
+        let itemInSelf = _UnsafeHandle.read(r.node) { $0[item: r.slot] }
+        _ = result.updateValue(.top, forKey: itemInSelf.key, hash) {
+          $0.initialize(to: itemInSelf)
+        }
+      }
+    }
+    return Self(_new: result)
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isDisjoint.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isDisjoint.swift
@@ -65,10 +65,13 @@ extension PersistentSet {
   ///
   /// - Complexity: In the worst case, this makes O(*n*) calls to
   ///    `self.contains`, where *n* is the length of the sequence.
- @inlinable
+  @inlinable
   public func isDisjoint<S: Sequence>(with other: S) -> Bool
   where S.Element == Element
   {
-    other.allSatisfy { !self.contains($0) }
+    if S.self == Self.self {
+      return isDisjoint(with: other as! Self)
+    }
+    return other.allSatisfy { !self.contains($0) }
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isEqual.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isEqual.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+// FIXME: These are non-standard extensions generalizing ==.
+extension PersistentSet {
+  @inlinable
+  public func isEqual(to other: Self) -> Bool {
+    _root.isEqual(to: other._root, by: { _, _ in true })
+  }
+
+  @inlinable
+  public func isEqual<Value>(
+    to other: PersistentDictionary<Element, Value>.Keys
+  ) -> Bool {
+    _root.isEqual(to: other._base._root, by: { _, _ in true })
+  }
+
+  @inlinable
+  public func isEqual<S: Sequence>(to other: S) -> Bool
+  where S.Element == Element
+  {
+    if S.self == Self.self {
+      return isEqual(to: other as! Self)
+    }
+
+    guard other.underestimatedCount <= self.count else { return false }
+    // FIXME: Would making this a BitSet of seen positions be better?
+    var seen: _Node = ._empty()
+    for item in other {
+      let hash = _Hash(item)
+      guard self._root.containsKey(.top, item, hash) else { return false }
+      guard seen.insert(.top, (item, ()), hash).inserted
+      else { return false }
+    }
+    return seen.count == self.count
+  }
+}

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isStrictSubset.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isStrictSubset.swift
@@ -91,6 +91,10 @@ extension PersistentSet {
   public func isStrictSubset<S: Sequence>(of other: S) -> Bool
   where S.Element == Element
   {
+    if S.self == Self.self {
+      return isStrictSubset(of: other as! Self)
+    }
+
     var it = self.makeIterator()
     guard let first = it.next() else {
       return other.contains(where: { _ in true })
@@ -104,10 +108,13 @@ extension PersistentSet {
     }
 
     // FIXME: Would making this a BitSet of seen positions be better?
-    var seen: PersistentSet? = []
+    var seen: _Node? = ._empty()
     var isStrict = false
     for item in other {
-      if self.contains(item), seen?._insert(item) == true {
+      let hash = _Hash(item)
+      if self._root.containsKey(.top, item, hash),
+         seen?.insert(.top, (item, ()), hash).inserted == true
+      {
         if seen?.count == self.count {
           if isStrict { return true }
           // Stop collecting seen items -- we just need to decide

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isSubset.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isSubset.swift
@@ -83,6 +83,10 @@ extension PersistentSet {
   public func isSubset<S: Sequence>(of other: S) -> Bool
   where S.Element == Element
   {
+    if S.self == Self.self {
+      return isSubset(of: other as! Self)
+    }
+
     var it = self.makeIterator()
     guard let first = it.next() else { return true }
     if let match = other._customContainsEquatableElement(first) {
@@ -95,9 +99,12 @@ extension PersistentSet {
     }
 
     // FIXME: Would making this a BitSet of seen positions be better?
-    var seen: PersistentSet = []
+    var seen: _Node = ._empty()
     for item in other {
-      if contains(item), seen._insert(item), seen.count == self.count {
+      let hash = _Hash(item)
+      guard contains(item) else { continue }
+      guard seen.insert(.top, (item, ()), hash).inserted else { continue }
+      if seen.count == self.count {
         return true
       }
     }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isSuperset.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra isSuperset.swift
@@ -79,6 +79,10 @@ extension PersistentSet {
   public func isSuperset<S: Sequence>(of other: S) -> Bool
   where S.Element == Element
   {
-    other.allSatisfy { self.contains($0) }
+    if S.self == Self.self {
+      return isSuperset(of: other as! Self)
+    }
+
+    return other.allSatisfy { self.contains($0) }
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra subtract.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra subtract.swift
@@ -27,4 +27,17 @@ extension PersistentSet {
   public mutating func subtract(_ other: Self) {
     self = subtracting(other)
   }
+
+  @inlinable
+  public mutating func subtract<Value>(
+    _ other: PersistentDictionary<Element, Value>.Keys
+  ) {
+    self = subtracting(other)
+  }
+
+  @inlinable
+  public mutating func subtract<S: Sequence>(_ other: S)
+  where S.Element == Element {
+    self = subtracting(other)
+  }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra subtracting.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra subtracting.swift
@@ -26,10 +26,47 @@ extension PersistentSet {
   ///     parts of the input trees directly into the result.
   @inlinable
   public __consuming func subtracting(_ other: Self) -> Self {
-    let builder = _root.subtracting(.top, .emptyPrefix, other._root)
+    _subtracting(other._root)
+  }
+
+  @inlinable
+  public __consuming func subtracting<V>(
+    _ other: PersistentDictionary<Element, V>.Keys
+  ) -> Self {
+    _subtracting(other._base._root)
+  }
+
+  @inlinable
+  internal __consuming func _subtracting<V>(
+    _ other: PersistentCollections._Node<Element, V>
+  ) -> Self {
+    let builder = _root.subtracting(.top, .emptyPrefix, other)
     guard let builder = builder else { return self }
     let root = builder.finalize(.top)
     root._fullInvariantCheck(.top, .emptyPrefix)
+    return Self(_new: root)
+  }
+
+  @inlinable
+  public __consuming func subtracting<S: Sequence>(
+    _ other: S
+  ) -> Self
+  where S.Element == Element {
+    if S.self == Self.self {
+      return subtracting(other as! Self)
+    }
+
+    guard let first = self.first else { return Self() }
+    if other._customContainsEquatableElement(first) != nil {
+      // Fast path: the sequence has fast containment checks.
+      return self.filter { !other.contains($0) }
+    }
+
+    var root = self._root
+    for item in other {
+      let hash = _Hash(item)
+      _ = root.remove(.top, item, hash)
+    }
     return Self(_new: root)
   }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra symmetricDifference.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra symmetricDifference.swift
@@ -31,4 +31,25 @@ extension PersistentSet {
     let root = branch.finalize(.top)
     return PersistentSet(_new: root)
   }
+
+  @inlinable
+  public func symmetricDifference<S: Sequence>(_ other: __owned S) -> Self
+  where S.Element == Element {
+    if S.self == Self.self {
+      return symmetricDifference(other as! Self)
+    }
+
+    var root = self._root
+    for item in other {
+      let hash = _Hash(item)
+      var state = root.prepareValueUpdate(item, hash)
+      if state.found {
+        state.value = nil
+      } else {
+        state.value = ()
+      }
+      root.finalizeValueUpdate(state)
+    }
+    return Self(_new: root)
+  }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra union.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet+SetAlgebra union.swift
@@ -34,4 +34,19 @@ extension PersistentSet {
     r.node._fullInvariantCheck(.top, .emptyPrefix)
     return PersistentSet(_new: r.node)
   }
+
+  @inlinable
+  public func union<S: Sequence>(_ other: __owned S) -> Self
+  where S.Element == Element {
+    if S.self == Self.self {
+      return union(other as! Self)
+    }
+
+    var root = self._root
+    for item in other {
+      let hash = _Hash(item)
+      _ = root.insert(.top, (item, ()), hash)
+    }
+    return Self(_new: root)
+  }
 }

--- a/Sources/PersistentCollections/PersistentSet/PersistentSet.swift
+++ b/Sources/PersistentCollections/PersistentSet/PersistentSet.swift
@@ -14,6 +14,9 @@ public struct PersistentSet<Element: Hashable> {
   internal typealias _Node = PersistentCollections._Node<Element, Void>
 
   @usableFromInline
+  internal typealias _UnsafeHandle = _Node.UnsafeHandle
+
+  @usableFromInline
   internal var _root: _Node
 
   @usableFromInline

--- a/Sources/_CollectionsTestSupport/Utilities/SetAPIChecker.swift
+++ b/Sources/_CollectionsTestSupport/Utilities/SetAPIChecker.swift
@@ -66,6 +66,13 @@ public protocol SetAPIChecker {
 
   mutating func formSymmetricDifference<S: Sequence>(_ other: __owned S)
   where S.Element == Element
+
+  #if false
+  // Non-standard extensions
+  func isEqual(to other: Self) -> Bool
+  public func isEqual<S: Sequence>(to other: S) -> Bool
+  where S.Element == Element
+  #endif
 }
 
 extension Set: SetAPIChecker {}

--- a/Tests/PersistentCollectionsTests/PersistentSet Tests.swift
+++ b/Tests/PersistentCollectionsTests/PersistentSet Tests.swift
@@ -12,6 +12,8 @@
 import _CollectionsTestSupport
 import PersistentCollections
 
+extension PersistentSet: SetAPIChecker {}
+
 class PersistentSetTests: CollectionTestCase {
   func test_init_empty() {
     let set = PersistentSet<Int>()
@@ -195,7 +197,7 @@ class PersistentSetTests: CollectionTestCase {
     expectEqualSets(s6.intersection(s9), [])
   }
 
-  func test_isEqual_Self_exhaustive() {
+  func test_isEqual_exhaustive() {
     withEverySubset("a", of: testItems) { a in
       let x = PersistentSet(a)
       let u = Set(a)
@@ -203,12 +205,26 @@ class PersistentSetTests: CollectionTestCase {
       withEverySubset("b", of: testItems) { b in
         let y = PersistentSet(b)
         let v = Set(b)
-        expectEqual(x.isEqual(to: y), u == v)
+
+        let reference = (u == v)
+
+        func checkSequence<S: Sequence>(
+          _ a: PersistentSet<RawCollider>,
+          _ b: S
+        ) -> Bool
+        where S.Element == RawCollider {
+          a.isEqual(to: b)
+        }
+
+        expectEqual(x.isEqual(to: y), reference)
+        expectEqual(checkSequence(x, y), reference)
+        expectEqual(x.isEqual(to: v), reference)
+        expectEqual(x.isEqual(to: b), reference)
       }
     }
   }
 
-  func test_isSubset_Self_exhaustive() {
+  func test_isSubset_exhaustive() {
     withEverySubset("a", of: testItems) { a in
       let x = PersistentSet(a)
       let u = Set(a)
@@ -216,12 +232,26 @@ class PersistentSetTests: CollectionTestCase {
       withEverySubset("b", of: testItems) { b in
         let y = PersistentSet(b)
         let v = Set(b)
-        expectEqual(x.isSubset(of: y), u.isSubset(of: v))
+
+        let reference = u.isSubset(of: v)
+
+        func checkSequence<S: Sequence>(
+          _ a: PersistentSet<RawCollider>,
+          _ b: S
+        ) -> Bool
+        where S.Element == RawCollider {
+          a.isSubset(of: b)
+        }
+
+        expectEqual(x.isSubset(of: y), reference)
+        expectEqual(checkSequence(x, y), reference)
+        expectEqual(x.isSubset(of: v), reference)
+        expectEqual(x.isSubset(of: b), reference)
       }
     }
   }
 
-  func test_isSuperset_Self_exhaustive() {
+  func test_isSuperset_exhaustive() {
     withEverySubset("a", of: testItems) { a in
       let x = PersistentSet(a)
       let u = Set(a)
@@ -229,12 +259,26 @@ class PersistentSetTests: CollectionTestCase {
       withEverySubset("b", of: testItems) { b in
         let y = PersistentSet(b)
         let v = Set(b)
-        expectEqual(x.isSuperset(of: y), u.isSuperset(of: v))
+
+        let reference = u.isSuperset(of: v)
+
+        func checkSequence<S: Sequence>(
+          _ a: PersistentSet<RawCollider>,
+          _ b: S
+        ) -> Bool
+        where S.Element == RawCollider {
+          a.isSuperset(of: b)
+        }
+
+        expectEqual(x.isSuperset(of: y), reference)
+        expectEqual(checkSequence(x, y), reference)
+        expectEqual(x.isSuperset(of: v), reference)
+        expectEqual(x.isSuperset(of: b), reference)
       }
     }
   }
 
-  func test_isStrictsubset_Self_exhaustive() {
+  func test_isStrictsubset_exhaustive() {
     withEverySubset("a", of: testItems) { a in
       let x = PersistentSet(a)
       let u = Set(a)
@@ -242,12 +286,26 @@ class PersistentSetTests: CollectionTestCase {
       withEverySubset("b", of: testItems) { b in
         let y = PersistentSet(b)
         let v = Set(b)
-        expectEqual(x.isStrictSubset(of: y), u.isStrictSubset(of: v))
+
+        let reference = u.isStrictSubset(of: v)
+
+        func checkSequence<S: Sequence>(
+          _ a: PersistentSet<RawCollider>,
+          _ b: S
+        ) -> Bool
+        where S.Element == RawCollider {
+          a.isStrictSubset(of: b)
+        }
+
+        expectEqual(x.isStrictSubset(of: y), reference)
+        expectEqual(checkSequence(x, y), reference)
+        expectEqual(x.isStrictSubset(of: v), reference)
+        expectEqual(x.isStrictSubset(of: b), reference)
       }
     }
   }
 
-  func test_isStrictSuperset_Self_exhaustive() {
+  func test_isStrictSuperset_exhaustive() {
     withEverySubset("a", of: testItems) { a in
       let x = PersistentSet(a)
       let u = Set(a)
@@ -255,12 +313,26 @@ class PersistentSetTests: CollectionTestCase {
       withEverySubset("b", of: testItems) { b in
         let y = PersistentSet(b)
         let v = Set(b)
-        expectEqual(x.isStrictSuperset(of: y), u.isStrictSuperset(of: v))
+
+        let reference = u.isStrictSuperset(of: v)
+
+        func checkSequence<S: Sequence>(
+          _ a: PersistentSet<RawCollider>,
+          _ b: S
+        ) -> Bool
+        where S.Element == RawCollider {
+          a.isStrictSuperset(of: b)
+        }
+
+        expectEqual(x.isStrictSuperset(of: y), reference)
+        expectEqual(checkSequence(x, y), reference)
+        expectEqual(x.isStrictSuperset(of: v), reference)
+        expectEqual(x.isStrictSuperset(of: b), reference)
       }
     }
   }
 
-  func test_isDisjoint_Self_exhaustive() {
+  func test_isDisjoint_exhaustive() {
     withEverySubset("a", of: testItems) { a in
       let x = PersistentSet(a)
       let u = Set(a)
@@ -268,12 +340,26 @@ class PersistentSetTests: CollectionTestCase {
       withEverySubset("b", of: testItems) { b in
         let y = PersistentSet(b)
         let v = Set(b)
-        expectEqual(x.isDisjoint(with: y), u.isDisjoint(with: v))
+
+        let reference = u.isDisjoint(with: v)
+
+        func checkSequence<S: Sequence>(
+          _ a: PersistentSet<RawCollider>,
+          _ b: S
+        ) -> Bool
+        where S.Element == RawCollider {
+          a.isDisjoint(with: b)
+        }
+
+        expectEqual(x.isDisjoint(with: y), reference)
+        expectEqual(checkSequence(x, y), reference)
+        expectEqual(x.isDisjoint(with: v), reference)
+        expectEqual(x.isDisjoint(with: b), reference)
       }
     }
   }
 
-  func test_intersection_Self_exhaustive() {
+  func test_intersection_exhaustive() {
     withEverySubset("a", of: testItems) { a in
       let x = PersistentSet(a)
       let u = Set(a)
@@ -281,12 +367,26 @@ class PersistentSetTests: CollectionTestCase {
       withEverySubset("b", of: testItems) { b in
         let y = PersistentSet(b)
         let v = Set(b)
-        expectEqualSets(x.intersection(y), u.intersection(v))
+
+        let reference = u.intersection(v)
+
+        func checkSequence<S: Sequence>(
+          _ a: PersistentSet<RawCollider>,
+          _ b: S
+        ) -> PersistentSet<RawCollider>
+        where S.Element == RawCollider {
+          a.intersection(b)
+        }
+
+        expectEqualSets(x.intersection(y), reference)
+        expectEqualSets(checkSequence(x, y), reference)
+        expectEqualSets(x.intersection(v), reference)
+        expectEqualSets(x.intersection(b), reference)
       }
     }
   }
 
-  func test_subtracting_Self_exhaustive() {
+  func test_subtracting_exhaustive() {
     withEverySubset("a", of: testItems) { a in
       let x = PersistentSet(a)
       let u = Set(a)
@@ -294,7 +394,21 @@ class PersistentSetTests: CollectionTestCase {
       withEverySubset("b", of: testItems) { b in
         let y = PersistentSet(b)
         let v = Set(b)
-        expectEqualSets(x.subtracting(y), u.subtracting(v))
+
+        let reference = u.subtracting(v)
+
+        func checkSequence<S: Sequence>(
+          _ a: PersistentSet<RawCollider>,
+          _ b: S
+        ) -> PersistentSet<RawCollider>
+        where S.Element == RawCollider {
+          a.subtracting(b)
+        }
+
+        expectEqualSets(x.subtracting(y), reference)
+        expectEqualSets(checkSequence(x, y), reference)
+        expectEqualSets(x.subtracting(v), reference)
+        expectEqualSets(x.subtracting(b), reference)
       }
     }
   }
@@ -309,7 +423,7 @@ class PersistentSetTests: CollectionTestCase {
     }
   }
 
-  func test_union_Self_exhaustive() {
+  func test_union_exhaustive() {
     withEverySubset("a", of: testItems) { a in
       let x = PersistentSet(a)
       let u = Set(a)
@@ -317,12 +431,26 @@ class PersistentSetTests: CollectionTestCase {
       withEverySubset("b", of: testItems) { b in
         let y = PersistentSet(b)
         let v = Set(b)
-        expectEqualSets(x.union(y), u.union(v))
+
+        let reference = u.union(v)
+
+        func checkSequence<S: Sequence>(
+          _ a: PersistentSet<RawCollider>,
+          _ b: S
+        ) -> PersistentSet<RawCollider>
+        where S.Element == RawCollider {
+          a.union(b)
+        }
+
+        expectEqualSets(x.union(y), reference)
+        expectEqualSets(checkSequence(x, y), reference)
+        expectEqualSets(x.union(v), reference)
+        expectEqualSets(x.union(b), reference)
       }
     }
   }
 
-  func test_symmetricDifference_Self_exhaustive() {
+  func test_symmetricDifference_exhaustive() {
     withEverySubset("a", of: testItems) { a in
       let x = PersistentSet(a)
       let u = Set(a)
@@ -330,7 +458,21 @@ class PersistentSetTests: CollectionTestCase {
       withEverySubset("b", of: testItems) { b in
         let y = PersistentSet(b)
         let v = Set(b)
-        expectEqualSets(x.symmetricDifference(y), u.symmetricDifference(v))
+
+        let reference = u.symmetricDifference(v)
+
+        func checkSequence<S: Sequence>(
+          _ a: PersistentSet<RawCollider>,
+          _ b: S
+        ) -> PersistentSet<RawCollider>
+        where S.Element == RawCollider {
+          a.symmetricDifference(b)
+        }
+
+        expectEqualSets(x.symmetricDifference(y), reference)
+        expectEqualSets(checkSequence(x, y), reference)
+        expectEqualSets(x.symmetricDifference(v), reference)
+        expectEqualSets(x.symmetricDifference(b), reference)
       }
     }
   }


### PR DESCRIPTION
This adds customary overloads and some missing customization points, making `PersistentSet` work more like what's expected of a set-like type.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
