### PR TITLE
Require Swift 5.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Collections open source project

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The following table maps existing package releases to their minimum required Swi
 | Package version         | Swift version | Xcode release |
 | ----------------------- | ------------- | ------------- |
 | swift-collections 1.0.x | >= Swift 5.3  | >= Xcode 12   |
-| swift-collections 1.1.x | >= Swift 5.5  | >= Xcode 13   |
+| swift-collections 1.1.x | >= Swift 5.6  | >= Xcode 13.3 |
 
 (Note: the package has no minimum deployment target, so while it does require clients to use a recent Swift toolchain to build it, the code itself is able to run on any OS release that supports running Swift code.)
 


### PR DESCRIPTION
Swift 5.8 is out now, so let’s bump the minimum required toolchain to Swift 5.6. (The package wants to support three major language releases, and now that 5.8 is out, supporting 5.5 would bump that to four.)

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
