### PR TITLE
[test] Use @retroactive in test conformances

### DIFF
--- a/Tests/BitCollectionsTests/BitSet.Counted Tests.swift
+++ b/Tests/BitCollectionsTests/BitSet.Counted Tests.swift
@@ -18,6 +18,19 @@ import BitCollections
 import OrderedCollections
 #endif
 
+#if compiler(>=6.0)
+extension BitSet.Counted: @retroactive SetAPIChecker {}
+
+extension BitSet.Counted: @retroactive SetAPIExtras {
+  public mutating func update(_ member: Int, at index: Index) -> Int {
+    fatalError("Not this one though")
+  }
+}
+
+extension BitSet.Counted: @retroactive SortedCollectionAPIChecker {}
+#else
+extension BitSet.Counted: SetAPIChecker {}
+
 extension BitSet.Counted: SetAPIExtras {
   public mutating func update(_ member: Int, at index: Index) -> Int {
     fatalError("Not this one though")
@@ -25,6 +38,8 @@ extension BitSet.Counted: SetAPIExtras {
 }
 
 extension BitSet.Counted: SortedCollectionAPIChecker {}
+#endif
+
 
 final class BitSetCountedTests: CollectionTestCase {
   func test_union() {

--- a/Tests/BitCollectionsTests/BitSetTests.swift
+++ b/Tests/BitCollectionsTests/BitSetTests.swift
@@ -18,6 +18,19 @@ import BitCollections
 import OrderedCollections
 #endif
 
+#if compiler(>=6.0)
+extension BitSet: @retroactive SetAPIChecker {}
+
+extension BitSet: @retroactive SetAPIExtras {
+  public mutating func update(_ member: Int, at index: Index) -> Int {
+    fatalError("Not this one though")
+  }
+}
+
+extension BitSet: @retroactive SortedCollectionAPIChecker {}
+#else
+extension BitSet: SetAPIChecker {}
+
 extension BitSet: SetAPIExtras {
   public mutating func update(_ member: Int, at index: Index) -> Int {
     fatalError("Not this one though")
@@ -25,6 +38,7 @@ extension BitSet: SetAPIExtras {
 }
 
 extension BitSet: SortedCollectionAPIChecker {}
+#endif
 
 final class BitSetTest: CollectionTestCase {
   func test_empty_initializer() {

--- a/Tests/HashTreeCollectionsTests/TreeDictionary Tests.swift
+++ b/Tests/HashTreeCollectionsTests/TreeDictionary Tests.swift
@@ -16,7 +16,13 @@ import _CollectionsTestSupport
 import HashTreeCollections
 #endif
 
+#if compiler(>=6.0)
+extension TreeDictionary: @retroactive DictionaryAPIChecker {}
+extension TreeDictionary: @retroactive DictionaryAPIExtras {}
+#else
+extension TreeDictionary: DictionaryAPIChecker {}
 extension TreeDictionary: DictionaryAPIExtras {}
+#endif
 
 class TreeDictionaryTests: CollectionTestCase {
   func test_empty() {

--- a/Tests/HashTreeCollectionsTests/TreeSet Tests.swift
+++ b/Tests/HashTreeCollectionsTests/TreeSet Tests.swift
@@ -16,7 +16,11 @@ import _CollectionsTestSupport
 import HashTreeCollections
 #endif
 
+#if compiler(>=6.0)
+extension TreeSet: @retroactive SetAPIExtras {}
+#else
 extension TreeSet: SetAPIExtras {}
+#endif
 
 class TreeSetTests: CollectionTestCase {
   func test_init_empty() {

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
@@ -17,7 +17,13 @@ import XCTest
 import _CollectionsTestSupport
 #endif
 
+#if compiler(>=6.0)
+extension OrderedDictionary: @retroactive DictionaryAPIChecker {}
+extension OrderedDictionary: @retroactive DictionaryAPIExtras {}
+#else
+extension OrderedDictionary: DictionaryAPIChecker {}
 extension OrderedDictionary: DictionaryAPIExtras {}
+#endif
 
 class OrderedDictionaryTests: CollectionTestCase {
   func test_empty() {

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -17,7 +17,13 @@ import XCTest
 import _CollectionsTestSupport
 #endif
 
+#if compiler(>=6.0)
+extension OrderedSet: @retroactive SetAPIChecker {}
+extension OrderedSet: @retroactive SetAPIExtras {}
+#else
+extension OrderedSet: SetAPIChecker {}
 extension OrderedSet: SetAPIExtras {}
+#endif
 
 class OrderedSetTests: CollectionTestCase {
   func test_init_uncheckedUniqueElements_concrete() {


### PR DESCRIPTION
The swift-collections test suite includes some test protocols to validate that dictionary- and set-like types provide the API surfaces that’s expected of their kind. These are being conformed to in the test targets, triggering new warnings on retroactive conformances.

Use `@retroactive` to silence such warnings.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
