### PR TITLE
[Benchmarks] Add Collection Equality Benchmarks

### DIFF
--- a/Benchmarks/Sources/Benchmarks/DequeBenchmarks.swift
+++ b/Benchmarks/Sources/Benchmarks/DequeBenchmarks.swift
@@ -512,7 +512,7 @@ extension Benchmark {
     }
     
     self.add(
-      title: "Deque<Int> equality different instance",
+      title: "Deque<Int> equality, unique",
       input: Int.self
     ) { size in
       let left = Deque(0 ..< size)
@@ -525,7 +525,7 @@ extension Benchmark {
     }
     
     self.add(
-      title: "Deque<Int> equality same instance",
+      title: "Deque<Int> equality, shared",
       input: Int.self
     ) { size in
       let left = Deque(0 ..< size)
@@ -536,5 +536,6 @@ extension Benchmark {
         }
       }
     }
+    
   }
 }

--- a/Benchmarks/Sources/Benchmarks/DictionaryBenchmarks.swift
+++ b/Benchmarks/Sources/Benchmarks/DictionaryBenchmarks.swift
@@ -407,6 +407,34 @@ extension Benchmark {
         blackHole(d)
       }
     }
-
+    
+    self.add(
+      title: "Dictionary<Int, Int> equality, unique",
+      input: [Int].self
+    ) { input in
+      let keysAndValues = input.map { ($0, 2 * $0) }
+      let left = Dictionary(uniqueKeysWithValues: keysAndValues)
+      let right = Dictionary(uniqueKeysWithValues: keysAndValues)
+      return { timer in
+        timer.measure {
+          precondition(left == right)
+        }
+      }
+    }
+    
+    self.add(
+      title: "Dictionary<Int, Int> equality, shared",
+      input: [Int].self
+    ) { input in
+      let keysAndValues = input.map { ($0, 2 * $0) }
+      let left = Dictionary(uniqueKeysWithValues: keysAndValues)
+      let right = left
+      return { timer in
+        timer.measure {
+          precondition(left == right)
+        }
+      }
+    }
+    
   }
 }

--- a/Benchmarks/Sources/Benchmarks/OrderedDictionaryBenchmarks.swift
+++ b/Benchmarks/Sources/Benchmarks/OrderedDictionaryBenchmarks.swift
@@ -541,7 +541,7 @@ extension Benchmark {
     }
     
     self.add(
-      title: "OrderedDictionary<Int, Int> equality different instance",
+      title: "OrderedDictionary<Int, Int> equality, unique",
       input: [Int].self
     ) { input in
       let keysAndValues = input.map { ($0, 2 * $0) }
@@ -555,7 +555,7 @@ extension Benchmark {
     }
     
     self.add(
-      title: "OrderedDictionary<Int, Int> equality same instance",
+      title: "OrderedDictionary<Int, Int> equality, shared",
       input: [Int].self
     ) { input in
       let keysAndValues = input.map { ($0, 2 * $0) }
@@ -569,7 +569,7 @@ extension Benchmark {
     }
     
     self.add(
-      title: "OrderedDictionary<Int, Int>.Values equality different instance",
+      title: "OrderedDictionary<Int, Int>.Values equality, unique",
       input: [Int].self
     ) { input in
       let keysAndValues = input.map { ($0, 2 * $0) }
@@ -583,7 +583,7 @@ extension Benchmark {
     }
     
     self.add(
-      title: "OrderedDictionary<Int, Int>.Values equality same instance",
+      title: "OrderedDictionary<Int, Int>.Values equality, shared",
       input: [Int].self
     ) { input in
       let keysAndValues = input.map { ($0, 2 * $0) }
@@ -595,5 +595,6 @@ extension Benchmark {
         }
       }
     }
+    
   }
 }

--- a/Benchmarks/Sources/Benchmarks/OrderedSetBenchmarks.swift
+++ b/Benchmarks/Sources/Benchmarks/OrderedSetBenchmarks.swift
@@ -557,7 +557,7 @@ extension Benchmark {
     }
     
     self.add(
-      title: "OrderedSet<Int> equality different instance",
+      title: "OrderedSet<Int> equality, unique",
       input: Int.self
     ) { size in
       return { timer in
@@ -570,7 +570,7 @@ extension Benchmark {
     }
     
     self.add(
-      title: "OrderedSet<Int> equality same instance",
+      title: "OrderedSet<Int> equality, shared",
       input: Int.self
     ) { size in
       return { timer in
@@ -583,7 +583,7 @@ extension Benchmark {
     }
     
     self.add(
-      title: "OrderedSet<Int>.SubSequence equality different instance",
+      title: "OrderedSet<Int>.SubSequence equality, unique",
       input: Int.self
     ) { size in
       return { timer in
@@ -596,7 +596,7 @@ extension Benchmark {
     }
     
     self.add(
-      title: "OrderedSet<Int>.SubSequence equality same instance",
+      title: "OrderedSet<Int>.SubSequence equality, shared",
       input: Int.self
     ) { size in
       return { timer in

--- a/Benchmarks/Sources/Benchmarks/SetBenchmarks.swift
+++ b/Benchmarks/Sources/Benchmarks/SetBenchmarks.swift
@@ -473,5 +473,32 @@ extension Benchmark {
         }
       }
     }
+    
+    self.add(
+      title: "Set<Int> equality, unique",
+      input: Int.self
+    ) { size in
+      return { timer in
+        let left = Set(0 ..< size)
+        let right = Set(0 ..< size)
+        timer.measure {
+          precondition(left == right)
+        }
+      }
+    }
+    
+    self.add(
+      title: "Set<Int> equality, shared",
+      input: Int.self
+    ) { size in
+      return { timer in
+        let left = Set(0 ..< size)
+        let right = left
+        timer.measure {
+          precondition(left == right)
+        }
+      }
+    }
+    
   }
 }

--- a/Benchmarks/Sources/Benchmarks/ShareableSetBenchmarks.swift
+++ b/Benchmarks/Sources/Benchmarks/ShareableSetBenchmarks.swift
@@ -446,5 +446,32 @@ extension Benchmark {
         }
       }
     }
+    
+    self.add(
+      title: "TreeSet<Int> equality, unique",
+      input: Int.self
+    ) { size in
+      return { timer in
+        let left = TreeSet(0 ..< size)
+        let right = TreeSet(0 ..< size)
+        timer.measure {
+          precondition(left == right)
+        }
+      }
+    }
+    
+    self.add(
+      title: "TreeSet<Int> equality, shared",
+      input: Int.self
+    ) { size in
+      return { timer in
+        let left = TreeSet(0 ..< size)
+        let right = left
+        timer.measure {
+          precondition(left == right)
+        }
+      }
+    }
+    
   }
 }


### PR DESCRIPTION
# Background

We have `benchmarks` defined to measure the performance of `OrderedSet` and `OrderedDictionary` equality to confirm that equality of shared instances perform efficiently (in `O(1)` time). We would like to add `benchmarks` for `TreeSet` and `TreeDictionary` to confirm the same behavior. We can also go ahead and add those same `benchmarks` for the system `Set` and `Dictionary` implementations.

# Changes

We only make changes to `benchmarks`. This diff contains no implementation changes.

In addition to the new `benchmarks`, we can also make small changes to previous `benchmarks` to make them more consistent (we migrate `same instance` to `shared` and `different instance` to `unique`.

# Benchmarks

```
swift run -c release benchmark run results.json --cycles 5 --tasks \
"Set<Int> equality, unique" \
"OrderedSet<Int> equality, unique" \
"OrderedSet<Int>.SubSequence equality, unique" \
"TreeSet<Int> equality, unique" \
"Set<Int> equality, shared" \
"OrderedSet<Int> equality, shared" \
"OrderedSet<Int>.SubSequence equality, shared" \
"TreeSet<Int> equality, shared"

swift run -c release benchmark render results.json set-unique.png --amortized false --tasks \
"Set<Int> equality, unique" \
"OrderedSet<Int> equality, unique" \
"OrderedSet<Int>.SubSequence equality, unique" \
"TreeSet<Int> equality, unique"

swift run -c release benchmark render results.json set-shared.png --amortized false --tasks \
"Set<Int> equality, shared" \
"OrderedSet<Int> equality, shared" \
"OrderedSet<Int>.SubSequence equality, shared" \
"TreeSet<Int> equality, shared"

swift run -c release benchmark run results.json --cycles 5 --tasks \
"Dictionary<Int, Int> equality, unique" \
"OrderedDictionary<Int, Int> equality, unique" \
"OrderedDictionary<Int, Int>.Values equality, unique" \
"Dictionary<Int, Int> equality, shared" \
"OrderedDictionary<Int, Int> equality, shared" \
"OrderedDictionary<Int, Int>.Values equality, shared" \

swift run -c release benchmark render results.json dictionary-unique.png --amortized false --tasks \
"Dictionary<Int, Int> equality, unique" \
"OrderedDictionary<Int, Int> equality, unique" \
"OrderedDictionary<Int, Int>.Values equality, unique" \

swift run -c release benchmark render results.json dictionary-shared.png --amortized false --tasks \
"Dictionary<Int, Int> equality, shared" \
"OrderedDictionary<Int, Int> equality, shared" \
"OrderedDictionary<Int, Int>.Values equality, shared" \
```

<img width="1280" alt="dictionary-shared" src="https://github.com/apple/swift-collections/assets/7544575/ff7360a6-5842-405f-8e27-566fd4a644bf">
<img width="1280" alt="dictionary-unique" src="https://github.com/apple/swift-collections/assets/7544575/1d01c389-0558-4731-adf3-089467c95c27">
<img width="1280" alt="set-shared" src="https://github.com/apple/swift-collections/assets/7544575/88d16d22-bb3b-4c17-8ea8-bfe4ea1c3280">
<img width="1280" alt="set-unique" src="https://github.com/apple/swift-collections/assets/7544575/3e39033e-f1af-46d6-bc21-50664578a5cb">

# Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
