### PR TITLE
Let deque have its capacity shrunk

### DIFF
--- a/Sources/DequeModule/Deque+Collection.swift
+++ b/Sources/DequeModule/Deque+Collection.swift
@@ -525,6 +525,22 @@ extension Deque: RangeReplaceableCollection {
     _storage.ensureUnique(minimumCapacity: minimumCapacity, linearGrowth: true)
   }
 
+  /// Reduces the capacity to store at least the specified number of elements.
+  ///
+  /// Use this method to request that the deque reduces its storage capacity.
+  /// If the capacity of the deque is larger than the target capacity then
+  /// the capacity _may_ be reduced. If the capacity of the deque is smaller
+  /// than the requested capacity, or the deque contains more elements than
+  /// the requested capacity, then the capacity won't be changed.
+  ///
+  /// - Parameters:
+  ///   - targetCapacity: The requested capacity of the deque.
+  ///
+  /// - Complexity: O(`count`)
+  public mutating func shrinkCapacity(_ targetCapacity: Int) {
+    _storage.shrink(targetCapacity: targetCapacity)
+  }
+
   /// Replaces a range of elements with the elements in the specified
   /// collection.
   ///

--- a/Sources/DequeModule/Deque+Testing.swift
+++ b/Sources/DequeModule/Deque+Testing.swift
@@ -41,6 +41,11 @@ extension Deque {
     _storage.capacity
   }
 
+  @_spi(Testing)
+  public var _requestedCapacity: Int {
+    _storage.requestedCapacity
+  }
+
   /// The number of the storage slot in this deque that holds the first element.
   /// (Or would hold it after an insertion in case the deque is currently
   /// empty.)
@@ -67,7 +72,10 @@ extension Deque {
     precondition(contents.count <= capacity)
     let startSlot = _Slot(at: startSlot)
     let buffer = _DequeBuffer<Element>.create(minimumCapacity: capacity) { _ in
-      _DequeBufferHeader(capacity: capacity, count: contents.count, startSlot: startSlot)
+      _DequeBufferHeader(capacity: capacity, 
+                         requestedCapacity: capacity,
+                         count: contents.count,
+                         startSlot: startSlot)
     }
     let storage = Deque<Element>._Storage(unsafeDowncast(buffer, to: _DequeBuffer.self))
     if contents.count > 0 {

--- a/Sources/DequeModule/Deque._UnsafeHandle.swift
+++ b/Sources/DequeModule/Deque._UnsafeHandle.swift
@@ -306,6 +306,7 @@ extension Deque._UnsafeHandle {
         #endif
         return _DequeBufferHeader(
           capacity: capacity,
+          requestedCapacity: minimumCapacity,
           count: count,
           startSlot: .zero)
       })
@@ -340,6 +341,7 @@ extension Deque._UnsafeHandle {
         #endif
         return _DequeBufferHeader(
           capacity: capacity,
+          requestedCapacity: minimumCapacity,
           count: count,
           startSlot: .zero)
       })

--- a/Sources/DequeModule/_DequeBuffer.swift
+++ b/Sources/DequeModule/_DequeBuffer.swift
@@ -44,6 +44,6 @@ extension _DequeBuffer: CustomStringConvertible {
 internal let _emptyDequeStorage = _DequeBuffer<Void>.create(
   minimumCapacity: 0,
   makingHeaderWith: { _ in
-    _DequeBufferHeader(capacity: 0, count: 0, startSlot: .init(at: 0))
+    _DequeBufferHeader(capacity: 0, requestedCapacity: 0, count: 0, startSlot: .init(at: 0))
   })
 

--- a/Sources/DequeModule/_DequeBufferHeader.swift
+++ b/Sources/DequeModule/_DequeBufferHeader.swift
@@ -15,14 +15,18 @@ internal struct _DequeBufferHeader {
   var capacity: Int
 
   @usableFromInline
+  var requestedCapacity: Int
+
+  @usableFromInline
   var count: Int
 
   @usableFromInline
   var startSlot: _DequeSlot
 
   @usableFromInline
-  init(capacity: Int, count: Int, startSlot: _DequeSlot) {
+  init(capacity: Int, requestedCapacity: Int, count: Int, startSlot: _DequeSlot) {
     self.capacity = capacity
+    self.requestedCapacity = requestedCapacity
     self.count = count
     self.startSlot = startSlot
     _checkInvariants()
@@ -32,6 +36,7 @@ internal struct _DequeBufferHeader {
   @usableFromInline @inline(never) @_effects(releasenone)
   internal func _checkInvariants() {
     precondition(capacity >= 0)
+    precondition(requestedCapacity <= capacity)
     precondition(count >= 0 && count <= capacity)
     precondition(startSlot.position >= 0 && startSlot.position <= capacity)
   }

--- a/Tests/DequeTests/DequeTests.swift
+++ b/Tests/DequeTests/DequeTests.swift
@@ -374,5 +374,40 @@ final class DequeTests: CollectionTestCase {
     }
   }
 
+  func test_shrinkCapacityWhenEmpty() {
+    withEvery("capacity", in: [0, 1, 2, 5, 10, 50, 100]) { capacity in
+      var deque = Deque<Int>(minimumCapacity: capacity)
+
+      XCTAssertGreaterThanOrEqual(deque._capacity, capacity)
+      XCTAssertLessThanOrEqual(deque._requestedCapacity, capacity)
+
+      let actual = deque._capacity
+      let reducedCapacity = deque._requestedCapacity / 4
+      deque.shrinkCapacity(reducedCapacity)
+
+      print(actual, deque._capacity)
+      // Shrinkage isn't guaranteed.
+      XCTAssertGreaterThanOrEqual(deque._capacity, reducedCapacity)
+      XCTAssertLessThanOrEqual(deque._requestedCapacity, reducedCapacity)
+    }
+  }
+
+  func test_shrinkCapacityWhenMoreElementsThanTarget() {
+    withEvery("count", in: [0, 1, 2, 5, 10, 50, 100]) { count in
+      var deque = Deque(repeating: 0, count: count)
+      let capacity = deque._capacity
+      deque.shrinkCapacity(0)
+      XCTAssertEqual(deque._capacity, capacity)
+    }
+  }
+
+  func test_shrinkCapacityWhenTargetIsLargerThanCurrent() {
+    withEvery("capacity", in: [0, 1, 2, 5, 10, 50, 100]) { capacity in
+      var deque = Deque<Int>(minimumCapacity: capacity)
+      let capacity = deque._capacity
+      deque.shrinkCapacity(capacity + 1)
+      XCTAssertEqual(deque._capacity, capacity)
+    }
+  }
 }
 


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Collections!

    Before you submit your request, please replace each paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Description

Deque is often used as a buffer and buffers can be subject to "spiky" sizes; many elements may be buffered before being removed which can result in applications holding on to more memory than desired. Since the capacity of deque is an implementation detail, one way to reduce the size of the deque is asking it to shrink itself. 

Related discussion https://github.com/apple/swift-collections/issues/308

### Detailed Design

```swift
extension Deque {
  /// Reduces the capacity to store at least the specified number of elements.
  ///
  /// Use this method to request that the deque reduces its storage capacity.
  /// If the capacity of the deque is larger than the target capacity then
  /// the capacity _may_ be reduced. If the capacity of the deque is smaller
  /// than the requested capacity, or the deque contains more elements than
  /// the requested capacity, then the capacity won't be changed.
  ///
  /// - Parameters:
  ///   - targetCapacity: The requested capacity of the deque.
  ///
  /// - Complexity: O(`count`)
  public mutating func shrinkCapacity(_ targetCapacity: Int)
}
```

### Documentation

> How has the new feature been documented? 

On the new method only.

> Have the relevant portions of the guides in the Documentation folder been updated in addition to symbol-level documentation?

 Yes.

### Testing

> How is the new feature tested?

- By shrinking the capacity of deques of differing capacities
- By attempting to shrink a deque to a capacity smaller than the required capacity
- By attempting to shrink a deque to a capacity greater than its current capacity

### Performance

> How did you verify the new feature performs as expected?

I didn't.

### Source Impact

API addition only

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (to the extent possible).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexpected benchmark regressions.
- [x] I've updated the documentation (if appropriate).
