### PR TITLE
Fix CustomStringConvertible/CustomDebugStringConvertible conformances

### DIFF
--- a/Sources/BitCollections/BitArray/BitArray+Descriptions.swift
+++ b/Sources/BitCollections/BitArray/BitArray+Descriptions.swift
@@ -33,8 +33,23 @@ extension BitArray: CustomStringConvertible {
 
 extension BitArray: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
+  ///
+  /// Bit arrays print themselves as a string of binary bits, with the highest-indexed elements
+  /// appearing first, as in the binary representation of integers:
+  ///
+  ///     let bits: BitArray = [false, false, false, true, true]
+  ///     print(bits) // "11000"
+  ///
+  /// As a special case, the debug description of an empty bit array is an empty pair of brackets.
+  /// This makes this case read better in structured printouts, like when the `BitArray` is printed
+  /// as part of another collection value:
+  ///
+  ///     let list: [BitArray] = [[false, true], [], [false]]
+  ///     print(list) // "[10, [], 0]"
+  ///
   public var debugDescription: String {
-    "BitArray(\(_bitString))"
+    guard !isEmpty else { return "[]" }
+    return description
   }
 }
 

--- a/Sources/BitCollections/BitSet/BitSet+CustomDebugStringConvertible.swift
+++ b/Sources/BitCollections/BitSet/BitSet+CustomDebugStringConvertible.swift
@@ -12,11 +12,7 @@
 extension BitSet: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _debugDescription(typeName: "BitSet")
-  }
-
-  internal func _debugDescription(typeName: String) -> String {
-    var result = "\(typeName)(["
+    var result = "["
     var first = true
     for item in self {
       if first {
@@ -26,7 +22,7 @@ extension BitSet: CustomDebugStringConvertible {
       }
       debugPrint(item, terminator: "", to: &result)
     }
-    result += "])"
+    result += "]"
     return result
   }
 }

--- a/Sources/BitCollections/BitSet/BitSet.Counted.swift
+++ b/Sources/BitCollections/BitSet/BitSet.Counted.swift
@@ -197,7 +197,7 @@ extension BitSet.Counted: CustomStringConvertible {
 extension BitSet.Counted: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _bits._debugDescription(typeName: "BitSet.Counted")
+    description
   }
 }
 

--- a/Sources/BitCollections/BitSet/BitSet.Index.swift
+++ b/Sources/BitCollections/BitSet/BitSet.Index.swift
@@ -55,7 +55,7 @@ extension BitSet.Index: CustomStringConvertible {
 extension BitSet.Index: CustomDebugStringConvertible {
   // A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    "BitSet.Index(\(_value))"
+    description
   }
 }
 

--- a/Sources/DequeModule/Deque+Descriptions.swift
+++ b/Sources/DequeModule/Deque+Descriptions.swift
@@ -23,7 +23,6 @@ extension Deque: CustomStringConvertible {
 extension Deque: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _arrayDescription(
-      for: self, debug: true, typeName: "Deque<\(Element.self)>")
+    description
   }
 }

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Collection.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Collection.swift
@@ -94,7 +94,7 @@ extension TreeDictionary.Index: CustomStringConvertible {
 extension TreeDictionary.Index: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _path.description
+    description
   }
 }
 

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Descriptions.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Descriptions.swift
@@ -23,11 +23,6 @@ extension TreeDictionary: CustomStringConvertible {
 extension TreeDictionary: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _dictionaryDescription(
-      for: self, debug: true, typeName: Self._debugTypeName())
-  }
-
-  internal static func _debugTypeName() -> String {
-    "TreeDictionary<\(Key.self), \(Value.self)>"
+    description
   }
 }

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Keys.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Keys.swift
@@ -53,10 +53,7 @@ extension TreeDictionary.Keys: CustomStringConvertible {
 extension TreeDictionary.Keys: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _arrayDescription(
-      for: self,
-      debug: true,
-      typeName: "\(TreeDictionary._debugTypeName()).Keys")
+    description
   }
 }
 

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Values.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Values.swift
@@ -56,10 +56,7 @@ extension TreeDictionary.Values: CustomStringConvertible {
 extension TreeDictionary.Values: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _arrayDescription(
-      for: self,
-      debug: true,
-      typeName: "\(TreeDictionary._debugTypeName()).Values")
+    description
   }
 }
 

--- a/Sources/HashTreeCollections/TreeSet/TreeSet+Descriptions.swift
+++ b/Sources/HashTreeCollections/TreeSet/TreeSet+Descriptions.swift
@@ -23,11 +23,6 @@ extension TreeSet: CustomStringConvertible {
 extension TreeSet: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _arrayDescription(
-      for: self, debug: true, typeName: _debugTypeName())
-  }
-
-  internal func _debugTypeName() -> String {
-    "TreeSet<\(Element.self)>"
+    description
   }
 }

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Descriptions.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Descriptions.swift
@@ -23,11 +23,6 @@ extension OrderedDictionary: CustomStringConvertible {
 extension OrderedDictionary: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _dictionaryDescription(
-      for: self.elements, debug: true, typeName: Self._debugTypeName())
-  }
-
-  internal static func _debugTypeName() -> String {
-    "OrderedDictionary<\(Key.self), \(Value.self)>"
+    description
   }
 }

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.SubSequence.swift
@@ -47,11 +47,7 @@ extension OrderedDictionary.Elements.SubSequence: CustomStringConvertible {
 extension OrderedDictionary.Elements.SubSequence: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _dictionaryDescription(
-      for: self,
-      debug: true,
-      typeName: "\(OrderedDictionary._debugTypeName()).Elements.SubSequence"
-    )
+    description
   }
 }
 

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
@@ -342,10 +342,7 @@ extension OrderedDictionary.Elements: CustomStringConvertible {
 extension OrderedDictionary.Elements: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _dictionaryDescription(
-      for: self,
-      debug: true,
-      typeName: "OrderedDictionary<\(Key.self), \(Value.self)>.Elements")
+    description
   }
 }
 

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
@@ -41,10 +41,7 @@ extension OrderedDictionary.Values: CustomStringConvertible {
 extension OrderedDictionary.Values: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _arrayDescription(
-      for: self,
-      debug: true,
-      typeName: "OrderedDictionary<\(Key.self), \(Value.self)>.Keys")
+    description
   }
 }
 

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Descriptions.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Descriptions.swift
@@ -23,11 +23,6 @@ extension OrderedSet: CustomStringConvertible {
 extension OrderedSet: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _arrayDescription(
-      for: self, debug: true, typeName: Self._debugTypeName())
-  }
-
-  internal static func _debugTypeName() -> String {
-    "OrderedSet<\(Element.self)>"
+    description
   }
 }

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
@@ -63,11 +63,7 @@ extension OrderedSet.SubSequence: CustomStringConvertible {
 extension OrderedSet.SubSequence: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _arrayDescription(
-      for: self,
-      debug: true,
-      typeName: "\(OrderedSet._debugTypeName()).SubSequence"
-    )
+    description
   }
 }
 

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
@@ -71,17 +71,14 @@ extension OrderedSet.UnorderedView: Sendable where Element: Sendable {}
 extension OrderedSet.UnorderedView: CustomStringConvertible {
   /// A textual representation of this instance.
   public var description: String {
-    _base.description
+    _arrayDescription(for: _base)
   }
 }
 
 extension OrderedSet.UnorderedView: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
-    _arrayDescription(
-      for: _base,
-      debug: true,
-      typeName: "\(OrderedSet._debugTypeName()).UnorderedView")
+    description
   }
 }
 

--- a/Sources/_CollectionsUtilities/Descriptions.swift.gyb
+++ b/Sources/_CollectionsUtilities/Descriptions.swift.gyb
@@ -35,15 +35,9 @@ ${modifier} func _addressString<T: AnyObject>(for object: Unmanaged<T>) -> Strin
 
 @inlinable
 ${modifier} func _arrayDescription<C: Collection>(
-  for elements: C,
-  debug: Bool = false,
-  typeName: String? = nil
+  for elements: C
 ) -> String {
-  var result = ""
-  if let typeName = typeName {
-    result += "\(typeName)("
-  }
-  result += "["
+  var result = "["
   var first = true
   for item in elements {
     if first {
@@ -51,53 +45,30 @@ ${modifier} func _arrayDescription<C: Collection>(
     } else {
       result += ", "
     }
-    if debug {
-      debugPrint(item, terminator: "", to: &result)
-    } else {
-      print(item, terminator: "", to: &result)
-    }
+    debugPrint(item, terminator: "", to: &result)
   }
   result += "]"
-  if typeName != nil { result += ")" }
   return result
 }
 
 @inlinable
 ${modifier} func _dictionaryDescription<Key, Value, C: Collection>(
-  for elements: C,
-  debug: Bool = false,
-  typeName: String? = nil
+  for elements: C
 ) -> String where C.Element == (key: Key, value: Value) {
-  var result = ""
-  if let typeName = typeName {
-    result += "\(typeName)("
-  }
-
-  if elements.isEmpty {
-    result += "[:]"
-  } else {
-    result += "["
-    var first = true
-    for (key, value) in elements {
-      if first {
-        first = false
-      } else {
-        result += ", "
-      }
-      if debug {
-        debugPrint(key, terminator: "", to: &result)
-        result += ": "
-        debugPrint(value, terminator: "", to: &result)
-      } else {
-        result += "\(key): \(value)"
-      }
+  guard !elements.isEmpty else { return "[:]" }
+  var result = "["
+  var first = true
+  for (key, value) in elements {
+    if first {
+      first = false
+    } else {
+      result += ", "
     }
-    result += "]"
+    debugPrint(key, terminator: "", to: &result)
+    result += ": "
+    debugPrint(value, terminator: "", to: &result)
   }
-
-  if typeName != nil {
-    result += ")"
-  }
+  result += "]"
   return result
 }
 % end

--- a/Sources/_CollectionsUtilities/autogenerated/Descriptions.swift
+++ b/Sources/_CollectionsUtilities/autogenerated/Descriptions.swift
@@ -41,15 +41,9 @@ internal func _addressString<T: AnyObject>(for object: Unmanaged<T>) -> String {
 
 @inlinable
 internal func _arrayDescription<C: Collection>(
-  for elements: C,
-  debug: Bool = false,
-  typeName: String? = nil
+  for elements: C
 ) -> String {
-  var result = ""
-  if let typeName = typeName {
-    result += "\(typeName)("
-  }
-  result += "["
+  var result = "["
   var first = true
   for item in elements {
     if first {
@@ -57,53 +51,30 @@ internal func _arrayDescription<C: Collection>(
     } else {
       result += ", "
     }
-    if debug {
-      debugPrint(item, terminator: "", to: &result)
-    } else {
-      print(item, terminator: "", to: &result)
-    }
+    debugPrint(item, terminator: "", to: &result)
   }
   result += "]"
-  if typeName != nil { result += ")" }
   return result
 }
 
 @inlinable
 internal func _dictionaryDescription<Key, Value, C: Collection>(
-  for elements: C,
-  debug: Bool = false,
-  typeName: String? = nil
+  for elements: C
 ) -> String where C.Element == (key: Key, value: Value) {
-  var result = ""
-  if let typeName = typeName {
-    result += "\(typeName)("
-  }
-
-  if elements.isEmpty {
-    result += "[:]"
-  } else {
-    result += "["
-    var first = true
-    for (key, value) in elements {
-      if first {
-        first = false
-      } else {
-        result += ", "
-      }
-      if debug {
-        debugPrint(key, terminator: "", to: &result)
-        result += ": "
-        debugPrint(value, terminator: "", to: &result)
-      } else {
-        result += "\(key): \(value)"
-      }
+  guard !elements.isEmpty else { return "[:]" }
+  var result = "["
+  var first = true
+  for (key, value) in elements {
+    if first {
+      first = false
+    } else {
+      result += ", "
     }
-    result += "]"
+    debugPrint(key, terminator: "", to: &result)
+    result += ": "
+    debugPrint(value, terminator: "", to: &result)
   }
-
-  if typeName != nil {
-    result += ")"
-  }
+  result += "]"
   return result
 }
 #else // !COLLECTIONS_SINGLE_MODULE
@@ -126,15 +97,9 @@ public func _addressString<T: AnyObject>(for object: Unmanaged<T>) -> String {
 
 @inlinable
 public func _arrayDescription<C: Collection>(
-  for elements: C,
-  debug: Bool = false,
-  typeName: String? = nil
+  for elements: C
 ) -> String {
-  var result = ""
-  if let typeName = typeName {
-    result += "\(typeName)("
-  }
-  result += "["
+  var result = "["
   var first = true
   for item in elements {
     if first {
@@ -142,53 +107,30 @@ public func _arrayDescription<C: Collection>(
     } else {
       result += ", "
     }
-    if debug {
-      debugPrint(item, terminator: "", to: &result)
-    } else {
-      print(item, terminator: "", to: &result)
-    }
+    debugPrint(item, terminator: "", to: &result)
   }
   result += "]"
-  if typeName != nil { result += ")" }
   return result
 }
 
 @inlinable
 public func _dictionaryDescription<Key, Value, C: Collection>(
-  for elements: C,
-  debug: Bool = false,
-  typeName: String? = nil
+  for elements: C
 ) -> String where C.Element == (key: Key, value: Value) {
-  var result = ""
-  if let typeName = typeName {
-    result += "\(typeName)("
-  }
-
-  if elements.isEmpty {
-    result += "[:]"
-  } else {
-    result += "["
-    var first = true
-    for (key, value) in elements {
-      if first {
-        first = false
-      } else {
-        result += ", "
-      }
-      if debug {
-        debugPrint(key, terminator: "", to: &result)
-        result += ": "
-        debugPrint(value, terminator: "", to: &result)
-      } else {
-        result += "\(key): \(value)"
-      }
+  guard !elements.isEmpty else { return "[:]" }
+  var result = "["
+  var first = true
+  for (key, value) in elements {
+    if first {
+      first = false
+    } else {
+      result += ", "
     }
-    result += "]"
+    debugPrint(key, terminator: "", to: &result)
+    result += ": "
+    debugPrint(value, terminator: "", to: &result)
   }
-
-  if typeName != nil {
-    result += ")"
-  }
+  result += "]"
   return result
 }
 #endif // COLLECTIONS_SINGLE_MODULE

--- a/Tests/BitCollectionsTests/BitArrayTests.swift
+++ b/Tests/BitCollectionsTests/BitArrayTests.swift
@@ -934,13 +934,13 @@ final class BitArrayTests: CollectionTestCase {
 
   func test_debugDescription() {
     let a: BitArray = []
-    expectEqual("\(String(reflecting: a))", "BitArray()")
+    expectEqual("\(String(reflecting: a))", "[]")
 
     let b: BitArray = [true, false, true, true, true]
-    expectEqual("\(String(reflecting: b))", "BitArray(11101)")
+    expectEqual("\(String(reflecting: b))", "11101")
 
     let c: BitArray = [false, false, false, false, true, true, true, false]
-    expectEqual("\(String(reflecting: c))", "BitArray(01110000)")
+    expectEqual("\(String(reflecting: c))", "01110000")
   }
 
   func test_mirror() {

--- a/Tests/BitCollectionsTests/BitSetTests.swift
+++ b/Tests/BitCollectionsTests/BitSetTests.swift
@@ -1513,13 +1513,13 @@ final class BitSetTest: CollectionTestCase {
 
   func test_debugDescription() {
     let a: BitSet = []
-    expectEqual("\(String(reflecting: a))", "BitSet([])")
+    expectEqual("\(String(reflecting: a))", "[]")
 
     let b: BitSet = [1, 2, 3]
-    expectEqual("\(String(reflecting: b))", "BitSet([1, 2, 3])")
+    expectEqual("\(String(reflecting: b))", "[1, 2, 3]")
 
     let c: BitSet = [23, 652, 892, 19230]
-    expectEqual("\(String(reflecting: c))", "BitSet([23, 652, 892, 19230])")
+    expectEqual("\(String(reflecting: c))", "[23, 652, 892, 19230]")
   }
 
   func test_index_descriptions() {
@@ -1527,7 +1527,7 @@ final class BitSetTest: CollectionTestCase {
     let i = a.startIndex
 
     expectEqual(i.description, "3")
-    expectEqual(i.debugDescription, "BitSet.Index(3)")
+    expectEqual(i.debugDescription, "3")
   }
 
   func test_mirror() {

--- a/Tests/DequeTests/DequeTests.swift
+++ b/Tests/DequeTests/DequeTests.swift
@@ -52,19 +52,18 @@ final class DequeTests: CollectionTestCase {
     expectEqual("\([1, 2, nil, 3] as Deque<Int?>)", "[Optional(1), Optional(2), nil, Optional(3)]")
 
     let deque: Deque<StringConvertibleValue> = [1, 2, 3]
-    expectEqual("\(deque)", "[description(1), description(2), description(3)]")
+    expectEqual("\(deque)", "[debugDescription(1), debugDescription(2), debugDescription(3)]")
   }
 
   func test_debugDescription() {
-    expectEqual(String(reflecting: [] as Deque<Int>),
-                "Deque<Int>([])")
-    expectEqual(String(reflecting: [1, 2, 3] as Deque<Int>),
-                "Deque<Int>([1, 2, 3])")
-    expectEqual(String(reflecting: [1, 2, nil, 3] as Deque<Int?>),
-                "Deque<Optional<Int>>([Optional(1), Optional(2), nil, Optional(3)])")
+    expectEqual(String(reflecting: [] as Deque<Int>), "[]")
+    expectEqual(String(reflecting: [1, 2, 3] as Deque<Int>), "[1, 2, 3]")
+    expectEqual(
+      String(reflecting: [1, 2, nil, 3] as Deque<Int?>),
+      "[Optional(1), Optional(2), nil, Optional(3)]")
 
     let deque: Deque<StringConvertibleValue> = [1, 2, 3]
-    expectEqual(String(reflecting: deque), "Deque<StringConvertibleValue>([debugDescription(1), debugDescription(2), debugDescription(3)])")
+    expectEqual(String(reflecting: deque), "[debugDescription(1), debugDescription(2), debugDescription(3)]")
   }
 
   func test_customMirror() {

--- a/Tests/HashTreeCollectionsTests/Colliders.swift
+++ b/Tests/HashTreeCollectionsTests/Colliders.swift
@@ -43,11 +43,11 @@ struct Collider:
   }
 
   var description: String {
-    "\(identity)"
+    "\(identity)(#\(hash))"
   }
 
   var debugDescription: String {
-    "\(identity)-#\(hash)"
+    description
   }
 }
 

--- a/Tests/HashTreeCollectionsTests/TreeDictionary Tests.swift
+++ b/Tests/HashTreeCollectionsTests/TreeDictionary Tests.swift
@@ -471,20 +471,14 @@ class TreeDictionaryTests: CollectionTestCase {
 
   func test_CustomDebugStringConvertible() {
     let a: TreeDictionary<Int, Int> = [:]
-    expectEqual(
-      a.debugDescription,
-      "TreeDictionary<Int, Int>([:])")
+    expectEqual(a.debugDescription, "[:]")
 
     let b: TreeDictionary<Int, Int> = [0: 1]
-    expectEqual(
-      b.debugDescription,
-      "TreeDictionary<Int, Int>([0: 1])")
+    expectEqual(b.debugDescription, "[0: 1]")
 
     let c: TreeDictionary<Int, Int> = [0: 1, 2: 3, 4: 5]
     let cd = c.map { "\($0.key): \($0.value)"}.joined(separator: ", ")
-    expectEqual(
-      c.debugDescription,
-      "TreeDictionary<Int, Int>([\(cd)])")
+    expectEqual(c.debugDescription, "[\(cd)]")
   }
 
 

--- a/Tests/HashTreeCollectionsTests/TreeDictionary.Keys Tests.swift
+++ b/Tests/HashTreeCollectionsTests/TreeDictionary.Keys Tests.swift
@@ -37,15 +37,11 @@ class TreeDictionaryKeysTests: CollectionTestCase {
     ]
 
     if d.first!.key == "a" {
-      expectEqual(d.keys.description, "[a, b]")
-      expectEqual(
-        d.keys.debugDescription,
-        "TreeDictionary<String, Int>.Keys([\"a\", \"b\"])")
+      expectEqual(d.keys.description, #"["a", "b"]"#)
+      expectEqual(d.keys.debugDescription, #"["a", "b"]"#)
     } else {
-      expectEqual(d.keys.description, "[b, a]")
-      expectEqual(
-        d.keys.debugDescription,
-        "TreeDictionary<String, Int>.Keys([\"b\", \"a\"])")
+      expectEqual(d.keys.description, #"["b", "a"]"#)
+      expectEqual(d.keys.debugDescription, #"["b", "a"]"#)
     }
   }
 

--- a/Tests/HashTreeCollectionsTests/TreeSet Tests.swift
+++ b/Tests/HashTreeCollectionsTests/TreeSet Tests.swift
@@ -87,11 +87,11 @@ class TreeSetTests: CollectionTestCase {
   func test_descriptions() {
     let empty: TreeSet<Int> = []
     expectEqual(empty.description, "[]")
-    expectEqual(empty.debugDescription, "TreeSet<Int>([])")
+    expectEqual(empty.debugDescription, "[]")
 
     let a: TreeSet = ["a"]
-    expectEqual(a.description, "[a]")
-    expectEqual(a.debugDescription, "TreeSet<String>([\"a\"])")
+    expectEqual(a.description, #"["a"]"#)
+    expectEqual(a.debugDescription, #"["a"]"#)
   }
 
   func test_index_descriptions() {

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
@@ -866,16 +866,13 @@ class OrderedDictionaryTests: CollectionTestCase {
 
   func test_CustomDebugStringConvertible() {
     let a: OrderedDictionary<Int, Int> = [:]
-    expectEqual(a.debugDescription,
-                "OrderedDictionary<Int, Int>([:])")
+    expectEqual(a.debugDescription, "[:]")
 
     let b: OrderedDictionary<Int, Int> = [0: 1]
-    expectEqual(b.debugDescription,
-                "OrderedDictionary<Int, Int>([0: 1])")
+    expectEqual(b.debugDescription, "[0: 1]")
 
     let c: OrderedDictionary<Int, Int> = [0: 1, 2: 3, 4: 5]
-    expectEqual(c.debugDescription,
-                "OrderedDictionary<Int, Int>([0: 1, 2: 3, 4: 5])")
+    expectEqual(c.debugDescription, "[0: 1, 2: 3, 4: 5]")
   }
 
   func test_CustomReflectable() {

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Elements Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Elements Tests.swift
@@ -99,16 +99,13 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
 
   func test_CustomDebugStringConvertible() {
     let a: OrderedDictionary<Int, Int> = [:]
-    expectEqual(a.elements.debugDescription,
-                "OrderedDictionary<Int, Int>.Elements([:])")
+    expectEqual(a.elements.debugDescription, "[:]")
 
     let b: OrderedDictionary<Int, Int> = [0: 1]
-    expectEqual(b.elements.debugDescription,
-                "OrderedDictionary<Int, Int>.Elements([0: 1])")
+    expectEqual(b.elements.debugDescription, "[0: 1]")
 
     let c: OrderedDictionary<Int, Int> = [0: 1, 2: 3, 4: 5]
-    expectEqual(c.elements.debugDescription,
-                "OrderedDictionary<Int, Int>.Elements([0: 1, 2: 3, 4: 5])")
+    expectEqual(c.elements.debugDescription, "[0: 1, 2: 3, 4: 5]")
   }
 
   func test_SubSequence_descriptions() {
@@ -119,10 +116,8 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
 
     let s = d.elements[0 ..< 1]
 
-    expectEqual(s.description, "[a: 1]")
-    expectEqual(
-      s.debugDescription,
-      "OrderedDictionary<String, Int>.Elements.SubSequence([\"a\": 1])")
+    expectEqual(s.description, #"["a": 1]"#)
+    expectEqual(s.debugDescription, #"["a": 1]"#)
   }
 
   func test_customReflectable() {

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Values Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Values Tests.swift
@@ -35,9 +35,7 @@ class OrderedDictionaryValueTests: CollectionTestCase {
     ]
 
     expectEqual(d.values.description, "[1, 2]")
-    expectEqual(
-      d.values.debugDescription,
-      "OrderedDictionary<String, Int>.Keys([1, 2])")
+    expectEqual(d.values.debugDescription, "[1, 2]")
   }
 
   func test_values_RandomAccessCollection() {

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -147,13 +147,13 @@ class OrderedSetTests: CollectionTestCase {
 
   func test_CustomDebugStringConvertible() {
     let a: OrderedSet<Int> = []
-    expectEqual(a.debugDescription, "OrderedSet<Int>([])")
+    expectEqual(a.debugDescription, "[]")
 
     let b: OrderedSet<Int> = [0]
-    expectEqual(b.debugDescription, "OrderedSet<Int>([0])")
+    expectEqual(b.debugDescription, "[0]")
 
     let c: OrderedSet<Int> = [0, 1, 2, 3, 4]
-    expectEqual(c.debugDescription, "OrderedSet<Int>([0, 1, 2, 3, 4])")
+    expectEqual(c.debugDescription, "[0, 1, 2, 3, 4]")
   }
 
   func test_SubSequence_descriptions() {
@@ -162,10 +162,7 @@ class OrderedSetTests: CollectionTestCase {
     let slice = s[1 ..< 3]
 
     expectEqual(slice.description, "[1, 2]")
-    expectEqual(
-      slice.debugDescription,
-      "OrderedSet<Int>.SubSequence([1, 2])")
-
+    expectEqual(slice.debugDescription, "[1, 2]")
   }
 
   func test_customReflectable() {

--- a/Tests/_CollectionsTestSupport/MinimalTypes/MinimalDecoder.swift
+++ b/Tests/_CollectionsTestSupport/MinimalTypes/MinimalDecoder.swift
@@ -179,7 +179,7 @@ extension MinimalDecoder.KeyedContainer: KeyedDecodingContainerProtocol {
     return input[key.stringValue] != nil
   }
 
-  func _decode<Key: CodingKey>(key: Key) throws -> Value {
+  func _decode<K: CodingKey>(key: K) throws -> Value {
     expectTrue(isValid, "Container isn't valid", trapping: true)
     commitPendingContainer()
     guard let value = input[key.stringValue] else {


### PR DESCRIPTION
- For CustomStringConvertible, `description` should print elements using `String(reflecting:)` rather than `String(describing:)`, to avoid element output from interfering with syntactically relevant punctuation within structured list displays.
- To make this work without making displays overly verbose, make `debugDescription` mostly the same as `description`, except for escaping raw string displays when and if needed.
- Avoid printing type names in `debugDescription` — it is generally not helpful, as the type is already easily accessible elsewhere. Including it makes for overly verbose displays when the type serves as an Element of a collection.
- Avoid having `debugDescription` return the empty string — it can be confusing when such a description appears in list displays.

Resolves #301.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [X] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [X] I've updated the documentation if necessary.
