### PR TITLE
[1.0][benchmark] Update std::function syntax for current C++

### DIFF
--- a/Benchmarks/CppBenchmarks/src/CustomHash.h
+++ b/Benchmarks/CppBenchmarks/src/CustomHash.h
@@ -19,7 +19,7 @@
 
 extern cpp_hash_fn custom_hash_fn;
 
-struct custom_intptr_hash: public std::unary_function<intptr_t, std::size_t>
+struct custom_intptr_hash: public std::function<std::size_t(intptr_t)>
 {
   std::size_t
   operator()(intptr_t value) const


### PR DESCRIPTION
C++17 has removed `std::unary_function`. Migrate to using `std::function`.

(This may break our ability to build benchmarks with older clang/libc++ releases. That is fine.)

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
