### PR TITLE
Replace os() with canImport(Darwin)

### DIFF
--- a/Sources/_CollectionsUtilities/Compatibility/Array+WithContiguousStorage Compatibility.swift.gyb
+++ b/Sources/_CollectionsUtilities/Compatibility/Array+WithContiguousStorage Compatibility.swift.gyb
@@ -35,7 +35,7 @@ extension Array {
     // The bug is caused by a bogus precondition inside a non-inlinable stdlib
     // method, so to determine if we're affected, we need to check the currently
     // running OS version.
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    #if canImport(Darwin)
     if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
       // The OS is too new to be affected by this bug. (>= 5.5 stdlib)
       return false

--- a/Sources/_CollectionsUtilities/Compatibility/autogenerated/Array+WithContiguousStorage Compatibility.swift
+++ b/Sources/_CollectionsUtilities/Compatibility/autogenerated/Array+WithContiguousStorage Compatibility.swift
@@ -38,7 +38,7 @@ extension Array {
     // The bug is caused by a bogus precondition inside a non-inlinable stdlib
     // method, so to determine if we're affected, we need to check the currently
     // running OS version.
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    #if canImport(Darwin)
     if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
       // The OS is too new to be affected by this bug. (>= 5.5 stdlib)
       return false

--- a/Tests/_CollectionsTestSupport/AssertionContexts/CollectionTestCase.swift
+++ b/Tests/_CollectionsTestSupport/AssertionContexts/CollectionTestCase.swift
@@ -19,7 +19,7 @@ open class CollectionTestCase: XCTestCase {
 
   open var isAvailable: Bool { true }
 
-  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  #if canImport(Darwin)
   open override func invokeTest() {
     guard isAvailable else {
       print("\(Self.self) unavailable; skipping")


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Collections!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

With the release of Vision SDK, the refactor will need another `os(xrOS)` compiler directive conditional. A better and simple way to do this, as I saw in other projects, is to convert `os(iOS) || os(macOS) || os(tvOS) || os(watchOS)` to `canImport(Darwin)` leading to the same results.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
