### PR TITLE
`Rope.find` returns a bogus remainder for the end position

### DIFF
--- a/Sources/RopeModule/Rope/Operations/Rope+Find.swift
+++ b/Sources/RopeModule/Rope/Operations/Rope+Find.swift
@@ -19,7 +19,7 @@ extension Rope {
     let wholeSize = _root == nil ? 0 : metric.size(of: root.summary)
     precondition(position >= 0 && position <= wholeSize, "Position out of bounds")
     guard !isEmpty, preferEnd || position < wholeSize else {
-      return (endIndex, position)
+      return (endIndex, 0)
     }
     var position = position
     var node = root

--- a/Tests/RopeModuleTests/TestRope.swift
+++ b/Tests/RopeModuleTests/TestRope.swift
@@ -235,7 +235,29 @@ class TestRope: CollectionTestCase {
       }
     }
   }
-  
+
+  func test_find() {
+    let c = 500
+
+    let chunks = (0 ..< c).map {
+      Chunk(length: ($0 % 4) + 1, value: $0)
+    }
+    let rope = Rope<Chunk>(chunks)
+    let ref = chunks.flatMap { Array(repeating: $0.value, count: $0.length) }
+
+    for i in 0 ..< ref.count {
+      let (index, remaining) = rope.find(at: i, in: Chunk.Metric(), preferEnd: false)
+      let chunk = rope[index]
+      expectEqual(chunk.value, ref[i])
+      let pos = ref[..<i].lastIndex { $0 != ref[i] }.map { $0 + 1 }
+      expectEqual(remaining, i - (pos ?? 0))
+    }
+
+    let end = rope.find(at: ref.count, in: Chunk.Metric(), preferEnd: false)
+    expectEqual(end.index, rope.endIndex)
+    expectEqual(end.remaining, 0)
+  }
+
   func test_index_offsetBy() {
     let c = 500
     


### PR DESCRIPTION
When looking for the rope position precisely at the end of the rope, `Rope.find(at:in:preferEnd:)` fails to return the right result: it correctly returns the `endIndex`, but it indicates that the position we’re looking for is at a large offset into that (nonexistent) element, instead of correctly reporting the remainder as zero:

```swift
let chunks = (0 ..< 5).map { Chunk(length: 10, value: $0) }
let rope = Rope<Chunk>(chunks)
// `rope` contains 5 chunks, with 50 components according to the metric `Chunk.Metric`.

let (index, remaining) = rope.find(at: 50, in: Chunk.Metric(), preferEnd: false)
print(index == rope.endIndex) // true, OK
print(remaining) // prints 50, should be 0
```

Predictably, this can have dire consequences in client code.

rdar://110191289

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
