### PR TITLE
Bugfix Incorrect Assert in BTree.removeFirst/removeLast

### DIFF
--- a/Sources/SortedCollections/BTree/_BTree+Partial RangeReplaceableCollection.swift
+++ b/Sources/SortedCollections/BTree/_BTree+Partial RangeReplaceableCollection.swift
@@ -58,7 +58,7 @@ extension _BTree {
   @inlinable
   @inline(__always)
   public mutating func removeLast(_ k: Int) {
-    assert(0 <= k && k < self.count, "Can't remove more items from a collection than it contains")
+    assert(0 <= k && k <= self.count, "Can't remove more items from a collection than it contains")
     for _ in 0..<k {
       self.removeLast()
     }
@@ -95,7 +95,7 @@ extension _BTree {
   @inlinable
   @inline(__always)
   public mutating func removeFirst(_ k: Int) {
-    assert(0 <= k && k < self.count, "Can't remove more items from a collection than it contains")
+    assert(0 <= k && k <= self.count, "Can't remove more items from a collection than it contains")
     for _ in 0..<k {
       self.removeFirst()
     }

--- a/Tests/SortedCollectionsTests/BTree/BTree+Deletion Tests.swift
+++ b/Tests/SortedCollectionsTests/BTree/BTree+Deletion Tests.swift
@@ -29,5 +29,17 @@ final class NodeDeletionTests: CollectionTestCase {
       }
     }
   }
+
+  func test_removeAllWithRemoveFirst() {
+    withEvery("size", in: [1, 2, 4, 8, 16, 32, 64, 128, 512]) { size in
+      btreeOfSize(size) { tree, _ in
+        expectEqual(tree.count, size)
+
+        tree.removeFirst(size)
+
+        expectEqual(tree.count, 0)
+      }
+    }
+  }
 }
 #endif

--- a/Tests/SortedCollectionsTests/BTree/BTree+Deletion Tests.swift
+++ b/Tests/SortedCollectionsTests/BTree/BTree+Deletion Tests.swift
@@ -41,5 +41,17 @@ final class NodeDeletionTests: CollectionTestCase {
       }
     }
   }
+
+  func test_removeAllWithRemoveLast() {
+    withEvery("size", in: [1, 2, 4, 8, 16, 32, 64, 128, 512]) { size in
+      btreeOfSize(size) { tree, _ in
+        expectEqual(tree.count, size)
+
+        tree.removeLast(size)
+
+        expectEqual(tree.count, 0)
+      }
+    }
+  }
 }
 #endif


### PR DESCRIPTION
`_BTree.removeFirst(_:)` and `_BTree.removeLast(_:)` contains following incorrect assert:

```swift
assert(0 <= k && k < self.count, "Can't remove more items from a collection than it contains")
```

This assertion will cause a crash (in debug mode) when we call one of these functions with the same number of items as the collection contains.

This PR solves this issue by replacing `k < self.count` with `k <= self.count` in the assert.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- ~~I've added benchmarks covering new functionality (if appropriate).~~
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
