### PR TITLE
OrderedSet: Fix sendable conformance on old swifts

### DIFF
--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Sendable.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Sendable.swift
@@ -9,4 +9,6 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=5.5)
 extension OrderedSet: @unchecked Sendable where Element: Sendable {}
+#endif


### PR DESCRIPTION
`OrderedSet` has lost the condition `swift(>=5.5)` around its `Sendable` conformance, and that predictably causes issues on Swifts that predate that.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
