### PR TITLE
[HashCollections] Ensure `self` doesn’t get destroyed before we’re done working with it

### DIFF
--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary.swift
@@ -345,6 +345,7 @@ extension TreeDictionary {
   public mutating func updateValue(
     _ value: __owned Value, forKey key: Key
   ) -> Value? {
+    defer { _fixLifetime(self) }
     let hash = _Hash(key)
     let r = _root.updateValue(.top, forKey: key, hash) {
       $0.initialize(to: (key, value))
@@ -364,6 +365,7 @@ extension TreeDictionary {
   internal mutating func _updateValue(
     _ value: __owned Value, forKey key: Key
   ) -> Bool {
+    defer { _fixLifetime(self) }
     let hash = _Hash(key)
     let r = _root.updateValue(.top, forKey: key, hash) {
       $0.initialize(to: (key, value))
@@ -470,6 +472,7 @@ extension TreeDictionary {
     default defaultValue: @autoclosure () -> Value,
     with body: (inout Value) throws -> R
   ) rethrows -> R {
+    defer { _fixLifetime(self) }
     let hash = _Hash(key)
     let r = _root.updateValue(.top, forKey: key, hash) {
       $0.initialize(to: (key, defaultValue()))

--- a/Sources/HashTreeCollections/TreeSet/TreeSet+Extras.swift
+++ b/Sources/HashTreeCollections/TreeSet/TreeSet+Extras.swift
@@ -54,6 +54,7 @@ extension TreeSet {
   /// - Complexity: O(log(`count`)) if set storage might be shared; O(1)
   ///    otherwise.
   public mutating func update(_ member: Element, at index: Index) -> Element {
+    defer { _fixLifetime(self) }
     precondition(_isValid(index), "Invalid index")
     precondition(index._path.isOnItem, "Can't get element at endIndex")
     _invalidateIndices()

--- a/Sources/HashTreeCollections/TreeSet/TreeSet+SetAlgebra basics.swift
+++ b/Sources/HashTreeCollections/TreeSet/TreeSet+SetAlgebra basics.swift
@@ -51,6 +51,7 @@ extension TreeSet: SetAlgebra {
   public mutating func insert(
     _ newMember: __owned Element
   ) -> (inserted: Bool, memberAfterInsert: Element) {
+    defer { _fixLifetime(self) }
     let hash = _Hash(newMember)
     let r = _root.insert(.top, (newMember, ()), hash)
     if r.inserted {
@@ -117,6 +118,7 @@ extension TreeSet: SetAlgebra {
   @discardableResult
   @inlinable
   public mutating func update(with newMember: __owned Element) -> Element? {
+    defer { _fixLifetime(self) }
     let hash = _Hash(newMember)
     let r = _root.updateValue(.top, forKey: newMember, hash) {
       $0.initialize(to: (newMember, ()))


### PR DESCRIPTION
The HashCollections module includes several mutating methods that dereference unmanaged references to internal nodes after the last usage of `self`. Prevent the compiler from destroying `self` before we’re done working within descendants of its tree.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
