### PR TITLE
Update OrderedDictionary/OrderedSet documentation

### DIFF
--- a/Documentation/OrderedDictionary.md
+++ b/Documentation/OrderedDictionary.md
@@ -208,7 +208,7 @@ dictionary.
 The easiest way to achieve this is to make sure `Key` implements hashing
 following `Hashable`'s documented best practices. The conformance must
 implement the `hash(into:)` requirement, and every bit of information that
-is compared in `==` needs to be combined into the supplied `Hasher` value.
+is combined into the supplied `Hasher` value must be compared in `==`.
 When used correctly, `Hasher` produces high-quality, randomly seeded hash
 values that prevent repeatable hash collisions.
 

--- a/Documentation/OrderedSet.md
+++ b/Documentation/OrderedSet.md
@@ -224,7 +224,7 @@ cannot be induced merely by adding a particular list of members to the set.
 The easiest way to achieve this is to make sure `Element` implements hashing
 following `Hashable`'s documented best practices. The conformance must
 implement the `hash(into:)` requirement, and every bit of information that
-is compared in `==` needs to be combined into the supplied `Hasher` value.
+is combined into the supplied `Hasher` value must be compared in `==`.
 When used correctly, `Hasher` produces high-quality, randomly seeded hash
 values that prevent repeatable hash collisions.
 


### PR DESCRIPTION
Update documentation to reflect that all bits used in the hashing needs to be part of the equality check for correctness (not strictly necessarily vice-versa as the current documentation reads). 

See also:

https://github.com/apple/swift/issues/66282#issuecomment-1572642416

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [ ] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
