### PR TITLE
[OrderedSet, BitSet] Fix custom mirror display style

### DIFF
--- a/Sources/BitCollections/BitSet/BitSet+CustomReflectable.swift
+++ b/Sources/BitCollections/BitSet/BitSet+CustomReflectable.swift
@@ -12,6 +12,6 @@
 extension BitSet: CustomReflectable {
   /// The custom mirror for this instance.
   public var customMirror: Mirror {
-    Mirror(self, unlabeledChildren: self, displayStyle: .collection)
+    Mirror(self, unlabeledChildren: self, displayStyle: .set)
   }
 }

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+CustomReflectable.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+CustomReflectable.swift
@@ -12,6 +12,6 @@
 extension OrderedSet: CustomReflectable {
   /// The custom mirror for this instance.
   public var customMirror: Mirror {
-    Mirror(self, unlabeledChildren: _elements, displayStyle: .collection)
+    Mirror(self, unlabeledChildren: _elements, displayStyle: .set)
   }
 }

--- a/Tests/BitCollectionsTests/BitSetTests.swift
+++ b/Tests/BitCollectionsTests/BitSetTests.swift
@@ -1526,12 +1526,12 @@ final class BitSetTest: CollectionTestCase {
     }
 
     expectEqual(check(BitSet()), """
-      - 0 elements
+      - 0 members
 
       """)
 
     expectEqual(check([1, 2, 3] as BitSet), """
-      ▿ 3 elements
+      ▿ 3 members
         - 1
         - 2
         - 3

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -168,7 +168,7 @@ class OrderedSetTests: CollectionTestCase {
     do {
       let set: OrderedSet<Int> = [1, 2, 3]
       let mirror = Mirror(reflecting: set)
-      expectEqual(mirror.displayStyle, .collection)
+      expectEqual(mirror.displayStyle, .set)
       expectNil(mirror.superclassMirror)
       expectTrue(mirror.children.compactMap { $0.label }.isEmpty) // No label
       expectEqualElements(mirror.children.map { $0.value as? Int }, set.map { $0 })


### PR DESCRIPTION
These are set types, so their custom mirrors should have the `.set` display style, not `.collection`.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
