### PR TITLE
[test] TreeDictionary.Keys: Remove stray print that’s flooding test output

### DIFF
--- a/Tests/HashTreeCollectionsTests/TreeDictionary.Keys Tests.swift
+++ b/Tests/HashTreeCollectionsTests/TreeDictionary.Keys Tests.swift
@@ -119,7 +119,6 @@ class TreeDictionaryKeysTests: CollectionTestCase {
         expectEqualSets(y.keys, v)
 
         let reference = u == v
-        print(reference)
 
         expectEqual(x.keys == y.keys, reference)
       }


### PR DESCRIPTION
The `test_isEqual_exhaustive` test includes a stray print statement that is flooding test output with a myriad lines of useless data.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
