### PR TITLE
[BitSet] Fix a thinko in BitSet.isEqualSet

### DIFF
--- a/Sources/BitCollections/BitSet/BitSet._UnsafeHandle.swift
+++ b/Sources/BitCollections/BitSet/BitSet._UnsafeHandle.swift
@@ -223,8 +223,8 @@ extension _UnsafeBitSet {
     let r = range.clamped(to: 0 ..< UInt(capacity))
     guard r == range else { return false }
 
-    let lower = Index(range.lowerBound)
-    let upper = Index(range.upperBound)
+    let lower = Index(range.lowerBound).split
+    let upper = Index(range.upperBound).endSplit
 
     guard upper.word == wordCount &- 1 else { return false }
 

--- a/Tests/BitCollectionsTests/BitSetTests.swift
+++ b/Tests/BitCollectionsTests/BitSetTests.swift
@@ -1109,6 +1109,14 @@ final class BitSetTest: CollectionTestCase {
 
     let c = BitSet(130 ..< 160)
     expectTrue(c.isEqualSet(to: 130 ..< 160))
+
+    withEvery("i", in: stride(from: 0, to: 200, by: 4)) { i in
+      withEvery("j", in: stride(from: i, to: 200, by: 4)) { j in
+        let c = BitSet(i ..< j)
+        expectTrue(c.isEqualSet(to: i ..< j))
+        expectFalse(c.isEqualSet(to: i ..< (j + 1)))
+      }
+    }
   }
 
   func test_isEqual_to_counted_BitSet() {


### PR DESCRIPTION
If the interval we're checking against happens to end on a storage word boundary, then we mistakenly returned false even if the comparison should've succeeded.

This was caught by exercising the 32-bit code paths on watchOS -- one of the tests happened to use 130..<160 as the range, and 160 == 5 * 32. Add new test cases that would've caught this on 64 bit systems, too.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
