### PR TITLE
Replace `UnsafeMutablePointer.assign` with `update` to remove rename warnings

### DIFF
--- a/Sources/OrderedCollections/HashTable/_HashTable+UnsafeHandle.swift
+++ b/Sources/OrderedCollections/HashTable/_HashTable+UnsafeHandle.swift
@@ -484,7 +484,7 @@ extension _UnsafeHashTable {
   @usableFromInline
   internal func clear() {
     assertMutable()
-    _buckets.assign(repeating: 0, count: wordCount)
+    _buckets.update(repeating: 0, count: wordCount)
   }
 }
 

--- a/Sources/OrderedCollections/Utilities/_UnsafeBitset.swift
+++ b/Sources/OrderedCollections/Utilities/_UnsafeBitset.swift
@@ -184,7 +184,7 @@ extension _UnsafeBitset {
   @_effects(releasenone)
   internal mutating func clear() {
     guard _words.count > 0 else { return }
-    _words.baseAddress!.assign(repeating: .empty, count: _words.count)
+    _words.baseAddress!.update(repeating: .empty, count: _words.count)
     _count = 0
   }
 


### PR DESCRIPTION
Replaces to `UnsafeMutablePointer.assign(repeating:count:)` with renamed `UnsafeMutablePointer.update(repeating:count:)` to remove compilation warnings.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [X] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [X] I've updated the documentation if necessary.
