### PR TITLE
Make most of Rope inlinable

### DIFF
--- a/Sources/HashTreeCollections/HashNode/_HashNode+Builder.swift
+++ b/Sources/HashTreeCollections/HashNode/_HashNode+Builder.swift
@@ -13,7 +13,7 @@ extension _HashNode {
   @usableFromInline
   @frozen
   internal struct Builder {
-    @usableFromInline typealias Element = _HashNode.Element
+    @usableFromInline internal typealias Element = _HashNode.Element
 
     @usableFromInline
     @frozen

--- a/Sources/RopeModule/Rope/Basics/Rope+Debugging.swift
+++ b/Sources/RopeModule/Rope/Basics/Rope+Debugging.swift
@@ -14,19 +14,22 @@ import _CollectionsUtilities
 #endif
 
 extension Rope._UnmanagedLeaf: CustomStringConvertible {
-  var description: String {
+  @usableFromInline
+  internal var description: String {
     _addressString(for: _ref.toOpaque())
   }
 }
 
 extension Rope {
+  @inlinable
   public var _nodeCount: Int {
     _root?.nodeCount ?? 0
   }
 }
 
 extension Rope._Node {
-  var nodeCount: Int {
+  @inlinable
+  internal var nodeCount: Int {
     guard !isLeaf else { return 1 }
     return readInner { $0.children.reduce(into: 1) { $0 += $1.nodeCount } }
   }
@@ -47,7 +50,8 @@ extension Rope {
 }
 
 extension Rope._Node: CustomStringConvertible {
-  var description: String {
+  @usableFromInline
+  internal var description: String {
         """
         \(height > 0 ? "Inner@\(height)" : "Leaf")(\
         at: \(_addressString(for: object)), \
@@ -58,6 +62,7 @@ extension Rope._Node: CustomStringConvertible {
 }
 
 extension Rope._Node {
+  @usableFromInline
   internal func dump(
     heightLimit: Int = .max,
     firstPrefix: String = "",

--- a/Sources/RopeModule/Rope/Basics/Rope+Invariants.swift
+++ b/Sources/RopeModule/Rope/Basics/Rope+Invariants.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Rope {
+  @inlinable @inline(__always)
   public func _invariantCheck() {
 #if COLLECTIONS_INTERNAL_CHECKS
     _root?.invariantCheck(depth: 0, height: root.height, recursive: true)
@@ -18,8 +19,9 @@ extension Rope {
 }
 
 extension Rope._Node {
-  func invariantCheck(depth: UInt8, height: UInt8, recursive: Bool = true) {
 #if COLLECTIONS_INTERNAL_CHECKS
+  @usableFromInline
+  internal func invariantCheck(depth: UInt8, height: UInt8, recursive: Bool = true) {
     precondition(height == self.height, "Mismatching rope height")
     if isLeaf {
       precondition(self.childCount <= Summary.maxNodeSize, "Oversized leaf")
@@ -58,6 +60,11 @@ extension Rope._Node {
         child.invariantCheck(depth: depth + 1, height: height - 1, recursive: true)
       }
     }
-#endif
   }
+#else
+  @inlinable @inline(__always)
+  internal func invariantCheck(depth: UInt8, height: UInt8, recursive: Bool = true) {
+    // Do nothing.
+  }
+#endif
 }

--- a/Sources/RopeModule/Rope/Basics/Rope+_Storage.swift
+++ b/Sources/RopeModule/Rope/Basics/Rope+_Storage.swift
@@ -9,16 +9,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+@usableFromInline
 internal struct _RopeStorageHeader {
-  var _childCount: UInt16
-  let height: UInt8
-  
-  init(height: UInt8) {
+  @usableFromInline var _childCount: UInt16
+  @usableFromInline let height: UInt8
+
+  @inlinable
+  internal init(height: UInt8) {
     self._childCount = 0
     self.height = height
   }
-  
-  var childCount: Int {
+
+  @inlinable
+  internal var childCount: Int {
     get {
       numericCast(_childCount)
     }
@@ -29,15 +32,20 @@ internal struct _RopeStorageHeader {
 }
 
 extension Rope {
-  final class _Storage<Child: _RopeItem<Summary>>: ManagedBuffer<_RopeStorageHeader, Child> {
-    typealias Summary = Element.Summary
-    typealias _UnsafeHandle = Rope._UnsafeHandle
-    
-    static func create(height: UInt8) -> _Storage {
+  @usableFromInline
+  internal final class _Storage<Child: _RopeItem<Summary>>:
+    ManagedBuffer<_RopeStorageHeader, Child>
+  {
+    @usableFromInline internal typealias Summary = Element.Summary
+    @usableFromInline internal typealias _UnsafeHandle = Rope._UnsafeHandle
+
+    @inlinable
+    internal static func create(height: UInt8) -> _Storage {
       let object = create(minimumCapacity: Summary.maxNodeSize) { _ in .init(height: height) }
       return unsafeDowncast(object, to: _Storage.self)
     }
-    
+
+    @inlinable
     deinit {
       withUnsafeMutablePointers { h, p in
         p.deinitialize(count: h.pointee.childCount)

--- a/Sources/RopeModule/Rope/Basics/Rope+_UnmanagedLeaf.swift
+++ b/Sources/RopeModule/Rope/Basics/Rope+_UnmanagedLeaf.swift
@@ -10,27 +10,31 @@
 //===----------------------------------------------------------------------===//
 
 extension Rope {
+  @usableFromInline
   internal struct _UnmanagedLeaf {
-    typealias _Item = Rope._Item
-    typealias _Leaf = _Storage<_Item>
-    typealias _UnsafeHandle = Rope._UnsafeHandle
+    @usableFromInline internal typealias _Item = Rope._Item
+    @usableFromInline internal typealias _Leaf = _Storage<_Item>
+    @usableFromInline internal typealias _UnsafeHandle = Rope._UnsafeHandle
 
-    var _ref: Unmanaged<_Leaf>
+    @usableFromInline var _ref: Unmanaged<_Leaf>
 
-    init(_ leaf: __shared _Leaf) {
+    @inlinable
+    internal init(_ leaf: __shared _Leaf) {
       _ref = .passUnretained(leaf)
     }
   }
 }
 
 extension Rope._UnmanagedLeaf: Equatable {
-  static func ==(left: Self, right: Self) -> Bool {
+  @inlinable
+  internal static func ==(left: Self, right: Self) -> Bool {
     left._ref.toOpaque() == right._ref.toOpaque()
   }
 }
 
 extension Rope._UnmanagedLeaf {
-  func read<R>(
+  @inlinable
+  internal func read<R>(
     body: (_UnsafeHandle<_Item>) -> R
   ) -> R {
     _ref._withUnsafeGuaranteedRef { leaf in

--- a/Sources/RopeModule/Rope/Basics/Rope.swift
+++ b/Sources/RopeModule/Rope/Basics/Rope.swift
@@ -13,24 +13,31 @@
 /// The rope is augmented by the commutative group specified by `Element.Summary`, enabling
 /// quick lookup operations.
 public struct Rope<Element: RopeElement> {
-  var _root: _Node?
-  var _version: _RopeVersion
+  @usableFromInline
+  internal var _root: _Node?
 
+  @usableFromInline
+  internal var _version: _RopeVersion
+
+  @inlinable
   public init() {
     self._root = nil
     self._version = _RopeVersion()
   }
-  
-  init(root: _Node?) {
+
+  @inlinable
+  internal init(root: _Node?) {
     self._root = root
     self._version = _RopeVersion()
   }
 
-  var root: _Node {
-    get { _root.unsafelyUnwrapped }
+  @inlinable
+  internal var root: _Node {
+    @inline(__always) get { _root.unsafelyUnwrapped }
     @inline(__always) _modify { yield &_root! }
   }
-  
+
+  @inlinable
   public init(_ value: Element) {
     self._root = .createLeaf(_Item(value))
     self._version = _RopeVersion()
@@ -40,13 +47,15 @@ public struct Rope<Element: RopeElement> {
 extension Rope: Sendable where Element: Sendable {}
 
 extension Rope {
-  mutating func _ensureUnique() {
+  @inlinable
+  internal mutating func _ensureUnique() {
     guard _root != nil else { return }
     root.ensureUnique()
   }
 }
 
 extension Rope {
+  @inlinable
   public var isSingleton: Bool {
     guard _root != nil else { return false }
     return root.isSingleton
@@ -54,6 +63,7 @@ extension Rope {
 }
 
 extension Rope {
+  @inlinable
   public func isIdentical(to other: Self) -> Bool {
     self._root?.object === other._root?.object
   }

--- a/Sources/RopeModule/Rope/Basics/RopeMetric.swift
+++ b/Sources/RopeModule/Rope/Basics/RopeMetric.swift
@@ -17,7 +17,7 @@ public protocol RopeMetric<Element>: Sendable {
 }
 
 extension RopeMetric {
-  @inline(__always)
+  @inlinable @inline(__always)
   internal func _nonnegativeSize(of summary: Element.Summary) -> Int {
     let r = size(of: summary)
     assert(r >= 0)

--- a/Sources/RopeModule/Rope/Basics/_RopeItem.swift
+++ b/Sources/RopeModule/Rope/Basics/_RopeItem.swift
@@ -14,6 +14,7 @@
 /// Used as an implementation detail to increase code reuse across internal nodes and leaf nodes.
 /// (Ideally `Rope._Node` would just conform to the full `RopeElement` protocol on its own, but
 /// while that's an obvious refactoring idea, it hasn't happened yet.)
+@usableFromInline
 internal protocol _RopeItem<Summary> {
   associatedtype Summary: RopeSummary
 
@@ -21,7 +22,8 @@ internal protocol _RopeItem<Summary> {
 }
 
 extension Sequence where Element: _RopeItem {
-  func _sum() -> Element.Summary {
+  @inlinable
+  internal func _sum() -> Element.Summary {
     self.reduce(into: .zero) { $0.add($1.summary) }
   }
 }
@@ -29,6 +31,7 @@ extension Sequence where Element: _RopeItem {
 extension Rope: _RopeItem {
   public typealias Summary = Element.Summary
 
+  @inlinable
   public var summary: Summary {
     guard _root != nil else { return .zero }
     return root.summary
@@ -38,35 +41,50 @@ extension Rope: _RopeItem {
 extension Rope {
   /// A trivial wrapper around a rope's Element type, giving it `_RopeItem` conformance without
   /// having to make the protocol public.
+  @usableFromInline
   internal struct _Item {
-    var value: Element
-    init(_ value: Element) { self.value = value }
+    @usableFromInline internal var value: Element
+
+    @inlinable
+    internal init(_ value: Element) { self.value = value }
   }
 }
 
 extension Rope._Item: _RopeItem {
-  typealias Summary = Rope.Summary
-  var summary: Summary { value.summary }
+  @usableFromInline internal typealias Summary = Rope.Summary
+
+  @inlinable
+  internal var summary: Summary { value.summary }
 }
 
 extension Rope._Item: CustomStringConvertible {
-  var description: String {
+  @usableFromInline
+  internal var description: String {
     "\(value)"
   }
 }
 
 extension Rope._Item {
-  var isEmpty: Bool { value.isEmpty }
-  var isUndersized: Bool { value.isUndersized }
-  mutating func rebalance(nextNeighbor right: inout Self) -> Bool {
+  @inlinable
+  internal var isEmpty: Bool { value.isEmpty }
+
+  @inlinable
+  internal var isUndersized: Bool { value.isUndersized }
+
+  @inlinable
+  internal mutating func rebalance(nextNeighbor right: inout Self) -> Bool {
     value.rebalance(nextNeighbor: &right.value)
   }
-  mutating func rebalance(prevNeighbor left: inout Self) -> Bool {
+
+  @inlinable
+  internal mutating func rebalance(prevNeighbor left: inout Self) -> Bool {
     value.rebalance(prevNeighbor: &left.value)
   }
 
-  typealias Index = Element.Index
-  mutating func split(at index: Index) -> Self {
+  @usableFromInline internal typealias Index = Element.Index
+
+  @inlinable
+  internal mutating func split(at index: Index) -> Self {
     Self(self.value.split(at: index))
   }
 }

--- a/Sources/RopeModule/Rope/Basics/_RopePath.swift
+++ b/Sources/RopeModule/Rope/Basics/_RopePath.swift
@@ -9,50 +9,58 @@
 //
 //===----------------------------------------------------------------------===//
 
+@usableFromInline
+@frozen // Not really! This module isn't ABI stable
 internal struct _RopePath<Summary: RopeSummary> {
   // ┌──────────────────────────────────┬────────┐
   // │ b63:b8                           │ b7:b0  │
   // ├──────────────────────────────────┼────────┤
   // │ path                             │ height │
   // └──────────────────────────────────┴────────┘
-  var _value: UInt64
+  @usableFromInline internal var _value: UInt64
 
-  @inline(__always)
-  static var _pathBitWidth: Int { 56 }
+  @inlinable @inline(__always)
+  internal static var _pathBitWidth: Int { 56 }
 
-  init(_value: UInt64) {
+  @inlinable
+  internal init(_value: UInt64) {
     self._value = _value
   }
 
-  init(height: UInt8) {
+  @inlinable
+  internal init(height: UInt8) {
     self._value = UInt64(truncatingIfNeeded: height)
     assert((Int(height) + 1) * Summary.nodeSizeBitWidth <= Self._pathBitWidth)
   }
 }
 
 extension Rope {
-  typealias _Path = _RopePath<Summary>
+  @usableFromInline internal typealias _Path = _RopePath<Summary>
 }
 
 extension _RopePath: Equatable {
-  static func ==(left: Self, right: Self) -> Bool {
+  @inlinable
+  internal static func ==(left: Self, right: Self) -> Bool {
     left._value == right._value
   }
 }
 extension _RopePath: Hashable {
-  func hash(into hasher: inout Hasher) {
+  @inlinable
+  internal func hash(into hasher: inout Hasher) {
     hasher.combine(_value)
   }
 }
 
 extension _RopePath: Comparable {
-  static func <(left: Self, right: Self) -> Bool {
+  @inlinable
+  internal static func <(left: Self, right: Self) -> Bool {
     left._value < right._value
   }
 }
 
 extension _RopePath: CustomStringConvertible {
-  var description: String {
+  @usableFromInline
+  internal var description: String {
     var r = "<"
     for h in stride(from: height, through: 0, by: -1) {
       r += "\(self[h])"
@@ -64,11 +72,13 @@ extension _RopePath: CustomStringConvertible {
 }
 
 extension _RopePath {
-  var height: UInt8 {
+  @inlinable
+  internal var height: UInt8 {
     UInt8(truncatingIfNeeded: _value)
   }
 
-  subscript(height: UInt8) -> Int {
+  @inlinable
+  internal subscript(height: UInt8) -> Int {
     get {
       assert(height <= self.height)
       let shift = 8 + Int(height) * Summary.nodeSizeBitWidth
@@ -85,14 +95,16 @@ extension _RopePath {
     }
   }
 
-  func isEmpty(below height: UInt8) -> Bool {
+  @inlinable
+  internal func isEmpty(below height: UInt8) -> Bool {
     let shift = Int(height) * Summary.nodeSizeBitWidth
     assert(shift + Summary.nodeSizeBitWidth <= Self._pathBitWidth)
     let mask: UInt64 = ((1 &<< shift) - 1) &<< 8
     return (_value & mask) == 0
   }
 
-  mutating func clear(below height: UInt8) {
+  @inlinable
+  internal mutating func clear(below height: UInt8) {
     let shift = Int(height) * Summary.nodeSizeBitWidth
     assert(shift + Summary.nodeSizeBitWidth <= Self._pathBitWidth)
     let mask: UInt64 = ((1 &<< shift) - 1) &<< 8

--- a/Sources/RopeModule/Rope/Basics/_RopeVersion.swift
+++ b/Sources/RopeModule/Rope/Basics/_RopeVersion.swift
@@ -9,32 +9,39 @@
 //
 //===----------------------------------------------------------------------===//
 
+@usableFromInline
+@frozen // Not really! This module isn't ABI stable.
 internal struct _RopeVersion {
   // FIXME: Replace this probabilistic mess with atomics when Swift gets its act together.
-  var _value: UInt
+  @usableFromInline internal var _value: UInt
 
-  init() {
+  @inlinable
+  internal init() {
     var rng = SystemRandomNumberGenerator()
     _value = rng.next()
   }
 
-  init(_ value: UInt) {
+  @inlinable
+  internal init(_ value: UInt) {
     self._value = value
   }
 }
 
 extension _RopeVersion: Equatable {
-  static func ==(left: Self, right: Self) -> Bool {
+  @inlinable
+  internal static func ==(left: Self, right: Self) -> Bool {
     left._value == right._value
   }
 }
 
 extension _RopeVersion {
-  mutating func bump() {
+  @inlinable
+  internal mutating func bump() {
     _value &+= 1
   }
 
-  mutating func reset() {
+  @inlinable
+  internal mutating func reset() {
     var rng = SystemRandomNumberGenerator()
     _value = rng.next()
   }

--- a/Sources/RopeModule/Rope/Conformances/Rope+Index.swift
+++ b/Sources/RopeModule/Rope/Conformances/Rope+Index.swift
@@ -10,18 +10,27 @@
 //===----------------------------------------------------------------------===//
 
 extension Rope {
+  @frozen // Not really! This module isn't ABI stable.
   public struct Index: @unchecked Sendable {
-    typealias Summary = Rope.Summary
-    typealias _Path = Rope._Path
+    @usableFromInline internal typealias Summary = Rope.Summary
+    @usableFromInline internal typealias _Path = Rope._Path
 
-    var _version: _RopeVersion
-    var _path: _Path
+    @usableFromInline
+    internal var _version: _RopeVersion
+
+    @usableFromInline
+    internal var _path: _Path
+
     /// A direct reference to the leaf node addressed by this index.
     /// This must only be dereferenced while we own a tree with a matching
     /// version.
-    var _leaf: _UnmanagedLeaf?
+    @usableFromInline
+    internal var _leaf: _UnmanagedLeaf?
 
-    init(version: _RopeVersion, path: _Path, leaf: __shared _UnmanagedLeaf?) {
+    @inlinable
+    internal init(
+      version: _RopeVersion, path: _Path, leaf: __shared _UnmanagedLeaf?
+    ) {
       self._version = version
       self._path = path
       self._leaf = leaf
@@ -30,27 +39,32 @@ extension Rope {
 }
 
 extension Rope.Index {
-  static var _invalid: Self {
+  @inlinable
+  internal static var _invalid: Self {
     Self(version: _RopeVersion(0), path: _RopePath(_value: .max), leaf: nil)
   }
 
-  var _isValid: Bool {
+  @inlinable
+  internal var _isValid: Bool {
     _path._value != .max
   }
 }
 
 extension Rope.Index: Equatable {
+  @inlinable
   public static func ==(left: Self, right: Self) -> Bool {
     left._path == right._path
   }
 }
 extension Rope.Index: Hashable {
+  @inlinable
   public func hash(into hasher: inout Hasher) {
     hasher.combine(_path)
   }
 }
 
 extension Rope.Index: Comparable {
+  @inlinable
   public static func <(left: Self, right: Self) -> Bool {
     left._path < right._path
   }
@@ -63,15 +77,18 @@ extension Rope.Index: CustomStringConvertible {
 }
 
 extension Rope.Index {
-  var _height: UInt8 {
+  @inlinable
+  internal var _height: UInt8 {
     _path.height
   }
 
-  func _isEmpty(below height: UInt8) -> Bool {
+  @inlinable
+  internal func _isEmpty(below height: UInt8) -> Bool {
     _path.isEmpty(below: height)
   }
 
-  mutating func _clear(below height: UInt8) {
+  @inlinable
+  internal mutating func _clear(below height: UInt8) {
     _path.clear(below: height)
   }
 }

--- a/Sources/RopeModule/Rope/Conformances/Rope+Sequence.swift
+++ b/Sources/RopeModule/Rope/Conformances/Rope+Sequence.swift
@@ -10,29 +10,37 @@
 //===----------------------------------------------------------------------===//
 
 extension Rope: Sequence {
+  @inlinable
   public func makeIterator() -> Iterator {
     Iterator(self, from: self.startIndex)
   }
-  
+
+  @inlinable
   public func makeIterator(from start: Index) -> Iterator {
     Iterator(self, from: start)
   }
-  
-  public struct Iterator: IteratorProtocol {
-    let rope: Rope
-    private(set) var index: Index
 
-    init(_ rope: Rope, from start: Index) {
+  @frozen // Not really! This module isn't ABI stable.
+  public struct Iterator: IteratorProtocol {
+    @usableFromInline
+    internal let _rope: Rope
+
+    @usableFromInline
+    internal var _index: Index
+
+    @inlinable
+    internal init(_ rope: Rope, from start: Index) {
       rope.validate(start)
-      self.rope = rope
-      self.index = start
-      self.rope.grease(&index)
+      self._rope = rope
+      self._index = start
+      self._rope.grease(&_index)
     }
-    
+
+    @inlinable
     public mutating func next() -> Element? {
-      guard let leaf = index._leaf else { return nil }
-      let item = leaf.read { $0.children[index._path[0]].value }
-      rope.formIndex(after: &index)
+      guard let leaf = _index._leaf else { return nil }
+      let item = leaf.read { $0.children[_index._path[0]].value }
+      _rope.formIndex(after: &_index)
       return item
     }
   }

--- a/Sources/RopeModule/Rope/Operations/Rope+Append.swift
+++ b/Sources/RopeModule/Rope/Operations/Rope+Append.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Rope {
+  @inlinable
   public mutating func append(_ item: __owned Element) {
     _invalidateIndices()
     if _root == nil {
@@ -23,7 +24,8 @@ extension Rope {
 }
 
 extension Rope._Node {
-  mutating func append(_ item: __owned _Item) -> Self? {
+  @inlinable
+  internal mutating func append(_ item: __owned _Item) -> Self? {
     var item = item
     if item.isUndersized, !self.isEmpty, self.lastItem.rebalance(nextNeighbor: &item) {
       return nil

--- a/Sources/RopeModule/Rope/Operations/Rope+Extract.swift
+++ b/Sources/RopeModule/Rope/Operations/Rope+Extract.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Rope {
+  @inlinable
   public func extract(from start: Int, to end: Int, in metric: some RopeMetric<Element>) -> Self {
     if _root == nil {
       precondition(start == 0 && end == 0, "Invalid range")
@@ -22,7 +23,8 @@ extension Rope {
 }
 
 extension Rope._Node {
-  func extract(
+  @inlinable
+  internal func extract(
     from start: Int,
     to end: Int,
     in metric: some RopeMetric<Element>,

--- a/Sources/RopeModule/Rope/Operations/Rope+Find.swift
+++ b/Sources/RopeModule/Rope/Operations/Rope+Find.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Rope {
+  @inlinable
   public func find(
     at position: Int,
     in metric: some RopeMetric<Element>,
@@ -39,7 +40,8 @@ extension Rope {
 }
 
 extension Rope._UnsafeHandle {
-  func findSlot(
+  @inlinable
+  internal func findSlot(
     at position: Int,
     in metric: some RopeMetric<Element>,
     preferEnd: Bool = true
@@ -59,7 +61,8 @@ extension Rope._UnsafeHandle {
     return preferEnd ? (childCount - 1, remaining + size) : (childCount, 0)
   }
 
-  func findSlot(
+  @inlinable
+  internal func findSlot(
     from p: (slot: Int, remaining: Int),
     offsetBy distance: Int,
     in metric: some RopeMetric<Element>,

--- a/Sources/RopeModule/Rope/Operations/Rope+ForEachWhile.swift
+++ b/Sources/RopeModule/Rope/Operations/Rope+ForEachWhile.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Rope {
+  @inlinable
   public func forEachWhile(
     _ body: (Element) -> Bool
   ) -> Bool {
@@ -17,6 +18,7 @@ extension Rope {
     return root.forEachWhile(body)
   }
 
+  @inlinable
   public func forEachWhile(
     from position: Int,
     in metric: some RopeMetric<Element>,
@@ -31,7 +33,8 @@ extension Rope {
 }
 
 extension Rope._Node {
-  func forEachWhile(
+  @inlinable
+  internal func forEachWhile(
     _ body: (Element) -> Bool
   ) -> Bool {
     if isLeaf {
@@ -52,7 +55,8 @@ extension Rope._Node {
     }
   }
 
-  func forEachWhile(
+  @inlinable
+  internal func forEachWhile(
     from position: Int,
     in metric: some RopeMetric<Element>,
     _ body: (Element, Element.Index?) -> Bool

--- a/Sources/RopeModule/Rope/Operations/Rope+Insert.swift
+++ b/Sources/RopeModule/Rope/Operations/Rope+Insert.swift
@@ -10,11 +10,13 @@
 //===----------------------------------------------------------------------===//
 
 extension Rope {
+  @inlinable
   public mutating func prepend(_ item: __owned Element) {
     _invalidateIndices()
     insert(item, at: startIndex)
   }
-  
+
+  @inlinable
   public mutating func insert(
     _ item: __owned Element,
     at index: Index
@@ -23,6 +25,7 @@ extension Rope {
     insert(item, at: index._path)
   }
 
+  @inlinable
   mutating func insert(
     _ item: __owned Element,
     at path: _Path
@@ -36,7 +39,8 @@ extension Rope {
     }
     _invalidateIndices()
   }
-  
+
+  @inlinable
   public mutating func insert(
     _ item: __owned Element,
     at position: Int,
@@ -54,11 +58,13 @@ extension Rope {
 }
 
 extension Rope._Node {
-  mutating func prepend(_ item: __owned _Item) -> Self? {
+  @inlinable
+  internal mutating func prepend(_ item: __owned _Item) -> Self? {
     insert(item, at: _startPath)
   }
-  
-  mutating func insert(
+
+  @inlinable
+  internal mutating func insert(
     _ item: __owned _Item,
     at path: _Path
   ) -> Self? {
@@ -72,8 +78,9 @@ extension Rope._Node {
     precondition(slot <= childCount, "Index out of bounds")
     return _leafInsert(item, at: slot)
   }
-  
-  mutating func insert(
+
+  @inlinable
+  internal mutating func insert(
     _ item: __owned _Item,
     at position: Int,
     in metric: some RopeMetric<Element>
@@ -94,7 +101,8 @@ extension Rope._Node {
 }
 
 extension Rope._Node {
-  mutating func _innerInsert(
+  @inlinable
+  internal mutating func _innerInsert(
     at slot: Int,
     with body: (inout Self) -> Self?
   ) -> Self? {
@@ -111,8 +119,11 @@ extension Rope._Node {
     guard let spawn = spawn else { return nil }
     return _applySpawn(spawn, of: slot)
   }
-  
-  mutating func _applySpawn(_ spawn: __owned Self, of slot: Int) -> Self? {
+
+  @inlinable
+  internal mutating func _applySpawn(
+    _ spawn: __owned Self, of slot: Int
+  ) -> Self? {
     var spawn = spawn
     var nextSlot = slot + 1
 #if true // Compress existing nodes if possible.
@@ -161,7 +172,10 @@ extension Rope._Node {
 }
 
 extension Rope._Node {
-  mutating func _leafInsert(_ item: __owned _Item, at slot: Int) -> Self? {
+  @inlinable
+  internal mutating func _leafInsert(
+    _ item: __owned _Item, at slot: Int
+  ) -> Self? {
     assert(slot <= childCount)
     var item = item
     if item.isUndersized, childCount > 0, _rebalanceBeforeInsert(&item, at: slot) {
@@ -181,8 +195,11 @@ extension Rope._Node {
     spawn._insertItem(item, at: slot - childCount)
     return spawn
   }
-  
-  mutating func _rebalanceBeforeInsert(_ item: inout _Item, at slot: Int) -> Bool {
+
+  @inlinable
+  internal mutating func _rebalanceBeforeInsert(
+    _ item: inout _Item, at slot: Int
+  ) -> Bool {
     assert(item.isUndersized)
     let r = updateLeaf { (h) -> (merged: Bool, delta: Summary) in
       if slot > 0 {

--- a/Sources/RopeModule/Rope/Operations/Rope+Join.swift
+++ b/Sources/RopeModule/Rope/Operations/Rope+Join.swift
@@ -10,23 +10,28 @@
 //===----------------------------------------------------------------------===//
 
 extension Rope {
+  @inlinable
   public mutating func append(_ other: __owned Self) {
     self = Rope.join(self, other)
   }
   
+  @inlinable
   public mutating func prepend(_ other: __owned Self) {
     self = Rope.join(other, self)
   }
   
-  mutating func _append(_ other: __owned _Node) {
+  @inlinable
+  internal mutating func _append(_ other: __owned _Node) {
     append(Self(root: other))
   }
   
-  mutating func _prepend(_ other: __owned _Node) {
+  @inlinable
+  internal mutating func _prepend(_ other: __owned _Node) {
     prepend(Self(root: other))
   }
   
   /// Concatenate `left` and `right` by linking up the two trees.
+  @inlinable
   public static func join(_ left: __owned Self, _ right: __owned Self) -> Self {
     guard !right.isEmpty else { return left }
     guard !left.isEmpty else { return right }
@@ -54,7 +59,10 @@ extension Rope {
 }
 
 extension Rope._Node {
-  mutating func _graftFront(_ scion: inout Self) -> (remainder: Self?, delta: Summary) {
+  @inlinable
+  internal mutating func _graftFront(
+    _ scion: inout Self
+  ) -> (remainder: Self?, delta: Summary) {
     assert(self.height >= scion.height)
     guard self.height > scion.height else {
       assert(self.height == scion.height)
@@ -85,8 +93,11 @@ extension Rope._Node {
     splinter._insertNode(remainder, at: 0)
     return (splinter, delta)
   }
-  
-  mutating func _graftBack(_ scion: inout Self) -> (remainder: Self?, delta: Summary) {
+
+  @inlinable
+  internal mutating func _graftBack(
+    _ scion: inout Self
+  ) -> (remainder: Self?, delta: Summary) {
     assert(self.height >= scion.height)
     guard self.height > scion.height else {
       assert(self.height == scion.height)

--- a/Sources/RopeModule/Rope/Operations/Rope+MutatingForEach.swift
+++ b/Sources/RopeModule/Rope/Operations/Rope+MutatingForEach.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Rope {
-  @inline(__always)
+  @inlinable @inline(__always)
   @discardableResult
   public mutating func mutatingForEach<R>(
     _ body: (inout Element) -> R?
@@ -19,7 +19,7 @@ extension Rope {
     return mutatingForEach(from: &i, body)
   }
   
-  @inline(__always)
+  @inlinable @inline(__always)
   @discardableResult
   public mutating func mutatingForEach<R>(
     from index: inout Index,
@@ -33,8 +33,9 @@ extension Rope {
     assert(completed == (r == nil))
     return r
   }
-  
-  mutating func _mutatingForEach(
+
+  @inlinable
+  internal mutating func _mutatingForEach(
     from index: inout Index,
     _ body: (inout Element) -> Bool
   ) -> Bool {
@@ -50,7 +51,8 @@ extension Rope {
 }
 
 extension Rope._Node {
-  mutating func mutatingForEach(
+  @inlinable
+  internal mutating func mutatingForEach(
     from index: inout Index,
     body: (inout Element) -> Bool
   ) -> (continue: Bool, delta: Summary) {

--- a/Sources/RopeModule/Rope/Operations/Rope+Remove.swift
+++ b/Sources/RopeModule/Rope/Operations/Rope+Remove.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Rope {
+  @inlinable
   public mutating func remove(at index: Index) -> Element {
     validate(index)
     let old = root.remove(at: index._path).removed
@@ -24,7 +25,8 @@ extension Rope {
 }
 
 extension Rope._Node {
-  mutating func remove(
+  @inlinable
+  internal mutating func remove(
     at path: _Path
   ) -> (removed: _Item, delta: Summary, needsFixing: Bool) {
     ensureUnique()
@@ -44,6 +46,7 @@ extension Rope._Node {
 }
 
 extension Rope {
+  @inlinable
   public mutating func remove(
     at position: Int,
     in metric: some RopeMetric<Element>
@@ -60,7 +63,8 @@ extension Rope {
 }
 
 extension Rope._Node {
-  mutating func remove(
+  @inlinable
+  internal mutating func remove(
     at position: Int,
     in metric: some RopeMetric<Element>
   ) -> (removed: _Item, delta: Summary, needsFixing: Bool) {
@@ -86,7 +90,8 @@ extension Rope._Node {
 }
 
 extension Rope._Node {
-  mutating func fixDeficiency(at slot: Int) {
+  @inlinable
+  internal mutating func fixDeficiency(at slot: Int) {
     assert(isUnique())
     updateInner {
       let c = $0.mutableChildren

--- a/Sources/RopeModule/Rope/Operations/Rope+RemoveSubrange.swift
+++ b/Sources/RopeModule/Rope/Operations/Rope+RemoveSubrange.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Rope {
+  @inlinable
   public mutating func removeSubrange(
     _ bounds: Range<Int>,
     in metric: some RopeMetric<Element>
@@ -24,6 +25,7 @@ extension Rope {
     self = builder.finalize()
   }
 
+  @inlinable
   public mutating func replaceSubrange(
     _ bounds: Range<Int>,
     in metric: some RopeMetric<Element>,
@@ -40,6 +42,7 @@ extension Rope {
     self = builder.finalize()
   }
 
+  @inlinable
   public mutating func builder(
     removing bounds: Range<Int>,
     in metric: some RopeMetric<Element>
@@ -96,7 +99,8 @@ extension Rope {
 }
 
 extension Rope._Node {
-  __consuming func _removeSubrange(
+  @inlinable
+  internal __consuming func _removeSubrange(
     from start: (slot: Int, remaining: Int),
     to end: (slot: Int, remaining: Int),
     in metric: some RopeMetric<Element>,
@@ -130,7 +134,8 @@ extension Rope._Node {
     builder._insertAfterTip(upper.split(at: i2))
   }
 
-  __consuming func removeSuffix(
+  @inlinable
+  internal __consuming func removeSuffix(
     from position: Int,
     in metric: some RopeMetric<Element>,
     into builder: inout Rope.Builder
@@ -158,7 +163,8 @@ extension Rope._Node {
     builder._insertBeforeTip(item)
   }
 
-  __consuming func removePrefix(
+  @inlinable
+  internal __consuming func removePrefix(
     upTo position: Int,
     in metric: some RopeMetric<Element>,
     into builder: inout Rope.Builder
@@ -184,7 +190,8 @@ extension Rope._Node {
     builder._insertAfterTip(item.split(at: i))
   }
 
-  mutating func _innerRemoveSuffix(
+  @inlinable
+  internal mutating func _innerRemoveSuffix(
     descending slot: Int,
     into builder: inout Rope.Builder
   ) {
@@ -216,7 +223,8 @@ extension Rope._Node {
     builder._insertBeforeTip(n)
   }
 
-  __consuming func _leafRemoveSuffix(
+  @inlinable
+  internal __consuming func _leafRemoveSuffix(
     returning slot: Int,
     into builder: inout Rope.Builder
   ) -> _Item {
@@ -246,7 +254,8 @@ extension Rope._Node {
     return item
   }
 
-  mutating func _innerRemovePrefix(
+  @inlinable
+  internal mutating func _innerRemovePrefix(
     descending slot: Int,
     into builder: inout Rope.Builder
   ) {
@@ -279,7 +288,8 @@ extension Rope._Node {
     builder._insertAfterTip(n)
   }
 
-  __consuming func _leafRemovePrefix(
+  @inlinable
+  internal __consuming func _leafRemovePrefix(
     returning slot: Int,
     into builder: inout Rope.Builder
   ) -> _Item {

--- a/Sources/RopeModule/Rope/Operations/Rope+Split.swift
+++ b/Sources/RopeModule/Rope/Operations/Rope+Split.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Rope {
+  @inlinable
   public mutating func builder(
     splittingAt position: Int,
     in metric: some RopeMetric<Element>
@@ -35,6 +36,7 @@ extension Rope {
     return builder
   }
 
+  @inlinable
   public mutating func split(at index: Index) -> (builder: Builder, item: Element) {
     validate(index)
     precondition(index < endIndex)
@@ -55,6 +57,7 @@ extension Rope {
     return (builder, item.value)
   }
 
+  @inlinable
   public mutating func split(at ropeIndex: Index, _ itemIndex: Element.Index) -> Builder {
     var (builder, item) = self.split(at: ropeIndex)
     let suffix = item.split(at: itemIndex)
@@ -69,7 +72,8 @@ extension Rope {
 }
 
 extension Rope._Node {
-  mutating func _innerSplit(
+  @inlinable
+  internal mutating func _innerSplit(
     at slot: Int,
     into builder: inout Rope.Builder
   ) {
@@ -102,8 +106,9 @@ extension Rope._Node {
     builder._insertBeforeTip(n)
     builder._insertAfterTip(suffix)
   }
-  
-  __consuming func _leafSplit(
+
+  @inlinable
+  internal __consuming func _leafSplit(
     at slot: Int,
     into builder: inout Rope.Builder
   ) -> _Item {

--- a/Sources/RopeModule/Utilities/Optional Utilities.swift
+++ b/Sources/RopeModule/Utilities/Optional Utilities.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Optional {
+  @inlinable
   internal mutating func _take() -> Self {
     let r = self
     self = nil

--- a/Utils/swift-collections.xcworkspace/xcshareddata/xcschemes/_RopeModule.xcscheme
+++ b/Utils/swift-collections.xcworkspace/xcshareddata/xcschemes/_RopeModule.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1430"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,15 +14,15 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "RopeModule"
-               BuildableName = "RopeModule"
-               BlueprintName = "RopeModule"
+               BlueprintIdentifier = "_RopeModule"
+               BuildableName = "_RopeModule"
+               BlueprintName = "_RopeModule"
                ReferencedContainer = "container:..">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">
@@ -75,9 +75,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "RopeModule"
-            BuildableName = "RopeModule"
-            BlueprintName = "RopeModule"
+            BlueprintIdentifier = "_RopeModule"
+            BuildableName = "_RopeModule"
+            BlueprintName = "_RopeModule"
             ReferencedContainer = "container:..">
          </BuildableReference>
       </MacroExpansion>
@@ -89,7 +89,4 @@
       buildConfiguration = "Release"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
-   <InstallAction
-      buildConfiguration = "Release">
-   </InstallAction>
 </Scheme>


### PR DESCRIPTION
This is crucial for the performance of code that directly uses `Rope`.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
