### PR TITLE
[OrderedDictionary] Explicitly mention in documentation that keys/values are ordered

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
@@ -159,7 +159,7 @@
 /// original dictionary value.)
 ///
 /// The ``values-swift.property`` collection is a mutable random-access
-/// collection of the values in the dictionary:
+/// ordered collection of the values in the dictionary:
 ///
 ///     d.values // "two", "one", "zero"
 ///     d.values[2] = "nada"
@@ -219,7 +219,7 @@ public struct OrderedDictionary<Key: Hashable, Value> {
 }
 
 extension OrderedDictionary {
-  /// A read-only collection view for the keys contained in this dictionary, as
+  /// A read-only ordered collection view for the keys contained in this dictionary, as
   /// an `OrderedSet`.
   ///
   /// - Complexity: O(1)
@@ -227,7 +227,7 @@ extension OrderedDictionary {
   @inline(__always)
   public var keys: OrderedSet<Key> { _keys }
 
-  /// A mutable collection view containing the values in this dictionary.
+  /// A mutable collection view containing the ordered values in this dictionary.
   ///
   /// - Complexity: O(1)
   @inlinable


### PR DESCRIPTION
It currently takes some mental gymnastics or deep data structures background to grok if OrderedDictionary's keys and values are ordered. These minor additions to the docs make that more explicit. If this sort of change is welcome I'm happy to clarify some of the other data structures as well. 

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [n/a] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [n/a] I've added benchmarks covering new functionality (if appropriate).
- [n/a] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
