### PR TITLE
[RopeModule] Remove unnecessary typealiases

### DIFF
--- a/Sources/RopeModule/Rope/Basics/Rope+_Node.swift
+++ b/Sources/RopeModule/Rope/Basics/Rope+_Node.swift
@@ -17,7 +17,6 @@ extension Rope {
   @frozen // Not really! This module isn't ABI stable.
   @usableFromInline
   internal struct _Node: _RopeItem {
-    @usableFromInline internal typealias Element = Rope.Element
     @usableFromInline internal typealias Summary = Rope.Summary
     @usableFromInline internal typealias Index = Rope.Index
     @usableFromInline internal typealias _Item = Rope._Item

--- a/Sources/RopeModule/Rope/Basics/Rope+_UnsafeHandle.swift
+++ b/Sources/RopeModule/Rope/Basics/Rope+_UnsafeHandle.swift
@@ -14,7 +14,6 @@ extension Rope {
   @frozen // Not really! This module isn't ABI stable.
   internal struct _UnsafeHandle<Child: _RopeItem<Summary>> {
     @usableFromInline internal typealias Summary = Rope.Summary
-    @usableFromInline internal typealias Element = Rope.Element
     
     @usableFromInline
     internal let _header: UnsafeMutablePointer<_RopeStorageHeader>


### PR DESCRIPTION
These render the emitted .swiftinterface unusable when the module is built with library evolution enabled.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
