### PR TITLE
Fix deprecated UnsafeMutablePointer.assign(repeating:count) method

### DIFF
--- a/Sources/OrderedCollections/HashTable/_HashTable+UnsafeHandle.swift
+++ b/Sources/OrderedCollections/HashTable/_HashTable+UnsafeHandle.swift
@@ -484,7 +484,11 @@ extension _UnsafeHashTable {
   @usableFromInline
   internal func clear() {
     assertMutable()
+    #if swift(>=5.8)
+    _buckets.update(repeating: 0, count: wordCount)
+    #else
     _buckets.assign(repeating: 0, count: wordCount)
+    #endif
   }
 }
 

--- a/Sources/OrderedCollections/Utilities/_UnsafeBitset.swift
+++ b/Sources/OrderedCollections/Utilities/_UnsafeBitset.swift
@@ -184,7 +184,11 @@ extension _UnsafeBitset {
   @_effects(releasenone)
   internal mutating func clear() {
     guard _words.count > 0 else { return }
+    #if swift(>=5.8)
+    _words.baseAddress!.update(repeating: .empty, count: _words.count)
+    #else
     _words.baseAddress!.assign(repeating: .empty, count: _words.count)
+    #endif
     _count = 0
   }
 


### PR DESCRIPTION
Upgrading to Xcode 14.3/Swift 5.8 results in 2 deprecation warnings caused by [SE-0370](https://github.com/apple/swift-evolution/blob/main/proposals/0370-pointer-family-initialization-improvements.md):
<img width="1078" alt="Screenshot 2023-03-29 at 17 30 47" src="https://user-images.githubusercontent.com/42500484/228615122-e359e368-2bfb-4027-b047-52e3aa9e35a8.png">

I have:
- replaced the deprecated method with the new one wrapped inside a swift version directive
- tested it with Xcode 14.3 (Swift 5.8) and Xcode 14.2 (Swift 5.7.2)

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
