### PR TITLE
Update CMake configuration

### DIFF
--- a/Sources/DequeModule/CMakeLists.txt
+++ b/Sources/DequeModule/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(DequeModule
   Deque+ExpressibleByArrayLiteral.swift
   Deque+Extras.swift
   Deque+Hashable.swift
+  Deque+Sendable.swift
   Deque+Testing.swift
   UnsafeMutableBufferPointer+Utilities.swift)
 set_target_properties(DequeModule PROPERTIES

--- a/Sources/OrderedCollections/CMakeLists.txt
+++ b/Sources/OrderedCollections/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(OrderedCollections
   "OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift"
   "OrderedDictionary/OrderedDictionary+Partial RangeReplaceableCollection.swift"
   "OrderedDictionary/OrderedDictionary+Sequence.swift"
+  "OrderedDictionary/OrderedDictionary+Sendable.swift"
   "OrderedDictionary/OrderedDictionary+Values.swift"
   "OrderedDictionary/OrderedDictionary+Deprecations.swift"
 
@@ -54,6 +55,7 @@ add_library(OrderedCollections
   "OrderedSet/OrderedSet+Partial SetAlgebra+Predicates.swift"
   "OrderedSet/OrderedSet+RandomAccessCollection.swift"
   "OrderedSet/OrderedSet+ReserveCapacity.swift"
+  "OrderedSet/OrderedSet+Sendable.swift"
   "OrderedSet/OrderedSet+SubSequence.swift"
   "OrderedSet/OrderedSet+Testing.swift"
   "OrderedSet/OrderedSet+UnorderedView.swift"


### PR DESCRIPTION
#343 missed updating the CMake build config. (Sadly this project has no working CI.)

Weirdly, the missing `Sendable` conformances are only causing problems on Swift 5.5 -- they must be inferred elsewhere.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
