### PR TITLE
Fix off by one error in BitSet

### DIFF
--- a/Sources/BitCollections/BitSet/BitSet+Extras.swift
+++ b/Sources/BitCollections/BitSet/BitSet+Extras.swift
@@ -69,7 +69,7 @@ extension BitSet {
       }
       if newValue {
         _ensureCapacity(forValue: member)
-      } else if member > _capacity {
+      } else if member >= _capacity {
         return
       }
       _updateThenShrink { handle, shrink in


### PR DESCRIPTION
This was caught by the newly randomized testing that was enabled in 4849d54.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
