### PR TITLE
Rope: Fix `Sendable` conformance

### DIFF
--- a/Sources/RopeModule/Rope/Basics/Rope+_Node.swift
+++ b/Sources/RopeModule/Rope/Basics/Rope+_Node.swift
@@ -46,6 +46,10 @@ extension Rope {
   }
 }
 
+extension Rope._Node: @unchecked Sendable where Element: Sendable {
+  // @unchecked because `object` is stored as an `AnyObject` above.
+}
+
 extension Rope._Node {
   var _headerPtr: UnsafePointer<_RopeStorageHeader> {
     let p = _getUnsafePointerToStoredProperties(object)


### PR DESCRIPTION
`Rope._Node` wasn’t declared `Sendable`, and that triggered valid warnings.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
