### PR TITLE
[Deque]: Fix bogus assert in Deque._Storage._ensureUnique

### DIFF
--- a/Sources/DequeModule/Deque._Storage.swift
+++ b/Sources/DequeModule/Deque._Storage.swift
@@ -187,25 +187,29 @@ extension Deque._Storage {
   ) {
     let unique = isUnique()
     if _slowPath(capacity < minimumCapacity || !unique) {
-      _ensureUnique(minimumCapacity: minimumCapacity, linearGrowth: linearGrowth)
+      _ensureUnique(isUnique: unique, minimumCapacity: minimumCapacity, linearGrowth: linearGrowth)
     }
   }
 
   @inlinable
+  @inline(never)
   internal mutating func _ensureUnique(
+    isUnique: Bool,
     minimumCapacity: Int,
     linearGrowth: Bool
   ) {
     if capacity >= minimumCapacity {
-      assert(!self.isUnique())
+      assert(!isUnique)
       self = self.read { $0.copyElements() }
-    } else if isUnique() {
-      let minimumCapacity = _growCapacity(to: minimumCapacity, linearly: linearGrowth)
+      return
+    }
+
+    let minimumCapacity = _growCapacity(to: minimumCapacity, linearly: linearGrowth)
+    if isUnique {
       self = self.update { source in
         source.moveElements(minimumCapacity: minimumCapacity)
       }
     } else {
-      let minimumCapacity = _growCapacity(to: minimumCapacity, linearly: linearGrowth)
       self = self.read { source in
         source.copyElements(minimumCapacity: minimumCapacity)
       }


### PR DESCRIPTION
A non-unique reference to a storage instance can legitimately become unique at any point, due to other references (say, held, by another thread) getting destroyed.

`Deque`’s `ensureUnique` implementation currently invokes the uniqueness check two times in quick succession, expecting it to return false both times. In rare circumstances, this can lead to a spurious trap in concurrent environments.

Fix this by avoiding calling `isUnique` more than once.

(We do not have a great way to exercise such concurrency issues, so this fix comes with no test case.)

Resolves #380

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
