### PR TITLE
Expose a handful of BigString.Index methods

### DIFF
--- a/Sources/RopeModule/BigString/Basics/BigString+Index.swift
+++ b/Sources/RopeModule/BigString/Basics/BigString+Index.swift
@@ -119,7 +119,7 @@ extension BigString.Index {
     _flags = 0
   }
 
-  internal var _isUTF16TrailingSurrogate: Bool {
+  public var _isUTF16TrailingSurrogate: Bool {
     _orderingValue & 1 != 0
   }
 
@@ -135,20 +135,20 @@ extension BigString.Index {
     return copy
   }
 
-  internal var _isKnownScalarAligned: Bool {
+  public var _isKnownScalarAligned: Bool {
     _rawBits & Self._scalarAlignmentBit != 0
   }
 
-  internal var _isKnownCharacterAligned: Bool {
+  public var _isKnownCharacterAligned: Bool {
     _rawBits & Self._characterAlignmentBit != 0
   }
 
-  internal init(_utf8Offset: Int) {
+  public init(_utf8Offset: Int) {
     _rawBits = Self._bitsForUTF8Offset(_utf8Offset)
     _rope = nil
   }
 
-  internal init(_utf8Offset: Int, utf16TrailingSurrogate: Bool) {
+  public init(_utf8Offset: Int, utf16TrailingSurrogate: Bool) {
     _rawBits = Self._bitsForUTF8Offset(_utf8Offset)
     if utf16TrailingSurrogate {
       _rawBits |= Self._utf16TrailingSurrogateBits


### PR DESCRIPTION
These help implementing conversions between `String.Index` and `BigString.Index`. Direct index conversions without the corresponding collection values aren't legitimate, but unfortunately they are sometimes necessary.

rdar://107778676

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
