### PR TITLE
Remove obsolete swift(>=5.5)/swift(>=5.6) checks

### DIFF
--- a/Sources/BitCollections/BitArray/BitArray.swift
+++ b/Sources/BitCollections/BitArray/BitArray.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -48,9 +48,7 @@ public struct BitArray {
   }
 }
 
-#if swift(>=5.5)
 extension BitArray: Sendable {}
-#endif
 
 extension BitArray {
   @inline(__always)

--- a/Sources/BitCollections/BitSet/BitSet+BidirectionalCollection.swift
+++ b/Sources/BitCollections/BitSet/BitSet+BidirectionalCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -88,9 +88,7 @@ extension BitSet: Sequence {
   }
 }
 
-#if swift(>=5.5)
 extension BitSet.Iterator: Sendable {}
-#endif
 
 extension BitSet: Collection, BidirectionalCollection {
   /// A Boolean value indicating whether the collection is empty.

--- a/Sources/BitCollections/BitSet/BitSet.Counted.swift
+++ b/Sources/BitCollections/BitSet/BitSet.Counted.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -28,9 +28,7 @@ extension BitSet {
   }
 }
 
-#if swift(>=5.5)
 extension BitSet.Counted: Sendable {}
-#endif
 
 extension BitSet.Counted {
 #if COLLECTIONS_INTERNAL_CHECKS

--- a/Sources/BitCollections/BitSet/BitSet.Index.swift
+++ b/Sources/BitCollections/BitSet/BitSet.Index.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -43,9 +43,7 @@ extension BitSet {
   }
 }
 
-#if swift(>=5.5)
 extension BitSet.Index: Sendable {}
-#endif
 
 extension BitSet.Index: CustomStringConvertible {
   // A textual representation of this instance.

--- a/Sources/BitCollections/BitSet/BitSet.swift
+++ b/Sources/BitCollections/BitSet/BitSet.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -33,9 +33,7 @@ public struct BitSet {
   }
 }
 
-#if swift(>=5.5)
 extension BitSet: Sendable {}
-#endif
 
 extension BitSet {
   @inline(__always)

--- a/Sources/DequeModule/Deque+Collection.swift
+++ b/Sources/DequeModule/Deque+Collection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -164,9 +164,7 @@ extension Deque: Sequence {
   }
 }
 
-#if swift(>=5.5)
 extension Deque.Iterator: Sendable where Element: Sendable {}
-#endif
 
 extension Deque: RandomAccessCollection {
   public typealias Index = Int

--- a/Sources/DequeModule/Deque+Sendable.swift
+++ b/Sources/DequeModule/Deque+Sendable.swift
@@ -2,13 +2,11 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.5)
 extension Deque: @unchecked Sendable where Element: Sendable {}
-#endif

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Codable.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Codable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -60,7 +60,6 @@ where Key: Encodable, Value: Encodable
       }
       return
     }
-#if swift(>=5.6)
     if #available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *),
             Key.self is CodingKeyRepresentable.Type {
       // Since the keys are CodingKeyRepresentable, we can use the `codingKey`
@@ -73,7 +72,6 @@ where Key: Encodable, Value: Encodable
       }
       return
     }
-#endif
     // Keys are Encodable but not Strings or Ints, so we cannot arbitrarily
     // convert to keys. We can encode as an array of alternating key-value
     // pairs, though.
@@ -133,7 +131,6 @@ where Key: Decodable, Value: Decodable
       return
     }
 
-#if swift(>=5.6)
     if #available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *),
        let keyType = Key.self as? CodingKeyRepresentable.Type {
       // The keys are CodingKeyRepresentable, so we should be able to expect
@@ -152,7 +149,6 @@ where Key: Decodable, Value: Decodable
       }
       return
     }
-#endif
 
     // We should have encoded as an array of alternating key-value pairs.
     var container = try decoder.unkeyedContainer()

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Collection.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Collection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -38,10 +38,8 @@ extension TreeDictionary {
   }
 }
 
-#if swift(>=5.5)
 extension TreeDictionary.Index: @unchecked Sendable
 where Key: Sendable, Value: Sendable {}
-#endif
 
 extension TreeDictionary.Index: Equatable {
   /// Returns a Boolean value indicating whether two index values are equal.

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Keys.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Keys.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -38,10 +38,8 @@ extension TreeDictionary {
   }
 }
 
-#if swift(>=5.5)
 extension TreeDictionary.Keys: Sendable
 where Key: Sendable, Value: Sendable {}
-#endif
 
 extension TreeDictionary.Keys: _UniqueCollection {}
 
@@ -114,10 +112,8 @@ extension TreeDictionary.Keys: Sequence {
   }
 }
 
-#if swift(>=5.5)
 extension TreeDictionary.Keys.Iterator: Sendable
 where Key: Sendable, Value: Sendable {}
-#endif
 
 extension TreeDictionary.Keys: Collection {
   public typealias Index = TreeDictionary.Index

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Sendable.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Sendable.swift
@@ -2,14 +2,12 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.5)
 extension TreeDictionary: @unchecked Sendable
 where Key: Sendable, Value: Sendable {}
-#endif

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Sequence.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Sequence.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2019 - 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2019 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -51,10 +51,8 @@ extension TreeDictionary: Sequence {
   }
 }
 
-#if swift(>=5.5)
 extension TreeDictionary.Iterator: @unchecked Sendable
 where Key: Sendable, Value: Sendable {}
-#endif
 
 extension TreeDictionary.Iterator: IteratorProtocol {
   /// The element type of a dictionary: a tuple containing an individual

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Values.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Values.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -43,10 +43,8 @@ extension TreeDictionary {
   }
 }
 
-#if swift(>=5.5)
 extension TreeDictionary.Values: Sendable
 where Key: Sendable, Value: Sendable {}
-#endif
 
 extension TreeDictionary.Values: CustomStringConvertible {
   // A textual representation of this instance.
@@ -92,10 +90,8 @@ extension TreeDictionary.Values: Sequence {
   }
 }
 
-#if swift(>=5.5)
 extension TreeDictionary.Values.Iterator: Sendable
 where Key: Sendable, Value: Sendable {}
-#endif
 
 // Note: This cannot be a MutableCollection because its subscript setter
 // needs to invalidate indices.

--- a/Sources/HashTreeCollections/TreeSet/TreeSet+Collection.swift
+++ b/Sources/HashTreeCollections/TreeSet/TreeSet+Collection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -38,10 +38,8 @@ extension TreeSet {
   }
 }
 
-#if swift(>=5.5)
 extension TreeSet.Index: @unchecked Sendable
 where Element: Sendable {}
-#endif
 
 extension TreeSet.Index: Equatable {
   /// Returns a Boolean value indicating whether two index values are equal.

--- a/Sources/HashTreeCollections/TreeSet/TreeSet+Sendable.swift
+++ b/Sources/HashTreeCollections/TreeSet/TreeSet+Sendable.swift
@@ -2,13 +2,11 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.5)
 extension TreeSet: @unchecked Sendable where Element: Sendable {}
-#endif

--- a/Sources/HashTreeCollections/TreeSet/TreeSet+Sequence.swift
+++ b/Sources/HashTreeCollections/TreeSet/TreeSet+Sequence.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -49,7 +49,5 @@ extension TreeSet: Sequence {
   }
 }
 
-#if swift(>=5.5)
 extension TreeSet.Iterator: @unchecked Sendable
 where Element: Sendable {}
-#endif

--- a/Sources/HeapModule/Heap.swift
+++ b/Sources/HeapModule/Heap.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -35,9 +35,7 @@ public struct Heap<Element: Comparable> {
   }
 }
 
-#if swift(>=5.5)
 extension Heap: Sendable where Element: Sendable {}
-#endif
 
 extension Heap {
   /// A Boolean value indicating whether or not the heap is empty.

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.SubSequence.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -34,10 +34,8 @@ extension OrderedDictionary.Elements {
   }
 }
 
-#if swift(>=5.5)
 extension OrderedDictionary.Elements.SubSequence: Sendable
 where Key: Sendable, Value: Sendable {}
-#endif
 
 extension OrderedDictionary.Elements.SubSequence: CustomStringConvertible {
   // A textual representation of this instance.
@@ -149,10 +147,8 @@ extension OrderedDictionary.Elements.SubSequence: Sequence {
   }
 }
 
-#if swift(>=5.5)
 extension OrderedDictionary.Elements.SubSequence.Iterator: Sendable
 where Key: Sendable, Value: Sendable {}
-#endif
 
 extension OrderedDictionary.Elements.SubSequence: RandomAccessCollection {
   /// The index type for an ordered dictionary: `Int`.

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -29,10 +29,8 @@ extension OrderedDictionary {
   }
 }
 
-#if swift(>=5.5)
 extension OrderedDictionary.Elements: Sendable
 where Key: Sendable, Value: Sendable {}
-#endif
 
 extension OrderedDictionary {
   /// A view of the contents of this dictionary as a random-access collection.

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sendable.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sendable.swift
@@ -2,14 +2,12 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.5)
 extension OrderedDictionary: @unchecked Sendable
 where Key: Sendable, Value: Sendable {}
-#endif

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sequence.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sequence.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -62,7 +62,5 @@ extension OrderedDictionary: Sequence {
   }
 }
 
-#if swift(>=5.5)
 extension OrderedDictionary.Iterator: Sendable
 where Key: Sendable, Value: Sendable {}
-#endif

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -28,10 +28,8 @@ extension OrderedDictionary {
   }
 }
 
-#if swift(>=5.5)
 extension OrderedDictionary.Values: Sendable
 where Key: Sendable, Value: Sendable {}
-#endif
 
 extension OrderedDictionary.Values: CustomStringConvertible {
   // A textual representation of this instance.

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -37,9 +37,7 @@ extension OrderedSet {
   }
 }
 
-#if swift(>=5.5)
 extension OrderedSet.SubSequence: Sendable where Element: Sendable {}
-#endif
 
 extension OrderedSet.SubSequence {
   @inlinable

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -66,9 +66,7 @@ extension OrderedSet {
   }
 }
 
-#if swift(>=5.5)
 extension OrderedSet.UnorderedView: Sendable where Element: Sendable {}
-#endif
 
 extension OrderedSet.UnorderedView: CustomStringConvertible {
   /// A textual representation of this instance.

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnstableInternals.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnstableInternals.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -47,7 +47,5 @@ extension OrderedSet {
   }
 }
 
-#if swift(>=5.5)
 extension OrderedSet._UnstableInternals: Sendable
 where Element: Sendable {}
-#endif

--- a/Tests/HashTreeCollectionsTests/TreeDictionary Tests.swift
+++ b/Tests/HashTreeCollectionsTests/TreeDictionary Tests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 - 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -274,7 +274,6 @@ class TreeDictionaryTests: CollectionTestCase {
       d, expectedContents: ref, by: ==)
   }
 
-#if swift(>=5.6)
   @available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *)
   struct FancyDictionaryKey: CodingKeyRepresentable, Hashable, Codable {
     var value: Int
@@ -290,7 +289,6 @@ class TreeDictionaryTests: CollectionTestCase {
       self.init(value)
     }
   }
-#endif
 
   struct BoringDictionaryKey: Hashable, Codable {
     var value: Int
@@ -316,7 +314,6 @@ class TreeDictionaryTests: CollectionTestCase {
     ])
     expectEqual(try MinimalEncoder.encode(d2), v2)
 
-#if swift(>=5.6)
     if #available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *) {
       let d3: TreeDictionary<FancyDictionaryKey, Int16> = [
         FancyDictionaryKey(1): 10, FancyDictionaryKey(2): 20
@@ -326,7 +323,6 @@ class TreeDictionaryTests: CollectionTestCase {
       ])
       expectEqual(try MinimalEncoder.encode(d3), v3)
     }
-#endif
 
     let d4: TreeDictionary<BoringDictionaryKey, UInt8> = [
       // Note: we only have a single element to prevent ordering
@@ -362,7 +358,6 @@ class TreeDictionaryTests: CollectionTestCase {
       try MinimalDecoder.decode(v2, as: PD<Int, String>.self),
       d2)
 
-#if swift(>=5.6)
     if #available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *) {
       let d3: TreeDictionary<FancyDictionaryKey, Int16> = [
         FancyDictionaryKey(1): 10, FancyDictionaryKey(2): 20
@@ -374,7 +369,6 @@ class TreeDictionaryTests: CollectionTestCase {
         try MinimalDecoder.decode(v3, as: PD<FancyDictionaryKey, Int16>.self),
         d3)
     }
-#endif
 
     let d4: TreeDictionary<BoringDictionaryKey, UInt8> = [
       // Note: we only have a single element to prevent ordering
@@ -396,7 +390,6 @@ class TreeDictionaryTests: CollectionTestCase {
       expectTrue($0 is DecodingError)
     }
 
-#if swift(>=5.6)
     if #available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *) {
       let v6: MinimalEncoder.Value = .dictionary([
         "This is not a number": .string("bus"),
@@ -419,7 +412,6 @@ class TreeDictionaryTests: CollectionTestCase {
         try MinimalDecoder.decode(v7, as: PD<FancyDictionaryKey, String>.self),
         d7)
     }
-#endif
 
     let v8: MinimalEncoder.Value = .array([
       .int32(1), .string("bike"), .int32(2),


### PR DESCRIPTION
Now that this package requires Swift 5.6, these are no longer necessary.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
