### PR TITLE
Rename RopeModule to _RopeModule in CMakeLists.txt to match Package.swift

### DIFF
--- a/Sources/RopeModule/CMakeLists.txt
+++ b/Sources/RopeModule/CMakeLists.txt
@@ -7,7 +7,7 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 See https://swift.org/LICENSE.txt for license information
 #]]
 
-add_library(RopeModule
+add_library(_RopeModule
   "BigString/Basics/BigString+Metrics.swift"
   "BigString/Basics/BigString+Index.swift"
   "BigString/Basics/BigString+Summary.swift"
@@ -85,10 +85,10 @@ add_library(RopeModule
   "Utilities/String.Index+ABI.swift"
   "Utilities/Optional Utilities.swift"
   )
-target_link_libraries(RopeModule PRIVATE
+target_link_libraries(_RopeModule PRIVATE
   _CollectionsUtilities)
-set_target_properties(RopeModule PROPERTIES
+set_target_properties(_RopeModule PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 
-_install_target(RopeModule)
-set_property(GLOBAL APPEND PROPERTY SWIFT_COLLECTIONS_EXPORTS RopeModule)
+_install_target(_RopeModule)
+set_property(GLOBAL APPEND PROPERTY SWIFT_COLLECTIONS_EXPORTS _RopeModule)


### PR DESCRIPTION
This PR renames `RopeModule` defined in `CMakeLists.txt` to `_RopeModule`, matching the one defined in `Package.swift`.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.

(All uncompleted tasks are not applicable to this PR)