### PR TITLE
initial version of DictionaryProtocol

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -227,6 +227,8 @@ let targets: [CustomTarget] = [
     kind: .test,
     name: "DequeTests",
     dependencies: ["DequeModule", "_CollectionsTestSupport"]),
+  
+  .target(kind: .exported, name: "DictionaryProtocol"),
 
   .target(
     kind: .exported,
@@ -251,7 +253,7 @@ let targets: [CustomTarget] = [
   .target(
     kind: .exported,
     name: "OrderedCollections",
-    dependencies: ["_CollectionsUtilities"],
+    dependencies: ["_CollectionsUtilities", "DictionaryProtocol"],
     exclude: ["CMakeLists.txt"]),
   .target(
     kind: .test,

--- a/Sources/DictionaryProtocol/DictionaryConformance.swift
+++ b/Sources/DictionaryProtocol/DictionaryConformance.swift
@@ -1,0 +1,4 @@
+extension Dictionary: DictionaryProtocol {
+    public typealias Elements = Self
+    public var elements: Elements { self }
+}

--- a/Sources/DictionaryProtocol/DictionaryProtocol.swift
+++ b/Sources/DictionaryProtocol/DictionaryProtocol.swift
@@ -1,0 +1,48 @@
+public protocol DictionaryProtocol<Key, Value>: Sequence, ExpressibleByDictionaryLiteral where Element == (key: Key, value: Value), Key: Hashable {
+    associatedtype Key
+    associatedtype Value
+    
+    associatedtype Keys: Collection where Keys.Element == Key
+    associatedtype Values: Collection where Values.Element == Value
+    associatedtype Elements: Collection where Elements.Element == Element
+    
+    var keys: Keys { get }
+    var values: Values { get }
+    var elements: Elements { get }
+        
+    subscript(key: Key) -> Value? { get }
+    
+    init()
+    
+    // Cannot implement since stdlib's Dictionary has a different signature (unlabelled tuple)
+    //init<S: Sequence>(uniqueKeysWithValues keysAndValues: S) where S.Element == (key: Key, value: Value)
+    
+    init<S: Sequence>(uniqueKeysWithValues keysAndValues: S) where S.Element == (Key, Value)
+    
+    init<S: Sequence>(
+        _ keysAndValues: S,
+        uniquingKeysWith combine: (Value, Value) throws -> Value
+    ) rethrows where S.Element == (Key, Value)
+    
+    // OrderedDictionary also has a more generic version of this with the where clause: `where Value: RangeReplaceableCollection, Value.Element == S.Element` instead of `Value == [S.Element]`
+    init<S: Sequence>(
+        grouping values: S,
+        by keyForValue: (S.Element) throws -> Key
+    ) rethrows where Value == [S.Element]
+
+    init(_ other: some DictionaryProtocol<Key, Value>)
+    
+    // does not work for stdlib Dictionary. Not sure how to capture stdlib Dictionary signature for this method in protocol
+    //func mapValues<T, Result: DictionaryProtocol>(_ transform: (Value) throws -> T) rethrows -> Result where Result.Value == T
+    // func compactMapValues<T> // same as above
+    
+    func filter(_ isIncluded: (Element) throws -> Bool) rethrows -> Self
+}
+
+extension DictionaryProtocol {
+    // This does not guarantee any sort of ordering when using `OrderedDictionary` however...
+    public init(_ other: some DictionaryProtocol<Key, Value>) {
+        // .lazy.map in order to remove labels from tuple
+        self.init(uniqueKeysWithValues: other.elements.lazy.map { $0 })
+    }
+}

--- a/Sources/DictionaryProtocol/MutableDictionaryProtocol.swift
+++ b/Sources/DictionaryProtocol/MutableDictionaryProtocol.swift
@@ -1,0 +1,7 @@
+protocol MutableDictionaryProtocol<Key, Value>: DictionaryProtocol {
+    var values: Values { get set }
+    var elements: Elements { get set }
+    
+    mutating func updateValue(_ value: Value, forKey key: Key) -> Value?
+    mutating func removeValue(forKey key: Key) -> Value?
+}

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import DictionaryProtocol
+
 /// An ordered collection of key-value pairs.
 ///
 /// Like the standard `Dictionary`, ordered dictionaries use a hash table to
@@ -217,6 +219,8 @@ public struct OrderedDictionary<Key: Hashable, Value> {
     self._values = values
   }
 }
+
+extension OrderedDictionary: DictionaryProtocol { }
 
 extension OrderedDictionary {
   /// A read-only ordered collection view for the keys contained in this dictionary, as


### PR DESCRIPTION
This is a first attempt at implementing a `DictionaryProtocol` protocol as discussed in #293 
This is not complete yet and needs discussion in order to improve! 
For now it conforms stdlib `Dictionary` and `OrderedDictionary` to the newly introduced `DictionaryProtocol`. 
Hoping to get some feedback on the current implementation and will add conformances to the other Dictionary objects next.

Would we also like to introduce a `SetProtocol`? Should we consider this first since Dictionaries often depend on some type of `Set` of keys? Or do we keep the keys collection more generic than constraining it to a `Set` kind of type?

Not all checks are done since this is still in development :) Would love to hear people's thoughts!

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
