### PR TITLE
[Heap] Final(?) Heap API adjustments for 1.1

### DIFF
--- a/Sources/HeapModule/Heap.swift
+++ b/Sources/HeapModule/Heap.swift
@@ -100,6 +100,22 @@ extension Heap {
     Array(_storage)
   }
 
+  /// Reserves enough space to store the specified number of elements.
+  ///
+  /// If you are adding a known number of elements to a heap, use this method
+  /// to avoid multiple reallocations. This method ensures that the heap has
+  /// unique, mutable, contiguous storage, with space allocated for at least
+  /// the requested number of elements.
+  ///
+  /// For performance reasons, the size of the newly allocated storage might be
+  /// greater than the requested capacity.
+  ///
+  /// - Complexity: O(`count`)
+  @inlinable
+  public mutating func reserveCapacity(_ minimumCapacity: Int) {
+    _storage.reserveCapacity(minimumCapacity)
+  }
+
   /// Inserts the given element into the heap.
   ///
   /// - Complexity: O(log(`count`)) element comparisons

--- a/Sources/HeapModule/Heap.swift
+++ b/Sources/HeapModule/Heap.swift
@@ -100,6 +100,23 @@ extension Heap {
     Array(_storage)
   }
 
+  /// Creates an empty heap with preallocated space for at least the
+  /// specified number of elements.
+  ///
+  /// Use this initializer to avoid intermediate reallocations of a heap's
+  /// storage when you know in advance how many elements you'll insert into it
+  /// after creation.
+  ///
+  /// - Parameter minimumCapacity: The minimum number of elements that the newly
+  ///   created heap should be able to store without reallocating its storage.
+  ///
+  /// - Complexity: O(1) allocations
+  @inlinable
+  public init(minimumCapacity: Int) {
+    self.init()
+    self.reserveCapacity(minimumCapacity)
+  }
+
   /// Reserves enough space to store the specified number of elements.
   ///
   /// If you are adding a known number of elements to a heap, use this method
@@ -109,6 +126,9 @@ extension Heap {
   ///
   /// For performance reasons, the size of the newly allocated storage might be
   /// greater than the requested capacity.
+  ///
+  /// - Parameter minimumCapacity: The minimum number of elements that the
+  ///   resulting heap should be able to store without reallocating its storage.
   ///
   /// - Complexity: O(`count`)
   @inlinable

--- a/Sources/HeapModule/Heap.swift
+++ b/Sources/HeapModule/Heap.swift
@@ -192,6 +192,7 @@ extension Heap {
   ///
   /// - Complexity: O(log(`count`)) element comparisons
   @inlinable
+  @discardableResult
   public mutating func removeMin() -> Element {
     return popMin()!
   }
@@ -202,6 +203,7 @@ extension Heap {
   ///
   /// - Complexity: O(log(`count`)) element comparisons
   @inlinable
+  @discardableResult
   public mutating func removeMax() -> Element {
     return popMax()!
   }


### PR DESCRIPTION
With thanks to @JadenGeller, land the following minor API improvements in `Heap`:

- Mark `removeMin()` and `removeMax()` as `@discardableResult`, emulating `removeFirst()`/`removeLast()` in the stdlib.
- Add a `reserveCapacity()` implementation that simply forwards to the similar method on the heap's array storage.
- Also add an `init(minimumCapacity:)` initializer that reserves capacity during heap creation. (This is generally a better idea than calling `reserveCapacity` on an already existing heap -- as it avoids getting called in a loop.)

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [X] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
