### PR TITLE
[1.1] Fix typos

### DIFF
--- a/Sources/DequeModule/_UnsafeWrappedBuffer.swift
+++ b/Sources/DequeModule/_UnsafeWrappedBuffer.swift
@@ -199,7 +199,7 @@ extension _UnsafeMutableWrappedBuffer {
     // Note: Array._copyContents traps when not given enough space, so we
     // need to check if we have enough contiguous space available above.
     //
-    // FIXME: Add suppport for segmented (a.k.a. piecewise contiguous)
+    // FIXME: Add support for segmented (a.k.a. piecewise contiguous)
     // collections to the stdlib.
     var (it, copied) = elements._copyContents(initializing: first)
     if copied == first.count, let second = second {

--- a/Sources/HashTreeCollections/HashNode/_UnsafePath.swift
+++ b/Sources/HashTreeCollections/HashNode/_UnsafePath.swift
@@ -874,7 +874,7 @@ extension _RawHashNode {
         }
         distance += c
       }
-      // See if the target is hiding somwhere in our immediate items.
+      // See if the target is hiding somewhere in our immediate items.
       distance &+= $0.itemCount
       if distance >= 0 {
         path.selectItem(at: _HashSlot(distance))

--- a/Sources/HashTreeCollections/TreeSet/TreeSet+ExpressibleByArrayLiteral.swift
+++ b/Sources/HashTreeCollections/TreeSet/TreeSet+ExpressibleByArrayLiteral.swift
@@ -18,7 +18,7 @@ extension TreeSet: ExpressibleByArrayLiteral {
   /// Do not call this initializer directly. It is used by the compiler when
   /// you use an array literal. Instead, create a new persistent set using an
   /// array literal as its value by enclosing a comma-separated list of values
-  /// in square brackets. You can use an array literal anywhere a peristent set
+  /// in square brackets. You can use an array literal anywhere a persistent set
   /// is expected by the type context.
   ///
   /// Like the standard `Set`, persistent sets do not preserve the order of

--- a/Sources/OrderedCollections/HashTable/_HashTable+BucketIterator.swift
+++ b/Sources/OrderedCollections/HashTable/_HashTable+BucketIterator.swift
@@ -14,7 +14,7 @@ extension _HashTable {
   /// table. This is a convenient tool for implementing linear probing.
   ///
   /// Beyond merely providing bucket values, bucket iterators can also tell
-  /// you their current oposition within the hash table, and (for mutable hash
+  /// you their current opposition within the hash table, and (for mutable hash
   /// tables) they allow you update the value of the currently visited bucket.
   /// (This is useful when implementing simple insertions, for example.)
   ///

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
@@ -240,7 +240,7 @@ import _CollectionsUtilities
 /// The hash table in an ordered set never needs to store larger indices than
 /// the current size of the storage array, and `OrderedSet` makes use of this
 /// observation to reduce the number of bits it uses to encode these integer
-/// vaues. Additionally, the actual hashed elements are stored in a flat array
+/// values. Additionally, the actual hashed elements are stored in a flat array
 /// value rather than the hash table itself, so they aren't subject to the hash
 /// table's strict maximum load factor. These two observations combine to
 /// optimize the memory utilization of `OrderedSet`, sometimes making it even

--- a/Sources/RopeModule/BigString/Chunk/BigString+Chunk+Description.swift
+++ b/Sources/RopeModule/BigString/Chunk/BigString+Chunk+Description.swift
@@ -34,7 +34,7 @@ extension BigString._Chunk: CustomStringConvertible {
 
   func _succinctContents(maxLength c: Int) -> String {
     /// 4+"short"-1
-    /// 0+"longer...tring"-1
+    /// 0+"longer...string"-1
     let pc = String(prefixCount)._lpad(to: 3)
     let sc = String(suffixCount)
 

--- a/Sources/RopeModule/Rope/Basics/RopeMetric.swift
+++ b/Sources/RopeModule/Rope/Basics/RopeMetric.swift
@@ -20,7 +20,7 @@ public protocol RopeMetric<Element>: Sendable {
   ///
   /// - Parameter offset: An integer offset from the start of `element` in this
   ///     metric, not exceeding `size(of: element.summary)`.
-  /// - Parameter element: An arbitary rope element.
+  /// - Parameter element: An arbitrary rope element.
   /// - Returns: The index addressing the desired position in the input element.
   func index(at offset: Int, in element: Element) -> Element.Index
 }

--- a/Tests/RopeModuleTests/TestBigString.swift
+++ b/Tests/RopeModuleTests/TestBigString.swift
@@ -968,7 +968,7 @@ class TestBigString: CollectionTestCase {
     let b1: BigString = "Foobar"
     var s1 = b1.suffix(3)
     expectEqual(s1, "bar")
-    s1.insert("\u{308}", at: s1.startIndex) // Combining diaresis
+    s1.insert("\u{308}", at: s1.startIndex) // Combining diaeresis
     expectEqual(s1.base, "Foöbar")
     expectEqual(s1, "öbar")
 


### PR DESCRIPTION
This is cherry picking parts of #356 to the release/1.1 branch, shortcutting some of the prerelease prep work.

(`SortedSet` and `SortedDictionary` aren't on this branch, so this PR omits those parts.)

Thanks @rex4539!
