### PR TITLE
BigString: Fix String.Index._knownScalarAligned

### DIFF
--- a/Sources/RopeModule/Utilities/String.Index+ABI.swift
+++ b/Sources/RopeModule/Utilities/String.Index+ABI.swift
@@ -64,7 +64,7 @@ extension String.Index {
   }
 
   var _knownScalarAligned: String.Index {
-    let r = _abi_rawBits | Self._abi_characterAlignmentBit | Self._abi_scalarAlignmentBit
+    let r = _abi_rawBits | Self._abi_scalarAlignmentBit
     return unsafeBitCast(r, to: String.Index.self)
   }
 }


### PR DESCRIPTION
This member isn’t currently used, but unlike its counterpart in the stdlib, this one accidentally sets the character-alignment bit.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
