### PR TITLE
[TreeDictionary] Fix in-place merge operation to properly update the count

### DIFF
--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Filter.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Filter.swift
@@ -26,7 +26,9 @@ extension TreeDictionary {
   ) rethrows -> Self {
     let result = try _root.filter(.top, isIncluded)
     guard let result = result else { return self }
-    return TreeDictionary(_new: result.finalize(.top))
+    let r = TreeDictionary(_new: result.finalize(.top))
+    r._invariantCheck()
+    return r
   }
 
   /// Removes all the elements that satisfy the given predicate.

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Initializers.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Initializers.swift
@@ -300,5 +300,6 @@ extension TreeDictionary {
         array.append(value)
       }
     }
+    _invariantCheck()
   }
 }

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Keys.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Keys.swift
@@ -209,7 +209,9 @@ extension TreeDictionary.Keys {
     guard let r = _base._root.intersection(.top, other._base._root) else {
       return self
     }
-    return TreeDictionary(_new: r).keys
+    let d = TreeDictionary(_new: r)
+    d._invariantCheck()
+    return d.keys
   }
 
   /// Returns a new keys view with the elements that are common to both this
@@ -235,7 +237,9 @@ extension TreeDictionary.Keys {
     guard let r = _base._root.intersection(.top, other._root) else {
       return self
     }
-    return TreeDictionary(_new: r).keys
+    let d = TreeDictionary(_new: r)
+    d._invariantCheck()
+    return d.keys
   }
 
   /// Returns a new keys view containing the elements of `self` that do not
@@ -260,7 +264,9 @@ extension TreeDictionary.Keys {
     guard let r = _base._root.subtracting(.top, other._base._root) else {
       return self
     }
-    return TreeDictionary(_new: r).keys
+    let d = TreeDictionary(_new: r)
+    d._invariantCheck()
+    return d.keys
   }
 
   /// Returns a new keys view containing the elements of `self` that do not
@@ -282,6 +288,8 @@ extension TreeDictionary.Keys {
     guard let r = _base._root.subtracting(.top, other._root) else {
       return self
     }
-    return TreeDictionary(_new: r).keys
+    let d = TreeDictionary(_new: r)
+    d._invariantCheck()
+    return d.keys
   }
 }

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+MapValues.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+MapValues.swift
@@ -25,7 +25,9 @@ extension TreeDictionary {
     _ transform: (Value) throws -> T
   ) rethrows -> TreeDictionary<Key, T> {
     let transformed = try _root.mapValues { try transform($0.value) }
-    return TreeDictionary<Key, T>(_new: transformed)
+    let r = TreeDictionary<Key, T>(_new: transformed)
+    r._invariantCheck()
+    return r
   }
 
   /// Returns a new dictionary containing only the key-value pairs that have
@@ -59,6 +61,8 @@ extension TreeDictionary {
     _ transform: (Value) throws -> T?
   ) rethrows -> TreeDictionary<Key, T> {
     let result = try _root.compactMapValues(.top, transform)
-    return TreeDictionary<Key, T>(_new: result.finalize(.top))
+    let d = TreeDictionary<Key, T>(_new: result.finalize(.top))
+    d._invariantCheck()
+    return d
   }
 }

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Merge.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Merge.swift
@@ -43,7 +43,8 @@ extension TreeDictionary {
     uniquingKeysWith combine: (Value, Value) throws -> Value
   ) rethrows {
     _invalidateIndices()
-    try _root.merge(.top, keysAndValues._root, combine)
+    _ = try _root.merge(.top, keysAndValues._root, combine)
+    _invariantCheck()
   }
 
   /// Merges the key-value pairs in the given sequence into the dictionary,
@@ -87,6 +88,7 @@ extension TreeDictionary {
         }
       }
     }
+    _invariantCheck()
   }
 
   /// Merges the key-value pairs in the given sequence into the dictionary,

--- a/Tests/HashTreeCollectionsTests/Utilities.swift
+++ b/Tests/HashTreeCollectionsTests/Utilities.swift
@@ -206,6 +206,7 @@ func expectEqualDictionaries<Key: Hashable, Value: Equatable>(
   file: StaticString = #file,
   line: UInt = #line
 ) {
+  expectEqual(map.count, dict.count, "Mismatching count", file: file, line: line)
   var dict = dict
   var seen: Set<Key> = []
   var mismatches: [(key: Key, map: Value?, dict: Value?)] = []


### PR DESCRIPTION
The in-place dictionary merge operation fails to update the count of the dictionary, leaving it in an invalid state.

Fix this and also add the missing calls to `_invariantCheck` (here and elsewhere) that would've caught this much earlier. D'oh!

rdar://102824928

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
