### PR TITLE
Restore support for building with Swift 5.5

### DIFF
--- a/Sources/BitCollections/BitSet/BitSet._UnsafeHandle.swift
+++ b/Sources/BitCollections/BitSet/BitSet._UnsafeHandle.swift
@@ -120,8 +120,10 @@ extension BitSet._UnsafeHandle {
       var buffer: (_Word, _Word) = (.empty, .empty)
       return try withUnsafeMutablePointer(to: &buffer) { p in
         // Homogeneous tuples are layout-compatible with their component type.
-        let words = UnsafeMutableRawPointer(p).assumingMemoryBound(to: _Word.self)
-        var bitset = Self(words: words, wordCount: wordCount, mutable: true)
+        let start = UnsafeMutableRawPointer(p)
+          .assumingMemoryBound(to: _Word.self)
+        let words = UnsafeMutableBufferPointer(start: start, count: wordCount)
+        var bitset = Self(words: words, mutable: true)
         return try body(&bitset)
       }
     }

--- a/Sources/PersistentCollections/Node/_Node+Initializers.swift
+++ b/Sources/PersistentCollections/Node/_Node+Initializers.swift
@@ -84,7 +84,7 @@ extension _Node {
       itemMap: _Bitmap(bucket1, bucket2),
       childMap: .empty,
       count: 2
-    ) { children, items in
+    ) { children, items -> (_Slot, _Slot) in
       assert(items.count == 2 && children.count == 0)
       let i1 = bucket1 < bucket2 ? 1 : 0
       let i2 = 1 &- i1

--- a/Sources/PersistentCollections/Node/_Node+Primitive Removals.swift
+++ b/Sources/PersistentCollections/Node/_Node+Primitive Removals.swift
@@ -110,7 +110,7 @@ extension _Node {
   ) -> _Node {
     defer { _invariantCheck() }
     assert(!isCollisionNode)
-    let child = update {
+    let child: _Node = update {
       assert($0.childMap.contains(bucket))
       assert($0.childMap.slot(of: bucket) == slot)
       let child = $0._removeChild(at: slot)
@@ -138,7 +138,7 @@ extension _Node {
   @inlinable
   internal mutating func removeSingletonChild() -> _Node {
     defer { _invariantCheck() }
-    let child = update {
+    let child: _Node = update {
       assert($0.itemCount == 0 && $0.childCount == 1)
       let child = $0._removeChild(at: .zero)
       $0.childMap = .empty

--- a/Sources/PersistentCollections/Node/_Node+Primitive Replacement.swift
+++ b/Sources/PersistentCollections/Node/_Node+Primitive Replacement.swift
@@ -34,7 +34,7 @@ extension _Node {
   internal mutating func replaceChild(
     at bucket: _Bucket, _ slot: _Slot, with child: _Node
   ) -> Int {
-    let delta = update {
+    let delta: Int = update {
       assert(!$0.isCollisionNode)
       assert($0.childMap.contains(bucket))
       assert($0.childMap.slot(of: bucket) == slot)

--- a/Sources/PersistentCollections/Node/_Node+Storage.swift
+++ b/Sources/PersistentCollections/Node/_Node+Storage.swift
@@ -168,7 +168,7 @@ extension _Node {
     let storage = Storage.allocate(
       byteCapacity: occupiedBytes &+ extraBytes)
     var node = _Node(storage: storage, count: count)
-    let result = node.update {
+    let result: R = node.update {
       $0.itemMap = itemMap
       $0.childMap = childMap
 
@@ -202,7 +202,7 @@ extension _Node {
     assert(MemoryLayout<_Hash>.alignment <= MemoryLayout<_RawNode>.alignment)
     let storage = Storage.allocate(byteCapacity: bytes &+ extraBytes)
     var node = _Node(storage: storage, count: count)
-    let result = node.update {
+    let result: R = node.update {
       $0.itemMap = _Bitmap(bitPattern: count)
       $0.childMap = $0.itemMap
       assert(bytes <= $0.bytesFree)

--- a/Sources/PersistentCollections/Node/_Node+Structural merge.swift
+++ b/Sources/PersistentCollections/Node/_Node+Structural merge.swift
@@ -206,7 +206,7 @@ extension _Node {
         let originalItemCount = self.count
         for rs: _Slot in stride(from: .zero, to: r.itemsEndSlot, by: 1) {
           let rp = r.itemPtr(at: rs)
-          let lslot = self.read { l in
+          let lslot: _Slot? = self.read { l in
             let litems = l.reverseItems
             return litems
               .suffix(originalItemCount)
@@ -301,7 +301,7 @@ extension _Node {
       }
       if self.read({ $0.childMap.contains(bucket) }) {
         self.ensureUnique(isUnique: isUnique)
-        let delta = try self.update { l in
+        let delta: Int = try self.update { l in
           let lslot = l.childMap.slot(of: bucket)
           let h = hashPrefix.appending(bucket, at: level)
           let lchild = l.childPtr(at: lslot)

--- a/Sources/PersistentCollections/Node/_Node+Subtree Insertions.swift
+++ b/Sources/PersistentCollections/Node/_Node+Subtree Insertions.swift
@@ -427,7 +427,7 @@ extension _Node {
     itemSlot: _Slot
   ) {
     let c = self.count
-    let node = update { src in
+    let node: _Node = update { src in
       assert(!src.isCollisionNode)
       assert(src.itemMap.contains(bucket))
       assert(!src.childMap.contains(bucket))

--- a/Sources/PersistentCollections/Node/_Node+Subtree Modify.swift
+++ b/Sources/PersistentCollections/Node/_Node+Subtree Modify.swift
@@ -147,7 +147,7 @@ extension _Node {
         level, hash[level], path.currentItemSlot, by: { _ in })
     } else {
       let slot = path.childSlot(at: level)
-      let needsInlining = update {
+      let needsInlining: Bool = update {
         let child = $0.childPtr(at: slot)
         child.pointee._finalizeRemoval(level.descend(), hash, at: path)
         return child.pointee.hasSingletonItem

--- a/Sources/PersistentCollections/Node/_Node+Subtree Removals.swift
+++ b/Sources/PersistentCollections/Node/_Node+Subtree Removals.swift
@@ -33,7 +33,7 @@ extension _Node {
       return _removeItemFromUniqueLeafNode(level, bucket, r.slot) { $0.move() }
     }
 
-    let (old, needsInlining) = update {
+    let (old, needsInlining): (Element?, Bool) = update {
       let child = $0.childPtr(at: r.slot)
       let old = child.pointee.remove(level.descend(), key, hash)
       guard old != nil else { return (old, false) }
@@ -98,7 +98,7 @@ extension _Node {
         level, bucket, slot, by: { $0.move() })
     }
     let slot = path.childSlot(at: level)
-    let (item, needsInlining) = update {
+    let (item, needsInlining): (Element, Bool) = update {
       let child = $0.childPtr(at: slot)
       let item = child.pointee.remove(level.descend(), at: path)
       return (item, child.pointee.hasSingletonItem)

--- a/Sources/_CollectionsTestSupport/Utilities/DictionaryAPIChecker.swift
+++ b/Sources/_CollectionsTestSupport/Utilities/DictionaryAPIChecker.swift
@@ -14,7 +14,7 @@
 ///
 /// To ensure maximum utility, this protocol doesn't refine `Collection`,
 /// although it does share some of the same requirements.
-public protocol DictionaryAPIChecker<Key, Value> {
+public protocol DictionaryAPIChecker {
   associatedtype Key
   associatedtype Value
   associatedtype Index

--- a/Sources/_CollectionsUtilities/UnsafeMutableBufferPointer+SE-0370.swift
+++ b/Sources/_CollectionsUtilities/UnsafeMutableBufferPointer+SE-0370.swift
@@ -64,7 +64,7 @@ extension UnsafeMutableBufferPointer {
     fromContentsOf source: C
   ) -> Index
   where C.Element == Element {
-    let count = source._withContiguousStorageIfAvailable_SR14663 {
+    let count: Int? = source._withContiguousStorageIfAvailable_SR14663 {
       guard let sourceAddress = $0.baseAddress, !$0.isEmpty else {
         return 0
       }
@@ -75,7 +75,7 @@ extension UnsafeMutableBufferPointer {
       baseAddress?.initialize(from: sourceAddress, count: $0.count)
       return $0.count
     }
-    if let count {
+    if let count = count {
       return startIndex.advanced(by: count)
     }
 

--- a/Tests/PersistentCollectionsTests/PersistentCollections Fixtures.swift
+++ b/Tests/PersistentCollectionsTests/PersistentCollections Fixtures.swift
@@ -390,12 +390,15 @@ extension LifetimeTracker {
     map: PersistentDictionary<LifetimeTracked<Key>, LifetimeTracked<Value>>,
     ref: [(key: LifetimeTracked<Key>, value: LifetimeTracked<Value>)]
   ) {
-    let ref = fixture.itemsInIterationOrder.map { item in
+    typealias K = LifetimeTracked<Key>
+    typealias V = LifetimeTracked<Value>
+
+    let ref: [(key: K, value: V)] = fixture.itemsInIterationOrder.map { item in
       let key = keyTransform(item)
       let value = valueTransform(item)
       return (key: self.instance(for: key), value: self.instance(for: value))
     }
-    let ref2 = fixture.itemsInInsertionOrder.map { item in
+    let ref2: [(key: K, value: V)] = fixture.itemsInInsertionOrder.map { item in
       let key = keyTransform(item)
       let value = valueTransform(item)
       return (key: self.instance(for: key), value: self.instance(for: value))

--- a/Tests/PersistentCollectionsTests/PersistentDictionary Tests.swift
+++ b/Tests/PersistentCollectionsTests/PersistentDictionary Tests.swift
@@ -288,6 +288,7 @@ class PersistentDictionaryTests: CollectionTestCase {
     }
   }
 
+#if swift(>=5.6)
   @available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *)
   struct FancyDictionaryKey: CodingKeyRepresentable, Hashable, Codable {
     var value: Int
@@ -303,6 +304,7 @@ class PersistentDictionaryTests: CollectionTestCase {
       self.init(value)
     }
   }
+#endif
 
   struct BoringDictionaryKey: Hashable, Codable {
     var value: Int
@@ -328,6 +330,7 @@ class PersistentDictionaryTests: CollectionTestCase {
     ])
     expectEqual(try MinimalEncoder.encode(d2), v2)
 
+#if swift(>=5.6)
     if #available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *) {
       let d3: PersistentDictionary<FancyDictionaryKey, Int16> = [
         FancyDictionaryKey(1): 10, FancyDictionaryKey(2): 20
@@ -337,6 +340,7 @@ class PersistentDictionaryTests: CollectionTestCase {
       ])
       expectEqual(try MinimalEncoder.encode(d3), v3)
     }
+#endif
 
     let d4: PersistentDictionary<BoringDictionaryKey, UInt8> = [
       // Note: we only have a single element to prevent ordering
@@ -372,6 +376,7 @@ class PersistentDictionaryTests: CollectionTestCase {
       try MinimalDecoder.decode(v2, as: PD<Int, String>.self),
       d2)
 
+#if swift(>=5.6)
     if #available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *) {
       let d3: PersistentDictionary<FancyDictionaryKey, Int16> = [
         FancyDictionaryKey(1): 10, FancyDictionaryKey(2): 20
@@ -383,6 +388,7 @@ class PersistentDictionaryTests: CollectionTestCase {
         try MinimalDecoder.decode(v3, as: PD<FancyDictionaryKey, Int16>.self),
         d3)
     }
+#endif
 
     let d4: PersistentDictionary<BoringDictionaryKey, UInt8> = [
       // Note: we only have a single element to prevent ordering
@@ -404,6 +410,7 @@ class PersistentDictionaryTests: CollectionTestCase {
       expectTrue($0 is DecodingError)
     }
 
+#if swift(>=5.6)
     if #available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *) {
       let v6: MinimalEncoder.Value = .dictionary([
         "This is not a number": .string("bus"),
@@ -426,6 +433,7 @@ class PersistentDictionaryTests: CollectionTestCase {
         try MinimalDecoder.decode(v7, as: PD<FancyDictionaryKey, String>.self),
         d7)
     }
+#endif
 
     let v8: MinimalEncoder.Value = .array([
       .int32(1), .string("bike"), .int32(2),


### PR DESCRIPTION
This is mostly about adding more type declarations to deal with type checker limitations in the older compiler. This also includes workarounds that allow better support for `CodingKeyRepresentable` in `PersistentDictionary`, and it fixes a couple of small oversights on various #else branches.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
