### PR TITLE
[BitSet] Fix invariant violation in member subscript

### DIFF
--- a/Sources/BitCollections/BitSet/BitSet+Extras.swift
+++ b/Sources/BitCollections/BitSet/BitSet+Extras.swift
@@ -70,7 +70,9 @@ extension BitSet {
       } else if member > _capacity {
         return
       }
-      _update { handle in handle[member: member] = newValue }
+      _updateThenShrink { handle, shrink in
+        shrink = handle.update(member, to: newValue)
+      }
     }
   }
 

--- a/Sources/BitCollections/BitSet/BitSet._UnsafeHandle.swift
+++ b/Sources/BitCollections/BitSet/BitSet._UnsafeHandle.swift
@@ -189,13 +189,11 @@ extension BitSet._UnsafeHandle {
     return _mutableWords[index.word].remove(index.bit)
   }
 
-  subscript(member member: UInt) -> Bool {
-    get { contains(member) }
-    set {
-      ensureMutable()
-      let (w, b) = _BitPosition(member).split
-      _mutableWords[w].update(b, to: newValue)
-    }
+  internal mutating func update(_ member: UInt, to newValue: Bool) -> Bool {
+    ensureMutable()
+    let (w, b) = _BitPosition(member).split
+    _mutableWords[w].update(b, to: newValue)
+    return w == _words.count &- 1
   }
 }
 


### PR DESCRIPTION
The `BitSet.subscript(member:)` setter had an (in retrospect) obvious invariant violation when the update deleted the maximum item in the set.

(This was already covered by the existing tests, although they need to be run with internal consistency checking enabled.)

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
