### PR TITLE
[CollectionUtilities] Silence a warning on 32 bit platforms

### DIFF
--- a/Sources/_CollectionsUtilities/IntegerTricks/Integer rank.swift.gyb
+++ b/Sources/_CollectionsUtilities/IntegerTricks/Integer rank.swift.gyb
@@ -41,13 +41,16 @@ extension UInt {
     var shift: Self = 0
     var n = Self(truncatingIfNeeded: n)
 
-    if Self.bitWidth == 64 {
+    if MemoryLayout<UInt>.size == 8 {
       let c32 = (self & 0xFFFFFFFF)._nonzeroBitCount
       if n >= c32 {
         shift &+= 32
         n &-= c32
       }
+    } else {
+      assert(MemoryLayout<Self>.size == 4, "Unknown platform")
     }
+
     let c16 = ((self &>> shift) & 0xFFFF)._nonzeroBitCount
     if n >= c16 {
       shift &+= 16

--- a/Sources/_CollectionsUtilities/IntegerTricks/autogenerated/Integer rank.swift
+++ b/Sources/_CollectionsUtilities/IntegerTricks/autogenerated/Integer rank.swift
@@ -47,13 +47,16 @@ extension UInt {
     var shift: Self = 0
     var n = Self(truncatingIfNeeded: n)
 
-    if Self.bitWidth == 64 {
+    if MemoryLayout<UInt>.size == 8 {
       let c32 = (self & 0xFFFFFFFF)._nonzeroBitCount
       if n >= c32 {
         shift &+= 32
         n &-= c32
       }
+    } else {
+      assert(MemoryLayout<Self>.size == 4, "Unknown platform")
     }
+
     let c16 = ((self &>> shift) & 0xFFFF)._nonzeroBitCount
     if n >= c16 {
       shift &+= 16
@@ -184,13 +187,16 @@ extension UInt {
     var shift: Self = 0
     var n = Self(truncatingIfNeeded: n)
 
-    if Self.bitWidth == 64 {
+    if MemoryLayout<UInt>.size == 8 {
       let c32 = (self & 0xFFFFFFFF)._nonzeroBitCount
       if n >= c32 {
         shift &+= 32
         n &-= c32
       }
+    } else {
+      assert(MemoryLayout<Self>.size == 4, "Unknown platform")
     }
+
     let c16 = ((self &>> shift) & 0xFFFF)._nonzeroBitCount
     if n >= c16 {
       shift &+= 16


### PR DESCRIPTION
It turns out `UInt.bitWidth` is getting too eagerly inlined, so conditions based on it trigger spurious “code will never be executed” warnings. Silence those by switching to looking at `MemoryLayout<UInt>`, which doesn’t get turned into a constant *that* early.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
