### PR TITLE
[Rope] Fix copy-on-write violation in Rope.join

### DIFF
--- a/Sources/RopeModule/Rope/Operations/Rope+Join.swift
+++ b/Sources/RopeModule/Rope/Operations/Rope+Join.swift
@@ -39,9 +39,6 @@ extension Rope {
     var left = left.root
     var right = right.root
     
-    left.ensureUnique()
-    right.ensureUnique()
-    
     if left.height >= right.height {
       let r = left._graftBack(&right)
       guard let remainder = r.remainder else { return Self(root: left) }
@@ -64,6 +61,10 @@ extension Rope._Node {
     _ scion: inout Self
   ) -> (remainder: Self?, delta: Summary) {
     assert(self.height >= scion.height)
+
+    self.ensureUnique()
+    scion.ensureUnique()
+
     guard self.height > scion.height else {
       assert(self.height == scion.height)
       let d = scion.summary
@@ -99,6 +100,10 @@ extension Rope._Node {
     _ scion: inout Self
   ) -> (remainder: Self?, delta: Summary) {
     assert(self.height >= scion.height)
+
+    self.ensureUnique()
+    scion.ensureUnique()
+
     guard self.height > scion.height else {
       assert(self.height == scion.height)
       let origSum = self.summary

--- a/Tests/RopeModuleTests/TestBigString.swift
+++ b/Tests/RopeModuleTests/TestBigString.swift
@@ -544,7 +544,28 @@ class TestBigString: CollectionTestCase {
     }
     return pieces
   }
-  
+
+  func test_append_copy_on_write() {
+    let flat = String(repeating: sampleString, count: 10)
+    withEvery("stride", in: [32, 64, 128, 250, 1_000, 10_000, 20_000]) { stride in
+      let pieces = self.pieces(of: flat, by: stride).map {
+        BigString($0.str)
+      }
+
+      var big: BigString = ""
+      withEvery("i", in: 0 ..< pieces.count) { i in
+        let copy = big
+        let expected = String(copy)
+
+        big.append(contentsOf: pieces[i])
+
+        let actual = String(copy)
+        expectTrue(actual == expected)
+        copy._invariantCheck()
+      }
+    }
+  }
+
   func test_insert_string() {
     let flat = sampleString
     let ref = BigString(flat)


### PR DESCRIPTION
`Rope.join` has a logic error where it fails to properly ensure uniqueness of child node references before zipping the two b-trees together.

rdar://128450202

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
