### PR TITLE
[1.0] Backport Sendable conformances on all public types

### DIFF
--- a/Sources/DequeModule/Deque+Collection.swift
+++ b/Sources/DequeModule/Deque+Collection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/DequeModule/Deque+Collection.swift
+++ b/Sources/DequeModule/Deque+Collection.swift
@@ -160,6 +160,10 @@ extension Deque: Sequence {
   }
 }
 
+#if swift(>=5.5)
+extension Deque.Iterator: Sendable where Element: Sendable {}
+#endif
+
 extension Deque: RandomAccessCollection {
   public typealias Index = Int
   public typealias SubSequence = Slice<Self>

--- a/Sources/DequeModule/Deque+Sendable.swift
+++ b/Sources/DequeModule/Deque+Sendable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/DequeModule/Deque+Sendable.swift
+++ b/Sources/DequeModule/Deque+Sendable.swift
@@ -1,0 +1,14 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if swift(>=5.5)
+extension Deque: @unchecked Sendable where Element: Sendable {}
+#endif

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements+SubSequence.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements+SubSequence.swift
@@ -30,6 +30,11 @@ extension OrderedDictionary.Elements {
   }
 }
 
+#if swift(>=5.5)
+extension OrderedDictionary.Elements.SubSequence: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
+
 extension OrderedDictionary.Elements.SubSequence {
   /// A read-only collection view containing the keys in this slice.
   ///
@@ -121,6 +126,11 @@ extension OrderedDictionary.Elements.SubSequence: Sequence {
     Iterator(_base: self)
   }
 }
+
+#if swift(>=5.5)
+extension OrderedDictionary.Elements.SubSequence.Iterator: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
 
 extension OrderedDictionary.Elements.SubSequence: RandomAccessCollection {
   /// The index type for an ordered dictionary: `Int`.

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
@@ -25,6 +25,11 @@ extension OrderedDictionary {
   }
 }
 
+#if swift(>=5.5)
+extension OrderedDictionary.Elements: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
+
 extension OrderedDictionary {
   /// A view of the contents of this dictionary as a random-access collection.
   ///

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sendable.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sendable.swift
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if swift(>=5.5)
+extension OrderedDictionary: @unchecked Sendable
+where Key: Sendable, Value: Sendable {}
+#endif

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sendable.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sendable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sequence.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sequence.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sequence.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Sequence.swift
@@ -61,3 +61,8 @@ extension OrderedDictionary: Sequence {
     Iterator(_base: self)
   }
 }
+
+#if swift(>=5.5)
+extension OrderedDictionary.Iterator: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
@@ -24,6 +24,11 @@ extension OrderedDictionary {
   }
 }
 
+#if swift(>=5.5)
+extension OrderedDictionary.Values: Sendable
+where Key: Sendable, Value: Sendable {}
+#endif
+
 extension OrderedDictionary.Values {
   /// A read-only view of the contents of this collection as an array value.
   ///

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Sendable.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Sendable.swift
@@ -1,0 +1,12 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension OrderedSet: @unchecked Sendable where Element: Sendable {}

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Sendable.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Sendable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
@@ -33,6 +33,10 @@ extension OrderedSet {
   }
 }
 
+#if swift(>=5.5)
+extension OrderedSet.SubSequence: Sendable where Element: Sendable {}
+#endif
+
 extension OrderedSet.SubSequence {
   @inlinable
   internal var _slice: Array<Element>.SubSequence {

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
@@ -62,6 +62,10 @@ extension OrderedSet {
   }
 }
 
+#if swift(>=5.5)
+extension OrderedSet.UnorderedView: Sendable where Element: Sendable {}
+#endif
+
 extension OrderedSet.UnorderedView: CustomStringConvertible {
   /// A textual representation of this instance.
   public var description: String {

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnstableInternals.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnstableInternals.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnstableInternals.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnstableInternals.swift
@@ -46,3 +46,8 @@ extension OrderedSet {
     }
   }
 }
+
+#if swift(>=5.5)
+extension OrderedSet._UnstableInternals: Sendable
+where Element: Sendable {}
+#endif


### PR DESCRIPTION
This backports #191 to the release/1.0 branch, retrofitting that release series with proper support for Swift 5.5.

Resolves #317

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
