### PR TITLE
[OrderedDictionary] forward ordered dictionary values equality to values property

### DIFF
--- a/Benchmarks/Benchmarks/OrderedDictionaryBenchmarks.swift
+++ b/Benchmarks/Benchmarks/OrderedDictionaryBenchmarks.swift
@@ -482,5 +482,61 @@ extension Benchmark {
         blackHole(d)
       }
     }
+    
+    self.add(
+      title: "OrderedDictionary<Int, Int> equality different instance",
+      input: [Int].self
+    ) { input in
+      let keysAndValues = input.map { ($0, 2 * $0) }
+      let left = OrderedDictionary(uniqueKeysWithValues: keysAndValues)
+      let right = OrderedDictionary(uniqueKeysWithValues: keysAndValues)
+      return { timer in
+        timer.measure {
+          precondition(left == right)
+        }
+      }
+    }
+    
+    self.add(
+      title: "OrderedDictionary<Int, Int> equality same instance",
+      input: [Int].self
+    ) { input in
+      let keysAndValues = input.map { ($0, 2 * $0) }
+      let left = OrderedDictionary(uniqueKeysWithValues: keysAndValues)
+      let right = left
+      return { timer in
+        timer.measure {
+          precondition(left == right)
+        }
+      }
+    }
+    
+    self.add(
+      title: "OrderedDictionary<Int, Int>.Values equality different instance",
+      input: [Int].self
+    ) { input in
+      let keysAndValues = input.map { ($0, 2 * $0) }
+      let left = OrderedDictionary(uniqueKeysWithValues: keysAndValues)
+      let right = OrderedDictionary(uniqueKeysWithValues: keysAndValues)
+      return { timer in
+        timer.measure {
+          precondition(left.values == right.values)
+        }
+      }
+    }
+    
+    self.add(
+      title: "OrderedDictionary<Int, Int>.Values equality same instance",
+      input: [Int].self
+    ) { input in
+      let keysAndValues = input.map { ($0, 2 * $0) }
+      let left = OrderedDictionary(uniqueKeysWithValues: keysAndValues)
+      let right = left
+      return { timer in
+        timer.measure {
+          precondition(left.values == right.values)
+        }
+      }
+    }
   }
 }

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
@@ -366,7 +366,7 @@ extension OrderedDictionary.Values: MutableCollection {
 extension OrderedDictionary.Values: Equatable where Value: Equatable {
   @inlinable
   public static func ==(left: Self, right: Self) -> Bool {
-    left.elementsEqual(right)
+    left._base._values == right._base._values
   }
 }
 

--- a/Sources/_CollectionsTestSupport/AssertionContexts/Assertions.swift
+++ b/Sources/_CollectionsTestSupport/AssertionContexts/Assertions.swift
@@ -300,22 +300,6 @@ public func expectEqualElements<S1: Sequence, S2: Sequence>(
     message, trapping: trapping, file: file, line: line)
 }
 
-public func expectNotEqualElements<S1: Sequence, S2: Sequence>(
-  _ left: S1,
-  _ right: S2,
-  _ message: @autoclosure () -> String = "",
-  trapping: Bool = false,
-  file: StaticString = #file,
-  line: UInt = #line
-) where S1.Element == S2.Element, S1.Element: Equatable {
-  let left = Array(left)
-  let right = Array(right)
-  if !left.elementsEqual(right) { return }
-  _expectFailure(
-    "'\(left)' does have equal elements to '\(right)'",
-    message, trapping: trapping, file: file, line: line)
-}
-
 public func expectEquivalentElements<S1: Sequence, S2: Sequence>(
   _ left: S1,
   _ right: S2,

--- a/Sources/_CollectionsTestSupport/AssertionContexts/Assertions.swift
+++ b/Sources/_CollectionsTestSupport/AssertionContexts/Assertions.swift
@@ -300,6 +300,22 @@ public func expectEqualElements<S1: Sequence, S2: Sequence>(
     message, trapping: trapping, file: file, line: line)
 }
 
+public func expectNotEqualElements<S1: Sequence, S2: Sequence>(
+  _ left: S1,
+  _ right: S2,
+  _ message: @autoclosure () -> String = "",
+  trapping: Bool = false,
+  file: StaticString = #file,
+  line: UInt = #line
+) where S1.Element == S2.Element, S1.Element: Equatable {
+  let left = Array(left)
+  let right = Array(right)
+  if !left.elementsEqual(right) { return }
+  _expectFailure(
+    "'\(left)' does have equal elements to '\(right)'",
+    message, trapping: trapping, file: file, line: line)
+}
+
 public func expectEquivalentElements<S1: Sequence, S2: Sequence>(
   _ left: S1,
   _ right: S2,

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Values Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Values Tests.swift
@@ -28,7 +28,8 @@ class OrderedDictionaryValueTests: CollectionTestCase {
       "three": 3,
       "four": 4,
     ]
-    expectEqual(left.values, right.values)
+    expectEqual(left.values, left.values) // Identity fast path
+    expectEqual(left.values, right.values) // Linear algorithm
   }
   
   func test_values_getter_not_equal() {

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Values Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Values Tests.swift
@@ -15,7 +15,40 @@ import XCTest
 import _CollectionsTestSupport
 
 class OrderedDictionaryValueTests: CollectionTestCase {
-  func test_values_getter() {
+  func test_values_getter_equal() {
+    let left: OrderedDictionary = [
+      "one": 1,
+      "two": 2,
+      "three": 3,
+      "four": 4,
+    ]
+    let right: OrderedDictionary = [
+      "one": 1,
+      "two": 2,
+      "three": 3,
+      "four": 4,
+    ]
+    expectEqual(left.values, right.values)
+  }
+  
+  func test_values_getter_not_equal() {
+    let left: OrderedDictionary = [
+      "one": 1,
+      "two": 2,
+      "three": 3,
+      "four": 4,
+    ]
+    let right: OrderedDictionary = [
+      "one": 1,
+      "two": 2,
+      "three": 3,
+      "four": 4,
+      "five": 5,
+    ]
+    expectNotEqual(left.values, right.values)
+  }
+  
+  func test_values_getter_equal_elements() {
     let d: OrderedDictionary = [
       "one": 1,
       "two": 2,
@@ -23,6 +56,16 @@ class OrderedDictionaryValueTests: CollectionTestCase {
       "four": 4,
     ]
     expectEqualElements(d.values, [1, 2, 3, 4])
+  }
+  
+  func test_values_getter_not_equal_elements() {
+    let d: OrderedDictionary = [
+      "one": 1,
+      "two": 2,
+      "three": 3,
+      "four": 4,
+    ]
+    expectNotEqualElements(d.values, [1, 2, 3, 4, 5])
   }
 
   func test_values_RandomAccessCollection() {

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Values Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Values Tests.swift
@@ -58,16 +58,6 @@ class OrderedDictionaryValueTests: CollectionTestCase {
     ]
     expectEqualElements(d.values, [1, 2, 3, 4])
   }
-  
-  func test_values_getter_not_equal_elements() {
-    let d: OrderedDictionary = [
-      "one": 1,
-      "two": 2,
-      "three": 3,
-      "four": 4,
-    ]
-    expectNotEqualElements(d.values, [1, 2, 3, 4, 5])
-  }
 
   func test_values_RandomAccessCollection() {
     withEvery("count", in: 0 ..< 30) { count in


### PR DESCRIPTION
### Background
https://github.com/apple/swift-collections/issues/334

The current implementation of `OrderedDictionary.Values.==` forwards to `Sequence.elementsEqual`, which needs to perform a linear-time (`O[N]`) comparison over both collections.[1]

Since the "backing store" of our `OrderedDictionary.Values` is a `ContiguousArray`, we can forward that equality check through to `ContiguousArray`. If both `Values` instances point to the same identity, the `ContiguousArray` implementation will return early from the comparison.[2]

We perform a similar check (against the `ContiguousArray`) in our implementation of `OrderedDictionary.==`.[3]

[1] https://github.com/apple/swift/blob/main/stdlib/public/core/SequenceAlgorithms.swift#L319-L336
[2] https://github.com/apple/swift/blob/main/stdlib/public/core/ContiguousArray.swift#L1318-L1321
[3] https://github.com/apple/swift-collections/blob/main/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary%2BEquatable.swift#L20-L22

---

### Changes

We migrate from:
```
public static func ==(left: Self, right: Self) -> Bool {
  left.elementsEqual(right)
}
```
We migrate to:
```
public static func ==(left: Self, right: Self) -> Bool {
  left._base._values == right._base._values
}
```

---

### Test Plan

Three new tests are added:

* `OrderedDictionaryValueTests.test_values_getter_equal`
* `OrderedDictionaryValueTests.test_values_getter_not_equal`
* `OrderedDictionaryValueTests.test_values_getter_not_equal_elements`
---

### Next Steps

https://github.com/apple/swift-collections/blob/main/Sources/OrderedCollections/OrderedSet/OrderedSet%2BEquatable.swift#L25-L27

The `OrderedSet` implements similar equality logic. We can implement a similar diff and forward the equality check to the `ContiguousArray` backing store. We can either add that work here in this diff or create a separate diff.

---

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
