### PR TITLE
[Draft][Heap] Use heapify algorithm for `insert(contentsOf:)`

### DIFF
--- a/Sources/HeapModule/Heap+UnsafeHandle.swift
+++ b/Sources/HeapModule/Heap+UnsafeHandle.swift
@@ -367,6 +367,39 @@ extension Heap._UnsafeHandle {
   }
 
   @inlinable
+  internal func heapify(from start: Int) {
+    // This is Floyd's linear-time heap construction algorithm,
+    // assuming that items up to `start` already form a heap.
+
+    guard start < count else { return }
+    let limit = count / 2 // The first offset without a left child
+    guard start > limit else {
+      heapify()
+      return
+    }
+    var startNode = _Node(offset: start)
+    var endNode = _Node(offset: count - 1)
+    if startNode.level != endNode.level {
+      endNode = endNode.parent()
+      assert(startNode.level == endNode.level)
+      assert(startNode.offset > endNode.offset)
+    }
+    while true {
+      if let nodes = _Node.allNodes(onLevel: startNode.level, limit: limit) {
+        if startNode <= endNode {
+          _heapify(startNode.level, nodes._from(startNode)?._upThrough(endNode))
+        } else {
+          _heapify(startNode.level, nodes._upTo(startNode))
+          _heapify(startNode.level, nodes._from(endNode))
+        }
+      }
+      guard startNode.level > 0 else { break }
+      startNode = startNode.parent()
+      endNode = endNode.parent()
+    }
+  }
+
+  @inlinable
   internal func _heapify(_ level: Int, _ nodes: ClosedRange<_Node>?) {
     guard let nodes = nodes else { return }
     if _Node.isMinLevel(level) {

--- a/Sources/HeapModule/Heap.swift
+++ b/Sources/HeapModule/Heap.swift
@@ -264,9 +264,11 @@ extension Heap {
       self = Self(newElements)
       return
     }
-    _storage.reserveCapacity(count + newElements.underestimatedCount)
-    for element in newElements {
-      insert(element)
+    let start = _storage.count
+    _storage.append(contentsOf: newElements)
+    _update { handle in
+      handle.heapify(from: start)
     }
+    _checkInvariants()
   }
 }

--- a/Sources/HeapModule/_Node.swift
+++ b/Sources/HeapModule/_Node.swift
@@ -171,4 +171,26 @@ extension ClosedRange where Bound == _Node {
       node.offset &+= 1
     }
   }
+
+  @inlinable
+  internal func _from(_ start: _Node) -> ClosedRange? {
+    guard self.upperBound >= start else { return nil }
+    guard self.lowerBound < start else { return self }
+    return ClosedRange(uncheckedBounds: (start, upperBound))
+  }
+
+  @inlinable
+  internal func _upThrough(_ end: _Node) -> ClosedRange? {
+    guard self.lowerBound <= end else { return nil }
+    guard self.upperBound > end else { return self }
+    return ClosedRange(uncheckedBounds: (lowerBound, end))
+  }
+
+  @inlinable
+  internal func _upTo(_ end: _Node) -> ClosedRange? {
+    guard self.lowerBound < end else { return nil }
+    guard self.upperBound >= end else { return self }
+    let last = _Node(offset: end.offset &- 1, level: end.level)
+    return ClosedRange(uncheckedBounds: (lowerBound, last))
+  }
 }


### PR DESCRIPTION
Use Floyd’s heapify algorithm to implement `insert(contentsOf:)`.

This isn’t necessarily a net benefit over inserting elements one by one — I believe this will depend on how many items we’re inserting. So there is analysis/benchmarking work still to be done; let's park this PR for now, until those can be done.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
