### PR TITLE
[Deque] check deque equality with buffer identity

### DIFF
--- a/Benchmarks/Benchmarks/DequeBenchmarks.swift
+++ b/Benchmarks/Benchmarks/DequeBenchmarks.swift
@@ -486,5 +486,31 @@ extension Benchmark {
         blackHole(deque)
       }
     }
+    
+    self.add(
+      title: "Deque<Int> equality different instance",
+      input: Int.self
+    ) { size in
+      let left = Deque(0 ..< size)
+      let right = Deque(0 ..< size)
+      return { timer in
+        timer.measure {
+          precondition(left == right)
+        }
+      }
+    }
+    
+    self.add(
+      title: "Deque<Int> equality same instance",
+      input: Int.self
+    ) { size in
+      let left = Deque(0 ..< size)
+      let right = Deque(0 ..< size)
+      return { timer in
+        timer.measure {
+          precondition(left == right)
+        }
+      }
+    }
   }
 }

--- a/Sources/DequeModule/Deque+Equatable.swift
+++ b/Sources/DequeModule/Deque+Equatable.swift
@@ -17,6 +17,16 @@ extension Deque: Equatable where Element: Equatable {
   /// - Complexity: O(`min(left.count, right.count)`)
   @inlinable
   public static func ==(left: Self, right: Self) -> Bool {
+    let lhsCount = left.count
+    if lhsCount != right.count {
+      return false
+    }
+
+    // Test referential equality.
+    if lhsCount == 0 || left._storage._buffer.buffer === right._storage._buffer.buffer {
+      return true
+    }
+    
     return left.elementsEqual(right)
   }
 }

--- a/Sources/DequeModule/Deque+Equatable.swift
+++ b/Sources/DequeModule/Deque+Equatable.swift
@@ -23,7 +23,7 @@ extension Deque: Equatable where Element: Equatable {
     }
 
     // Test referential equality.
-    if lhsCount == 0 || left._storage._buffer.buffer === right._storage._buffer.buffer {
+    if lhsCount == 0 || left._storage.isIdentical(to: right._storage) {
       return true
     }
     

--- a/Sources/DequeModule/Deque._Storage.swift
+++ b/Sources/DequeModule/Deque._Storage.swift
@@ -212,3 +212,11 @@ extension Deque._Storage {
     }
   }
 }
+
+extension Deque._Storage {
+  @inlinable
+  @inline(__always)
+  internal func isIdentical(to other: Self) -> Bool {
+    self._buffer.buffer === other._buffer.buffer
+  }
+}

--- a/Tests/DequeTests/DequeTests.swift
+++ b/Tests/DequeTests/DequeTests.swift
@@ -369,6 +369,23 @@ final class DequeTests: CollectionTestCase {
       }
     }
   }
+  
+  func test_equal() {
+    let deque: Deque<Int> = [1, 2, 3, 4]
+    let copy = deque
+    expectEqual(deque, copy)
+  }
+  
+  func test_not_equal() {
+    let left: Deque<Int> = [1, 2, 3, 4]
+    let right: Deque<Int> = [1, 2, 3, 4, 5]
+    expectNotEqual(left, right)
+  }
+  
+  func test_equal_elements() {
+    let deque: Deque<Int> = [1, 2, 3, 4]
+    expectEqualElements(deque, [1, 2, 3, 4])
+  }
 
 }
 

--- a/Tests/DequeTests/DequeTests.swift
+++ b/Tests/DequeTests/DequeTests.swift
@@ -369,11 +369,6 @@ final class DequeTests: CollectionTestCase {
       }
     }
   }
-  
-  func test_equal_elements() {
-    let deque: Deque<Int> = [1, 2, 3, 4]
-    expectEqualElements(deque, [1, 2, 3, 4])
-  }
 
 }
 

--- a/Tests/DequeTests/DequeTests.swift
+++ b/Tests/DequeTests/DequeTests.swift
@@ -370,18 +370,6 @@ final class DequeTests: CollectionTestCase {
     }
   }
   
-  func test_equal() {
-    let deque: Deque<Int> = [1, 2, 3, 4]
-    let copy = deque
-    expectEqual(deque, copy)
-  }
-  
-  func test_not_equal() {
-    let left: Deque<Int> = [1, 2, 3, 4]
-    let right: Deque<Int> = [1, 2, 3, 4, 5]
-    expectNotEqual(left, right)
-  }
-  
   func test_equal_elements() {
     let deque: Deque<Int> = [1, 2, 3, 4]
     expectEqualElements(deque, [1, 2, 3, 4])


### PR DESCRIPTION
### Background
https://github.com/apple/swift-collections/pull/335

Similar to what we added for `OrderedDictionary`, we can try and optimize our `Deque` equality checks for the case where two `Deque` instances point to the same identity.

Unlike `OrderedDictionary`, our `Deque` is not implemented on `ContiguousArray`. We can try and mimic the approach from `ContiguousArray` here in `Deque` by checking against the identity of the underlying `ManagedBufferPointer` instance.

---

### Changes

From:
```
public static func ==(left: Self, right: Self) -> Bool {
  left.elementsEqual(right)
}
```
To:
```
let lhsCount = left.count
if lhsCount != right.count {
  return false
}

// Test referential equality.
if lhsCount == 0 || left._storage.isIdentical(to: right._storage) {
  return true
}

return left.elementsEqual(right)
```

---

### Test Plan

We leverage the existing `DequeTests`.

---

### Open Questions

Are there any additional edge-casey behaviors we should be testing for?

---

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
