### PR TITLE
[OrderedSet] forward ordered set equality to elements property

### DIFF
--- a/Benchmarks/Benchmarks/OrderedSetBenchmarks.swift
+++ b/Benchmarks/Benchmarks/OrderedSetBenchmarks.swift
@@ -536,6 +536,58 @@ extension Benchmark {
         }
       }
     }
+    
+    self.add(
+      title: "OrderedSet<Int> equality different instance",
+      input: Int.self
+    ) { size in
+      return { timer in
+        let left = OrderedSet(0 ..< size)
+        let right = OrderedSet(0 ..< size)
+        timer.measure {
+          precondition(left == right)
+        }
+      }
+    }
+    
+    self.add(
+      title: "OrderedSet<Int> equality same instance",
+      input: Int.self
+    ) { size in
+      return { timer in
+        let left = OrderedSet(0 ..< size)
+        let right = left
+        timer.measure {
+          precondition(left == right)
+        }
+      }
+    }
+    
+    self.add(
+      title: "OrderedSet<Int>.SubSequence equality different instance",
+      input: Int.self
+    ) { size in
+      return { timer in
+        let left = OrderedSet(0 ..< size)[0 ..< size]
+        let right = OrderedSet(0 ..< size)[0 ..< size]
+        timer.measure {
+          precondition(left == right)
+        }
+      }
+    }
+    
+    self.add(
+      title: "OrderedSet<Int>.SubSequence equality same instance",
+      input: Int.self
+    ) { size in
+      return { timer in
+        let left = OrderedSet(0 ..< size)[0 ..< size]
+        let right = left
+        timer.measure {
+          precondition(left == right)
+        }
+      }
+    }
 
   }
 }

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Equatable.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Equatable.swift
@@ -18,6 +18,6 @@ extension OrderedSet: Equatable {
   /// - Complexity: O(`min(left.count, right.count)`)
   @inlinable
   public static func ==(left: Self, right: Self) -> Bool {
-    left.elementsEqual(right)
+    left._elements == right._elements
   }
 }

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
@@ -340,7 +340,7 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
 extension OrderedSet.SubSequence: Equatable {
   @inlinable
   public static func ==(left: Self, right: Self) -> Bool {
-    left.elementsEqual(right)
+    left._base._elements == right._base._elements
   }
 }
 

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
@@ -340,7 +340,7 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
 extension OrderedSet.SubSequence: Equatable {
   @inlinable
   public static func ==(left: Self, right: Self) -> Bool {
-    left._base._elements[_bounds] == right._base._elements[_bounds]
+    left._base._elements[left._bounds] == right._base._elements[right._bounds]
   }
 }
 

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
@@ -340,7 +340,7 @@ extension OrderedSet.SubSequence: RandomAccessCollection {
 extension OrderedSet.SubSequence: Equatable {
   @inlinable
   public static func ==(left: Self, right: Self) -> Bool {
-    left._base._elements == right._base._elements
+    left._base._elements[_bounds] == right._base._elements[_bounds]
   }
 }
 

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -1360,4 +1360,52 @@ class OrderedSetTests: CollectionTestCase {
       }
     }
   }
+  
+  func test_equal() {
+    withEvery("count", in: 0 ..< 20) { count in
+      let set = OrderedSet(0 ..< count)
+      let copy = set
+      expectEqual(copy, set)
+    }
+  }
+  
+  func test_not_equal() {
+    withEvery("count", in: 0 ..< 20) { count in
+      let left = OrderedSet(0 ..< count)
+      let right = OrderedSet(0 ... count)
+      expectNotEqual(left, right)
+    }
+  }
+  
+  func test_equal_elements() {
+    withEvery("count", in: 0 ..< 20) { count in
+      let set = OrderedSet(0 ..< count)
+      let copy = set
+      expectEqualElements(copy, set)
+    }
+  }
+  
+  func test_subsequence_equal() {
+    withEvery("count", in: 0 ..< 20) { count in
+      let subsequence = OrderedSet(0 ..< count)[0 ..< count]
+      let copy = subsequence
+      expectEqual(copy, subsequence)
+    }
+  }
+  
+  func test_subsequence_not_equal() {
+    withEvery("count", in: 0 ..< 20) { count in
+      let left = OrderedSet(0 ..< count)[0 ..< count]
+      let right = OrderedSet(0 ... count)[0 ... count]
+      expectNotEqual(left, right)
+    }
+  }
+  
+  func test_subsequence_equal_elements() {
+    withEvery("count", in: 0 ..< 20) { count in
+      let subsequence = OrderedSet(0 ..< count)[0 ..< count]
+      let copy = subsequence
+      expectEqualElements(copy, subsequence)
+    }
+  }
 }

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -1408,8 +1408,6 @@ class OrderedSetTests: CollectionTestCase {
       let rightSlice = items1[i + 1 ..< c]
       expectNotEqual(items1[0 ..< c], rightSlice) //  same identity
       expectNotEqual(items2[0 ..< c], rightSlice) //  different identity
-      withEvery("j", in: i ... c) { j in
-      }
     }
   }
 }

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -1392,10 +1392,25 @@ class OrderedSetTests: CollectionTestCase {
       withEvery("j", in: i ... c) { j in
         expectEqual(items1[i ..< j], items1[i ..< j]) // Reflective fast path based on identity
         expectEqual(items1[i ..< j], items2[i ..< j]) // Linear path
-        var items3 = OrderedSet(i ..< j)
-        items3.remove(j)
-        items3.insert(j + 1)
-        expectNotEqual(items1[i ..< j], items3[...]) // Slow negative path
+      }
+    }
+  }
+  
+  func test_subsequence_not_equality() {
+    let c = 5
+    let items1 = OrderedSet(0 ..< c)
+    let items2 = OrderedSet(0 ..< c)
+    print(items1)
+    withEvery("i", in: 0 ..< c) { i in
+      print("i", i)
+      let leftSlice = items1[0 ..< i]
+      expectNotEqual(items1[0 ..< c], leftSlice)  //  same identity
+      expectNotEqual(items2[0 ..< c], leftSlice)  //  different identity
+      
+      let rightSlice = items1[i + 1 ..< c]
+      expectNotEqual(items1[0 ..< c], rightSlice) //  same identity
+      expectNotEqual(items2[0 ..< c], rightSlice) //  different identity
+      withEvery("j", in: i ... c) { j in
       }
     }
   }

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -1400,9 +1400,7 @@ class OrderedSetTests: CollectionTestCase {
     let c = 5
     let items1 = OrderedSet(0 ..< c)
     let items2 = OrderedSet(0 ..< c)
-    print(items1)
     withEvery("i", in: 0 ..< c) { i in
-      print("i", i)
       let leftSlice = items1[0 ..< i]
       expectNotEqual(items1[0 ..< c], leftSlice)  //  same identity
       expectNotEqual(items2[0 ..< c], leftSlice)  //  different identity

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -1384,26 +1384,19 @@ class OrderedSetTests: CollectionTestCase {
     }
   }
   
-  func test_subsequence_equal() {
-    withEvery("count", in: 0 ..< 20) { count in
-      let subsequence = OrderedSet(0 ..< count)[0 ..< count]
-      let copy = subsequence
-      expectEqual(copy, subsequence)
-    }
-  }
-  
-  func test_subsequence_not_equal() {
-    withEvery("count", in: 0 ..< 20) { count in
-      let left = OrderedSet(0 ..< count)[0 ..< count]
-      let right = OrderedSet(0 ... count)[0 ... count]
-      expectNotEqual(left, right)
-    }
-  }
-  
-  func test_subsequence_equal_elements() {
-    withEvery("count", in: 0 ..< 20) { count in
-      let subsequence = OrderedSet(0 ..< count)[0 ..< count]
-      expectEqualElements(subsequence, 0 ..< count)
+  func test_subsequence_equality() {
+    let c = 5
+    let items1 = OrderedSet(0 ..< c)
+    let items2 = OrderedSet(0 ..< c)
+    withEvery("i", in: 0 ... c) { i in
+      withEvery("j", in: i ... c) { j in
+        expectEqual(items1[i ..< j], items1[i ..< j]) // Reflective fast path based on identity
+        expectEqual(items1[i ..< j], items2[i ..< j]) // Linear path
+        var items3 = OrderedSet(i ..< j)
+        items3.remove(j)
+        items3.insert(j + 1)
+        expectNotEqual(items1[i ..< j], items3[...]) // Slow negative path
+      }
     }
   }
 }

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -1380,8 +1380,7 @@ class OrderedSetTests: CollectionTestCase {
   func test_equal_elements() {
     withEvery("count", in: 0 ..< 20) { count in
       let set = OrderedSet(0 ..< count)
-      let copy = set
-      expectEqualElements(copy, set)
+      expectEqualElements(set, 0 ..< count)
     }
   }
   
@@ -1404,8 +1403,7 @@ class OrderedSetTests: CollectionTestCase {
   func test_subsequence_equal_elements() {
     withEvery("count", in: 0 ..< 20) { count in
       let subsequence = OrderedSet(0 ..< count)[0 ..< count]
-      let copy = subsequence
-      expectEqualElements(copy, subsequence)
+      expectEqualElements(subsequence, 0 ..< count)
     }
   }
 }


### PR DESCRIPTION
### Background
https://github.com/apple/swift-collections/pull/335

Similar to `OrderedDictionary`, we can forward our `OrderedSet` equality checks down to the `ContiguousArray` instance to take advantage of early return when both arrays point to the same identity (no need to perform a linear comparison over all elements).

A side-effect of this optimization is we also optimize `OrderedDictionary.==`, which performs an equality check on the `keys` property (which is an `OrderedSet`).[1]

[1] https://github.com/apple/swift-collections/blob/main/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary%2BEquatable.swift#L20-L22

---

### Changes

From:
```
public static func ==(left: Self, right: Self) -> Bool {
  left.elementsEqual(right)
}
```
To:
```
public static func ==(left: Self, right: Self) -> Bool {
  left._elements == right._elements
}
```

We can also migrate `OrderedSet.SubSequence`. From:
```
public static func ==(left: Self, right: Self) -> Bool {
  left.elementsEqual(right)
}
```
To:
```
public static func ==(left: Self, right: Self) -> Bool {
  left._base._elements[left._bounds] == right._base._elements[right._bounds]
}
```

---

### Test Plan

Five new tests are added:

- `OrderedSetTests.test_equal`
- `OrderedSetTests.test_not_equal`
- `OrderedSetTests.test_equal_elements`
- `OrderedSetTests.test_subsequence_equality`
- `OrderedSetTests.test_subsequence_not_equality`

---

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
