### PR TITLE
Fix typos: OrderedSet Documentation

### DIFF
--- a/Documentation/OrderedSet.md
+++ b/Documentation/OrderedSet.md
@@ -55,7 +55,7 @@ high-level set operations such as `union(_:)`, `intersection(_:)` or
 
 ```swift
 buildingMaterials.contains("glass") // false
-buildingMaterials.intersection(["brick", "straw"]) // ["straw", "brick"]
+buildingMaterials.intersection(["bricks", "straw"]) // ["straw", "bricks"]
 ```
 
 Operations that return an ordered set usually preserve the ordering of
@@ -111,7 +111,7 @@ elements to the end of the collection.
 
 ```swift
 buildingMaterials.unordered.insert("glass") // => inserted: true
-// buildingMaterials is now ["straw", "sticks", "brick", "glass"]
+// buildingMaterials is now ["straw", "sticks", "bricks", "glass"]
 ```
 
 Accessing the unordered view is an efficient operation, with constant

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
@@ -49,7 +49,7 @@
 /// ``intersection(_:)-4o09a`` or ``isSubset(of:)-ptij``.
 ///
 ///     buildingMaterials.contains("glass") // false
-///     buildingMaterials.intersection(["brick", "straw"]) // ["straw", "brick"]
+///     buildingMaterials.intersection(["bricks", "straw"]) // ["straw", "bricks"]
 ///
 /// Operations that return an ordered set usually preserve the ordering of
 /// elements in their input. For example, in the case of the `intersection` call
@@ -99,7 +99,7 @@
 /// elements to the end of the collection.
 ///
 ///     buildingMaterials.unordered.insert("glass") // => inserted: true
-///     // buildingMaterials is now ["straw", "sticks", "brick", "glass"]
+///     // buildingMaterials is now ["straw", "sticks", "bricks", "glass"]
 ///
 /// Accessing the unordered view is an efficient operation, with constant
 /// (minimal) overhead. Direct mutations of the unordered view (such as the


### PR DESCRIPTION
> This PR contains a small fix for a typo in OrderedSet Documentation

I found this typo while testing the [OrdedSet Documentation - Set Operations](https://github.com/apple/swift-collections/blob/main/Documentation/OrderedSet.md#set-operations)

<img width="1396" alt="before" src="https://github.com/apple/swift-collections/assets/19145853/699de461-6cbe-4c41-afe5-e597fad05c25">



#### After fix:

<img width="1122" alt="after" src="https://github.com/apple/swift-collections/assets/19145853/1d1f08d6-fc7f-414d-922b-df3400fb8931">


### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
