### PR TITLE
[1.0][test] Fix typename shadowing warning in Swift 5.9

### DIFF
--- a/Sources/_CollectionsTestSupport/MinimalTypes/MinimalDecoder.swift
+++ b/Sources/_CollectionsTestSupport/MinimalTypes/MinimalDecoder.swift
@@ -179,7 +179,7 @@ extension MinimalDecoder.KeyedContainer: KeyedDecodingContainerProtocol {
     return input[key.stringValue] != nil
   }
 
-  func _decode<Key: CodingKey>(key: Key) throws -> Value {
+  func _decode<CKey: CodingKey>(key: CKey) throws -> Value {
     expectTrue(isValid, "Container isn't valid", trapping: true)
     commitPendingContainer()
     guard let value = input[key.stringValue] else {


### PR DESCRIPTION
This resolves a valid 5.9 compiler warning within the test target.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
