### PR TITLE
Add prototypes of `Span` and `RawSpan`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Collections open source project
@@ -55,7 +55,8 @@ var defines: [String] = [
 let _settings: [SwiftSetting] = defines.map { .define($0) } + [
   .enableExperimentalFeature("BuiltinModule"),
   .enableExperimentalFeature("NonescapableTypes"),
-  .swiftLanguageVersion(.v5)
+  .enableExperimentalFeature("BitwiseCopyable"),
+//  .swiftLanguageVersion(.v5)
 ]
 
 struct CustomTarget {

--- a/Sources/Future/CMakeLists.txt
+++ b/Sources/Future/CMakeLists.txt
@@ -8,7 +8,10 @@ See https://swift.org/LICENSE.txt for license information
 #]]
 
 add_library(Future
-  "Dummy.swift"
+  "Inout.swift"
+  "Span.swift"
+  "RawSpan.swift"
+  "ContiguousStorage.swift"
 )
 
 target_link_libraries(Future PRIVATE

--- a/Sources/Future/ContiguousStorage.swift
+++ b/Sources/Future/ContiguousStorage.swift
@@ -1,0 +1,114 @@
+//===--- ContiguousStorage.swift ------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public protocol ContiguousStorage<StoredElement>: ~Copyable, ~Escapable {
+  associatedtype StoredElement/*: ~Copyable & ~Escapable*/
+
+  var storage: Span<StoredElement> { borrowing get }
+}
+
+extension Span: ContiguousStorage /*where Element: ~Copyable & ~Escapable*/ {
+  public typealias StoredElement = Element
+  public var storage: Self { self }
+}
+
+extension Array: ContiguousStorage {
+  public typealias StoredElement = Element
+  public var storage: Span<Element> {
+    _read {
+      if let a = _baseAddressIfContiguous {
+        yield Span(
+          unsafePointer: a, count: count, owner: self
+        )
+      }
+      else {
+        let a = ContiguousArray(copy self)
+        #if true
+        let s = Span(
+          unsafePointer: a._baseAddressIfContiguous!, count: a.count, owner: a
+        )
+        #else
+        let s = a.storage
+        #endif
+        yield s
+      }
+    }
+  }
+}
+
+extension ContiguousArray: ContiguousStorage {
+  public typealias StoredElement = Element
+  public var storage: Span<Element> {
+    borrowing get {
+      Span(
+        unsafePointer: _baseAddressIfContiguous!, count: count, owner: self
+      )
+    }
+  }
+}
+
+extension CollectionOfOne: ContiguousStorage {
+  public typealias StoredElement = Element
+  public var storage: Span<Element> {
+    _read {
+/* ideally: (with strawman syntax)
+      @addressable let value = self._element
+      yield Span(
+        unsafePointer: Builtin.addressable(value), count: 1, owner: self
+      )
+*/
+
+      let a = ContiguousArray(self)
+      yield Span(
+        unsafePointer: a._baseAddressIfContiguous!, count: 1, owner: a
+      )
+    }
+  }
+}
+
+extension String: ContiguousStorage {
+  public typealias StoredElement = UTF8.CodeUnit
+  public var storage: Span<UTF8.CodeUnit> {
+    _read {
+      if utf8.count < 16 { // Wrong way to know whether the String is smol
+//      if _guts.isSmall {
+//        let /*@addressable*/ rawStorage = _guts.asSmall._storage
+//        let span = RawSpan(
+//          unsafeRawPointer: UnsafeRawPointer(Builtin.adressable(rawStorage)),
+//          count: MemoryLayout<_SmallString.RawBitPattern>.size,
+//          owner: self
+//        )
+//        yield span.view(as: UTF8.CodeUnit.self)
+
+        let a = ContiguousArray(utf8)
+//        yield a.storage
+        yield Span(
+          unsafePointer: a._baseAddressIfContiguous!, count: 1, owner: a
+        )
+      }
+      else if let buffer = utf8.withContiguousStorageIfAvailable({ $0 }) {
+        // this is totally wrong, but there is a way with stdlib-internal API
+        yield Span(
+          unsafeBufferPointer: buffer,
+          owner: self
+        )
+      }
+      else { // copy non-fast code units if we don't have eager bridging
+        let a = ContiguousArray(utf8)
+//        yield a.storage
+        yield Span(
+          unsafePointer: a._baseAddressIfContiguous!, count: 1, owner: a
+        )
+      }
+    }
+  }
+}

--- a/Sources/Future/Dummy.swift
+++ b/Sources/Future/Dummy.swift
@@ -1,3 +1,0 @@
-public func greet() {
-  print("Hello from the future!")
-}

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -12,6 +12,8 @@
 
 import Builtin
 
+// A RawSpan represents a span of initialized memory
+// of unspecified type.
 @frozen
 public struct RawSpan: Copyable, ~Escapable {
   @usableFromInline let _start: UnsafeRawPointer
@@ -67,12 +69,12 @@ extension RawSpan {
   ///            the returned `Span`.
   @inlinable @inline(__always)
   public init<Owner: ~Copyable & ~Escapable>(
-    unsafeRawPointer pointer: UnsafeRawPointer,
-    count: Int,
+    unsafeStart pointer: UnsafeRawPointer,
+    byteCount: Int,
     owner: borrowing Owner
   ) {
-    precondition(count >= 0, "Count must not be negative")
-    self.init(_unchecked: pointer, count: count, owner: owner)
+    precondition(byteCount >= 0, "Count must not be negative")
+    self.init(_unchecked: pointer, count: byteCount, owner: owner)
   }
 
   /// Create a `RawSpan` over the memory represented by a `Span<T>`
@@ -92,8 +94,36 @@ extension RawSpan {
   }
 }
 
+extension RawSpan {
+
+  /// The number of bytes in the span.
+  ///
+  /// To check whether the span is empty, use its `isEmpty` property
+  /// instead of comparing `count` to zero.
+  ///
+  /// - Complexity: O(1)
+  @inlinable @inline(__always)
+  public var count: Int { _count }
+
+  /// A Boolean value indicating whether the span is empty.
+  ///
+  /// - Complexity: O(1)
+  @inlinable @inline(__always)
+  public var isEmpty: Bool { count == 0 }
+
+  /// The indices that are valid for subscripting the span, in ascending
+  /// order.
+  ///
+  /// - Complexity: O(1)
+  @inlinable @inline(__always)
+  public var indices: Range<Int> {
+    .init(uncheckedBounds: (0, count))
+  }
+}
+
 //MARK: Bounds Checking
 extension RawSpan {
+
   /// Traps if `offset` is not a valid offset into this `RawSpan`
   ///
   /// - Parameters:
@@ -119,69 +149,124 @@ extension RawSpan {
   }
 }
 
-//MARK: Offset Manipulation
+//MARK: extracting sub-spans
 extension RawSpan {
 
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not generally share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `RawSpan`.
+  ///
+  /// - Returns: A `Span` over the bytes within `bounds`
+  ///
+  /// - Complexity: O(1)
   @inlinable @inline(__always)
-  public var count: Int {
-    borrowing get { self._count }
+  public func extracting(_ bounds: Range<Int>) -> Self {
+    boundsCheckPrecondition(bounds)
+    return extracting(uncheckedBounds: bounds)
   }
 
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not generally share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `RawSpan`.
+  ///
+  /// - Returns: A `Span` over the bytes within `bounds`
+  ///
+  /// - Complexity: O(1)
   @inlinable @inline(__always)
-  public var isEmpty: Bool { count == 0 }
-
-  @inlinable @inline(__always)
-  public var indices: Range<Int> {
-    .init(uncheckedBounds: (0, count))
-  }
-}
-
-//MARK: integer offset subscripts
-extension RawSpan {
-
-  @inlinable @inline(__always)
-  public subscript(offsets offsets: Range<Int>) -> Self {
-    borrowing get {
-      boundsCheckPrecondition(offsets)
-      return self[uncheckedOffsets: offsets]
-    }
-  }
-
-  @inlinable @inline(__always)
-  public subscript(uncheckedOffsets offsets: Range<Int>) -> Self {
-    borrowing get {
-      RawSpan(
-        _unchecked: _start.advanced(by: offsets.lowerBound),
-        count: offsets.count,
-        owner: self
-      )
-    }
+  public func extracting(uncheckedBounds bounds: Range<Int>) -> Self {
+    RawSpan(
+      _unchecked: _start.advanced(by: bounds.lowerBound),
+      count: bounds.count,
+      owner: self
+    )
   }
 
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not generally share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `RawSpan`.
+  ///
+  /// - Returns: A `Span` over the bytes within `bounds`
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  public subscript(offsets offsets: some RangeExpression<Int>) -> Self {
-    borrowing get {
-      self[offsets: offsets.relative(to: indices)]
-    }
+  public func extracting(_ bounds: some RangeExpression<Int>) -> Self {
+    extracting(bounds.relative(to: indices))
   }
 
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not generally share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `RawSpan`.
+  ///
+  /// - Returns: A `Span` over the bytes within `bounds`
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  public subscript(uncheckedOffsets offsets: some RangeExpression<Int>) -> Self {
-    borrowing get {
-      self[uncheckedOffsets: offsets.relative(to: indices)]
-    }
+  public func extracting(
+    uncheckedBounds bounds: some RangeExpression<Int>
+  ) -> Self {
+    extracting(uncheckedBounds: bounds.relative(to: indices))
   }
 
+  /// Constructs a new span over all the bytes of this span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not generally share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Returns: A `RawSpan` over all the items of this span.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  public subscript(offsets _: UnboundedRange) -> Self {
-    borrowing get { copy self }
+  public func extracting(_: UnboundedRange) -> Self {
+    self
   }
 }
 
 extension RawSpan {
 
   //FIXME: mark closure parameter as non-escaping
-  @_alwaysEmitIntoClient
+  /// Calls the given closure with a pointer to the underlying bytes of
+  /// the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBytes(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  ///   If `body` has a return value, that value is also
+  ///   used as the return value for the `withUnsafeBytes(_:)` method.
+  ///   The closure's parameter is valid only for the duration of
+  ///   its execution.
+  /// - Returns: The return value of the `body` closure parameter.
   borrowing public func withUnsafeBytes<
     E: Error, Result: ~Copyable & ~Escapable
   >(
@@ -192,10 +277,14 @@ extension RawSpan {
 }
 
 extension RawSpan {
+  /// View the bytes of this span as a given type
+  ///
+  /// - Parameter type: The type as which we should view <reword>
+  /// - Returns: A typed span viewing these bytes as T
   borrowing public func view<T: BitwiseCopyable>(
-    as: T.Type
+    as type: T.Type
   ) -> dependsOn(self) Span<T> {
-    Span(unsafeRawPointer: _start, as: T.self, byteCount: count, owner: self)
+    Span(unsafeStart: _start, byteCount: count, owner: self)
   }
 }
 
@@ -236,49 +325,68 @@ extension RawSpan {
 //MARK: one-sided slicing operations
 extension RawSpan {
 
-  borrowing public func prefix(upTo offset: Int) -> dependsOn(self) Self {
-    if offset != 0 {
-      boundsCheckPrecondition(offset &- 1)
-    }
-    return Self(_unchecked: _start, count: offset, owner: self)
-  }
-
-  borrowing public func prefix(through offset: Int) -> dependsOn(self) Self {
-    boundsCheckPrecondition(offset)
-    return Self(_unchecked: _start, count: offset &+ 1, owner: self)
-  }
-
-  borrowing public func prefix(_ maxLength: Int) -> dependsOn(self) Self {
+  /// Returns a span containing the initial bytes of this span,
+  /// up to the specified maximum byte count.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the bytes.
+  ///
+  /// - Parameter maxLength: The maximum number of bytes to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` bytes.
+  ///
+  /// - Complexity: O(1)
+  borrowing public func extracting(first maxLength: Int) -> Self {
     precondition(maxLength >= 0, "Can't have a prefix of negative length.")
     let nc = maxLength < count ? maxLength : count
     return Self(_unchecked: _start, count: nc, owner: self)
   }
 
-  borrowing public func dropLast(_ k: Int = 1) -> dependsOn(self) Self {
+  /// Returns a span over all but the given number of trailing bytes.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// - Parameter k: The number of bytes to drop off the end of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span leaving off the specified number of bytes at the end.
+  ///
+  /// - Complexity: O(1)
+  borrowing public func extracting(droppingLast k: Int) -> Self {
     precondition(k >= 0, "Can't drop a negative number of elements.")
     let nc = k < count ? count&-k : 0
     return Self(_unchecked: _start, count: nc, owner: self)
   }
 
-  borrowing public func suffix(from offset: Int) -> dependsOn(self) Self {
-    if offset != count {
-      boundsCheckPrecondition(offset)
-    }
-    return Self(
-      _unchecked: _start.advanced(by: offset),
-      count: count &- offset,
-      owner: self
-    )
-  }
-
-  borrowing public func suffix(_ maxLength: Int) -> dependsOn(self) Self {
+  /// Returns a span containing the trailing bytes of the span,
+  /// up to the given maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the bytes.
+  ///
+  /// - Parameter maxLength: The maximum number of bytes to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` bytes.
+  ///
+  /// - Complexity: O(1)
+  borrowing public func extracting(last maxLength: Int) -> Self {
     precondition(maxLength >= 0, "Can't have a suffix of negative length.")
     let nc = maxLength < count ? maxLength : count
     let newStart = _start.advanced(by: count&-nc)
     return Self(_unchecked: newStart, count: nc, owner: self)
   }
 
-  borrowing public func dropFirst(_ k: Int = 1) -> dependsOn(self) Self {
+  /// Returns a span over all but the given number of initial bytes.
+  ///
+  /// If the number of elements to drop exceeds the number of bytes in
+  /// the span, the result is an empty span.
+  ///
+  /// - Parameter k: The number of bytes to drop from the beginning of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span starting after the specified number of bytes.
+  ///
+  /// - Complexity: O(1)
+  borrowing public func extracting(droppingFirst k: Int = 1) -> Self {
     precondition(k >= 0, "Can't drop a negative number of elements.")
     let dc = k < count ? k : count
     let newStart = _start.advanced(by: dc)

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -131,7 +131,7 @@ extension RawSpan {
   public var isEmpty: Bool { count == 0 }
 
   @inlinable @inline(__always)
-  public var offsets: Range<Int> {
+  public var indices: Range<Int> {
     .init(uncheckedBounds: (0, count))
   }
 }
@@ -161,14 +161,14 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   public subscript(offsets offsets: some RangeExpression<Int>) -> Self {
     borrowing get {
-      self[offsets: offsets.relative(to: 0..<count)]
+      self[offsets: offsets.relative(to: indices)]
     }
   }
 
   @_alwaysEmitIntoClient
   public subscript(uncheckedOffsets offsets: some RangeExpression<Int>) -> Self {
     borrowing get {
-      self[uncheckedOffsets: offsets.relative(to: 0..<count)]
+      self[uncheckedOffsets: offsets.relative(to: indices)]
     }
   }
 

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -178,7 +178,6 @@ extension RawSpan {
   }
 }
 
-//MARK: withUnsafeBytes
 extension RawSpan {
 
   //FIXME: mark closure parameter as non-escaping
@@ -190,20 +189,17 @@ extension RawSpan {
   ) throws(E) -> dependsOn(self) Result {
     try body(.init(start: (count==0) ? nil : _start, count: count))
   }
+}
 
+extension RawSpan {
   borrowing public func view<T: BitwiseCopyable>(
     as: T.Type
   ) -> dependsOn(self) Span<T> {
-    let (c, r) = count.quotientAndRemainder(dividingBy: MemoryLayout<T>.stride)
-    precondition(r == 0, "Returned span must contain whole number of T")
-    return Span(
-      unsafeRawPointer: _start, as: T.self, count: c, owner: self
-    )
+    Span(unsafeRawPointer: _start, as: T.self, byteCount: count, owner: self)
   }
 }
 
 //MARK: load
-
 extension RawSpan {
 
   public func load<T>(

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -1,0 +1,291 @@
+//===--- RawSpan.swift ----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Builtin
+
+@frozen
+public struct RawSpan: Copyable, ~Escapable {
+  @usableFromInline let _start: UnsafeRawPointer
+  @usableFromInline let _count: Int
+
+  @inlinable @inline(__always)
+  internal init<Owner: ~Copyable & ~Escapable>(
+    _unchecked start: UnsafeRawPointer,
+    count: Int,
+    owner: borrowing Owner
+  ) -> dependsOn(owner) Self {
+    self._start = start
+    self._count = count
+  }
+}
+
+@available(*, unavailable)
+extension RawSpan: Sendable {}
+
+extension RawSpan {
+
+  //FIXME: make failable once Optional can be non-escapable
+  /// Unsafely create a `RawSpan` over initialized memory.
+  ///
+  /// The memory in `buffer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the returned `RawSpan`.
+  @inlinable @inline(__always)
+  public init<Owner: ~Copyable & ~Escapable>(
+    unsafeBytes buffer: UnsafeRawBufferPointer,
+    owner: borrowing Owner
+  ) {
+    guard let baseAddress = buffer.baseAddress else {
+      fatalError("RawSpan requires a non-nil base address")
+    }
+    self.init(_unchecked: baseAddress, count: buffer.count, owner: owner)
+  }
+
+  /// Unsafely create a `RawSpan` over initialized memory.
+  ///
+  /// The memory over `count` bytes starting at
+  /// `pointer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized element.
+  ///   - count: the number of initialized elements in the view.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the returned `Span`.
+  @inlinable @inline(__always)
+  public init<Owner: ~Copyable & ~Escapable>(
+    unsafeRawPointer pointer: UnsafeRawPointer,
+    count: Int,
+    owner: borrowing Owner
+  ) {
+    precondition(count >= 0, "Count must not be negative")
+    self.init(_unchecked: pointer, count: count, owner: owner)
+  }
+
+  /// Create a `RawSpan` over the memory represented by a `Span<T>`
+  ///
+  /// - Parameters:
+  ///   - span: An existing `Span<T>`, which will define both this
+  ///           `RawSpan`'s lifetime and the memory it represents.
+  @inlinable @inline(__always)
+  public init<T: BitwiseCopyable>(
+    _ span: borrowing Span<T>
+  ) {
+    self.init(
+      _unchecked: UnsafeRawPointer(span._start),
+      count: span.count * MemoryLayout<T>.stride,
+      owner: span
+    )
+  }
+}
+
+//MARK: Bounds Checking
+extension RawSpan {
+  /// Traps if `offset` is not a valid offset into this `RawSpan`
+  ///
+  /// - Parameters:
+  ///   - position: an offset to validate
+  @inlinable @inline(__always)
+  public func boundsCheckPrecondition(_ offset: Int) {
+    precondition(
+      0 <= offset && offset < count,
+      "Offset out of bounds"
+    )
+  }
+
+  /// Traps if `bounds` is not a valid range of offsets into this `RawSpan`
+  ///
+  /// - Parameters:
+  ///   - offsets: a range of offsets to validate
+  @inlinable @inline(__always)
+  public func boundsCheckPrecondition(_ offsets: Range<Int>) {
+    precondition(
+      0 <= offsets.lowerBound && offsets.upperBound <= count,
+      "Range of offsets out of bounds"
+    )
+  }
+}
+
+//MARK: Offset Manipulation
+extension RawSpan {
+
+  @inlinable @inline(__always)
+  public var count: Int {
+    borrowing get { self._count }
+  }
+
+  @inlinable @inline(__always)
+  public var isEmpty: Bool { count == 0 }
+
+  @inlinable @inline(__always)
+  public var offsets: Range<Int> {
+    .init(uncheckedBounds: (0, count))
+  }
+}
+
+//MARK: integer offset subscripts
+extension RawSpan {
+
+  @inlinable @inline(__always)
+  public subscript(offsets offsets: Range<Int>) -> Self {
+    borrowing get {
+      boundsCheckPrecondition(offsets)
+      return self[uncheckedOffsets: offsets]
+    }
+  }
+
+  @inlinable @inline(__always)
+  public subscript(uncheckedOffsets offsets: Range<Int>) -> Self {
+    borrowing get {
+      RawSpan(
+        _unchecked: _start.advanced(by: offsets.lowerBound),
+        count: offsets.count,
+        owner: self
+      )
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  public subscript(offsets offsets: some RangeExpression<Int>) -> Self {
+    borrowing get {
+      self[offsets: offsets.relative(to: 0..<count)]
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  public subscript(uncheckedOffsets offsets: some RangeExpression<Int>) -> Self {
+    borrowing get {
+      self[uncheckedOffsets: offsets.relative(to: 0..<count)]
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  public subscript(offsets _: UnboundedRange) -> Self {
+    borrowing get { copy self }
+  }
+}
+
+//MARK: withUnsafeBytes
+extension RawSpan {
+
+  //FIXME: mark closure parameter as non-escaping
+  @_alwaysEmitIntoClient
+  borrowing public func withUnsafeBytes<
+    E: Error, Result: ~Copyable & ~Escapable
+  >(
+    _ body: (_ buffer: borrowing UnsafeRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> dependsOn(self) Result {
+    try body(.init(start: (count==0) ? nil : _start, count: count))
+  }
+
+  borrowing public func view<T: BitwiseCopyable>(
+    as: T.Type
+  ) -> dependsOn(self) Span<T> {
+    let (c, r) = count.quotientAndRemainder(dividingBy: MemoryLayout<T>.stride)
+    precondition(r == 0, "Returned span must contain whole number of T")
+    return Span(
+      unsafeRawPointer: _start, as: T.self, count: c, owner: self
+    )
+  }
+}
+
+//MARK: load
+
+extension RawSpan {
+
+  public func load<T>(
+    fromByteOffset offset: Int = 0, as: T.Type
+  ) -> T {
+    boundsCheckPrecondition(
+      Range(uncheckedBounds: (offset, offset+MemoryLayout<T>.size))
+    )
+    return load(fromUncheckedByteOffset: offset, as: T.self)
+  }
+
+  public func load<T>(
+    fromUncheckedByteOffset offset: Int, as: T.Type
+  ) -> T {
+    _start.load(fromByteOffset: offset, as: T.self)
+  }
+
+  public func loadUnaligned<T: BitwiseCopyable>(
+    fromByteOffset offset: Int = 0, as: T.Type
+  ) -> T {
+    boundsCheckPrecondition(
+      Range(uncheckedBounds: (offset, offset+MemoryLayout<T>.size))
+    )
+    return loadUnaligned(fromUncheckedByteOffset: offset, as: T.self)
+  }
+
+  public func loadUnaligned<T: BitwiseCopyable>(
+    fromUncheckedByteOffset offset: Int, as: T.Type
+  ) -> T {
+    _start.loadUnaligned(fromByteOffset: offset, as: T.self)
+  }
+}
+
+//MARK: one-sided slicing operations
+extension RawSpan {
+
+  borrowing public func prefix(upTo offset: Int) -> dependsOn(self) Self {
+    if offset != 0 {
+      boundsCheckPrecondition(offset &- 1)
+    }
+    return Self(_unchecked: _start, count: offset, owner: self)
+  }
+
+  borrowing public func prefix(through offset: Int) -> dependsOn(self) Self {
+    boundsCheckPrecondition(offset)
+    return Self(_unchecked: _start, count: offset &+ 1, owner: self)
+  }
+
+  borrowing public func prefix(_ maxLength: Int) -> dependsOn(self) Self {
+    precondition(maxLength >= 0, "Can't have a prefix of negative length.")
+    let nc = maxLength < count ? maxLength : count
+    return Self(_unchecked: _start, count: nc, owner: self)
+  }
+
+  borrowing public func dropLast(_ k: Int = 1) -> dependsOn(self) Self {
+    precondition(k >= 0, "Can't drop a negative number of elements.")
+    let nc = k < count ? count&-k : 0
+    return Self(_unchecked: _start, count: nc, owner: self)
+  }
+
+  borrowing public func suffix(from offset: Int) -> dependsOn(self) Self {
+    if offset != count {
+      boundsCheckPrecondition(offset)
+    }
+    return Self(
+      _unchecked: _start.advanced(by: offset),
+      count: count &- offset,
+      owner: self
+    )
+  }
+
+  borrowing public func suffix(_ maxLength: Int) -> dependsOn(self) Self {
+    precondition(maxLength >= 0, "Can't have a suffix of negative length.")
+    let nc = maxLength < count ? maxLength : count
+    let newStart = _start.advanced(by: count&-nc)
+    return Self(_unchecked: newStart, count: nc, owner: self)
+  }
+
+  borrowing public func dropFirst(_ k: Int = 1) -> dependsOn(self) Self {
+    precondition(k >= 0, "Can't drop a negative number of elements.")
+    let dc = k < count ? k : count
+    let newStart = _start.advanced(by: dc)
+    return Self(_unchecked: newStart, count: count&-dc, owner: self)
+  }
+}

--- a/Sources/Future/Span.swift
+++ b/Sources/Future/Span.swift
@@ -157,7 +157,9 @@ extension Span where Element: BitwiseCopyable {
     let (q, r) = c.quotientAndRemainder(dividingBy: s)
     precondition(r == 0)
     self.init(
-      unsafeRawPointer: baseAddress, as: Element.self, count: q, owner: owner
+      unsafePointer: baseAddress.assumingMemoryBound(to: Element.self),
+      count: q,
+      owner: owner
     )
   }
 
@@ -175,12 +177,15 @@ extension Span where Element: BitwiseCopyable {
   public init<Owner: ~Copyable & ~Escapable>(
     unsafeRawPointer pointer: UnsafeRawPointer,
     as type: Element.Type,
-    count: Int,
+    byteCount: Int,
     owner: borrowing Owner
   ) -> dependsOn(owner) Self {
+    let stride = MemoryLayout<Element>.stride
+    let (q, r) = byteCount.quotientAndRemainder(dividingBy: stride)
+    precondition(r == 0)
     self.init(
       unsafePointer: pointer.assumingMemoryBound(to: Element.self),
-      count: count,
+      count: q,
       owner: owner
     )
   }

--- a/Sources/Future/Span.swift
+++ b/Sources/Future/Span.swift
@@ -198,7 +198,7 @@ extension Span where Element: Equatable {
   ///
   /// - Complexity: O(*m*), where *m* is the lesser of the length of the
   ///   sequence and the length of `other`.
-  public func elementsEqual(_ other: Self) -> Bool {
+  public func _elementsEqual(_ other: Self) -> Bool {
     guard count == other.count else { return false }
     if count == 0 { return true }
 
@@ -225,11 +225,11 @@ extension Span where Element: Equatable {
   /// - Complexity: O(*m*), where *m* is the lesser of the length of the
   ///   sequence and the length of `other`.
   @inlinable
-  public func elementsEqual(_ other: some Collection<Element>) -> Bool {
+  public func _elementsEqual(_ other: some Collection<Element>) -> Bool {
     guard count == other.count else { return false }
     if count == 0 { return true }
 
-    return elementsEqual(AnySequence(other))
+    return _elementsEqual(AnySequence(other))
   }
 
   /// Returns a Boolean value indicating whether this span and a Sequence
@@ -243,7 +243,7 @@ extension Span where Element: Equatable {
   /// - Complexity: O(*m*), where *m* is the lesser of the length of the
   ///   sequence and the length of `other`.
   @inlinable
-  public func elementsEqual(_ other: some Sequence<Element>) -> Bool {
+  public func _elementsEqual(_ other: some Sequence<Element>) -> Bool {
     var offset = 0
     for otherElement in other {
       if offset >= count { return false }

--- a/Sources/Future/Span.swift
+++ b/Sources/Future/Span.swift
@@ -563,38 +563,6 @@ extension Span where Element: Copyable {
 //MARK: one-sided slicing operations
 extension Span where Element: ~Copyable /*& ~Escapable*/ {
 
-  /// Returns a span from positions zero up to, but not
-  /// including, the specified position.
-  ///
-  /// The resulting span *does not include* the element at the position
-  /// `end`.
-  ///
-  /// - Parameter end: The "past the end" index of the resulting span.
-  /// - Returns: A span up to, but not including, the `end` position.
-  ///
-  /// - Complexity: O(1)
-  borrowing public func prefix(upTo offset: Int) -> dependsOn(self) Self {
-    if offset != 0 {
-      boundsCheckPrecondition(offset &- 1)
-    }
-    return Self(_unchecked: _start, count: offset, owner: self)
-  }
-
-  /// Returns a span from positions zero through the specified position.
-  ///
-  /// The resulting span includes the element at the position
-  /// `end`.
-  ///
-  /// - Parameter position: The last index of the resulting span.
-  ///   `position` must be a valid index of the collection.
-  /// - Returns: A span up to, and including, the given position.
-  ///
-  /// - Complexity: O(1)
-  borrowing public func prefix(through offset: Int) -> dependsOn(self) Self {
-    boundsCheckPrecondition(offset)
-    return Self(_unchecked: _start, count: offset &+ 1, owner: self)
-  }
-
   /// Returns a span containing the initial elements of this span,
   /// up to the specified maximum length.
   ///
@@ -606,7 +574,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Returns: A span with at most `maxLength` elements.
   ///
   /// - Complexity: O(1)
-  borrowing public func prefix(_ maxLength: Int) -> dependsOn(self) Self {
+  borrowing public func extracting(first maxLength: Int) -> dependsOn(self) Self {
     precondition(maxLength >= 0, "Can't have a prefix of negative length.")
     let nc = maxLength < count ? maxLength : count
     return Self(_unchecked: _start, count: nc, owner: self)
@@ -622,31 +590,10 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Returns: A span leaving off the specified number of elements at the end.
   ///
   /// - Complexity: O(1)
-  borrowing public func dropLast(_ k: Int = 1) -> dependsOn(self) Self {
+  borrowing public func extracting(droppingLast k: Int) -> dependsOn(self) Self {
     precondition(k >= 0, "Can't drop a negative number of elements.")
     let nc = k < count ? count&-k : 0
     return Self(_unchecked: _start, count: nc, owner: self)
-  }
-
-  /// Returns a span from the specified position to the end of this span
-  ///
-  /// Passing the span's `count` as the `start` parameter results in
-  /// an empty subsequence.
-  ///
-  /// - Parameter start: The position at which to start the resulting span.
-  ///   `start` must be a valid index of the span.
-  /// - Returns: A span starting at the `start` position.
-  ///
-  /// - Complexity: O(1)
-  borrowing public func suffix(from offset: Int) -> dependsOn(self) Self {
-    if offset != count {
-      boundsCheckPrecondition(offset)
-    }
-    return Self(
-      _unchecked: _start.advanced(by: offset),
-      count: count &- offset,
-      owner: self
-    )
   }
 
   /// Returns a span containing the final elements of the span,
@@ -660,7 +607,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Returns: A span with at most `maxLength` elements.
   ///
   /// - Complexity: O(1)
-  borrowing public func suffix(_ maxLength: Int) -> dependsOn(self) Self {
+  borrowing public func extracting(last maxLength: Int) -> dependsOn(self) Self {
     precondition(maxLength >= 0, "Can't have a suffix of negative length.")
     let nc = maxLength < count ? maxLength : count
     let newStart = _start.advanced(by: count&-nc)
@@ -677,7 +624,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Returns: A span starting after the specified number of elements.
   ///
   /// - Complexity: O(1)
-  borrowing public func dropFirst(_ k: Int = 1) -> dependsOn(self) Self {
+  borrowing public func extracting(droppingFirst k: Int = 1) -> dependsOn(self) Self {
     precondition(k >= 0, "Can't drop a negative number of elements.")
     let dc = k < count ? k : count
     let newStart = _start.advanced(by: dc)

--- a/Sources/Future/Span.swift
+++ b/Sources/Future/Span.swift
@@ -1,0 +1,557 @@
+//===--- Span.swift -------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Builtin
+
+// A Span<Element> represents a span of memory which
+// contains initialized instances of `Element`.
+@frozen
+public struct Span<Element: ~Copyable /*& ~Escapable*/>: Copyable, ~Escapable {
+  @usableFromInline let _start: UnsafePointer<Element>
+  @usableFromInline let _count: Int
+
+  @inlinable @inline(__always)
+  internal init<Owner: ~Copyable & ~Escapable>(
+    _unchecked start: UnsafePointer<Element>,
+    count: Int,
+    owner: borrowing Owner
+  ) -> dependsOn(owner) Self {
+    self._start = start
+    self._count = count
+  }
+}
+
+@available(*, unavailable)
+extension Span: Sendable {}
+
+extension UnsafePointer where Pointee: ~Copyable /*& ~Escapable*/ {
+
+  @inline(__always)
+  fileprivate var isAligned: Bool {
+    (Int(bitPattern: self) & (MemoryLayout<Pointee>.alignment-1)) == 0
+  }
+}
+
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory representing `count` instances starting at
+  /// `pointer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized element.
+  ///   - count: the number of initialized elements in the view.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the returned `Span`.
+  public init<Owner: ~Copyable & ~Escapable>(
+    unsafePointer start: UnsafePointer<Element>,
+    count: Int,
+    owner: borrowing Owner
+  ) -> dependsOn(owner) Self {
+    precondition(count >= 0, "Count must not be negative")
+    precondition(
+      start.isAligned,
+      "baseAddress must be properly aligned for accessing \(Element.self)"
+    )
+    self.init(_unchecked: start, count: count, owner: owner)
+  }
+
+  //FIXME: make failable once Optional can be non-escapable
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory in `buffer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeBufferPointer` to initialized elements.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the returned `Span`.
+  public init<Owner: ~Copyable & ~Escapable>(
+    unsafeBufferPointer buffer: UnsafeBufferPointer<Element>,
+    owner: borrowing Owner
+  ) -> dependsOn(owner) Self {
+    guard let baseAddress = buffer.baseAddress else {
+      fatalError("Span requires a non-nil base address")
+    }
+    self.init(unsafePointer: baseAddress, count: buffer.count, owner: owner)
+  }
+}
+
+extension Span where Element: BitwiseCopyable {
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory representing `count` instances starting at
+  /// `pointer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized element.
+  ///   - count: the number of initialized elements in the view.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the returned `Span`.
+  public init<Owner: ~Copyable & ~Escapable>(
+    unsafePointer start: UnsafePointer<Element>,
+    count: Int,
+    owner: borrowing Owner
+  ) -> dependsOn(owner) Self {
+    precondition(count >= 0, "Count must not be negative")
+    self.init(_unchecked: start, count: count, owner: owner)
+  }
+
+  //FIXME: make failable once Optional can be non-escapable
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory in `buffer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - buffer: an `UnsafeBufferPointer` to initialized elements.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the returned `Span`.
+  public init<Owner: ~Copyable & ~Escapable>(
+    unsafeBufferPointer buffer: UnsafeBufferPointer<Element>,
+    owner: borrowing Owner
+  ) -> dependsOn(owner) Self {
+    guard let baseAddress = buffer.baseAddress else {
+      fatalError("Span requires a non-nil base address")
+    }
+    self.init(unsafePointer: baseAddress, count: buffer.count, owner: owner)
+  }
+
+  //FIXME: make failable once Optional can be non-escapable
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory in `unsafeBytes` must be owned by the instance `owner`
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// `unsafeBytes` must be correctly aligned for accessing
+  /// an element of type `Element`, and must contain a number of bytes
+  /// that is an exact multiple of `Element`'s stride.
+  ///
+  /// - Parameters:
+  ///   - unsafeBytes: a buffer to initialized elements.
+  ///   - type: the type to use when interpreting the bytes in memory.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the returned `Span`.
+  public init<Owner: ~Copyable & ~Escapable>(
+    unsafeBytes buffer: UnsafeRawBufferPointer,
+    as type: Element.Type,
+    owner: borrowing Owner
+  ) -> dependsOn(owner) Self {
+    guard let baseAddress = buffer.baseAddress else {
+      fatalError("Span requires a non-nil base address")
+    }
+    let (c, s) = (buffer.count, MemoryLayout<Element>.stride)
+    let (q, r) = c.quotientAndRemainder(dividingBy: s)
+    precondition(r == 0)
+    self.init(
+      unsafeRawPointer: baseAddress, as: Element.self, count: q, owner: owner
+    )
+  }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory representing `count` instances starting at
+  /// `pointer` must be owned by the instance `owner`,
+  /// meaning that as long as `owner` is alive the memory will remain valid.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized element.
+  ///   - count: the number of initialized elements in the view.
+  ///   - owner: a binding whose lifetime must exceed that of
+  ///            the returned `Span`.
+  public init<Owner: ~Copyable & ~Escapable>(
+    unsafeRawPointer pointer: UnsafeRawPointer,
+    as type: Element.Type,
+    count: Int,
+    owner: borrowing Owner
+  ) -> dependsOn(owner) Self {
+    self.init(
+      unsafePointer: pointer.assumingMemoryBound(to: Element.self),
+      count: count,
+      owner: owner
+    )
+  }
+}
+
+extension Span where Element: Equatable {
+
+  public func elementsEqual(_ other: Self) -> Bool {
+    guard count == other.count else { return false }
+    if count == 0 { return true }
+
+    //FIXME: This could be short-cut
+    //       with a layout constraint where stride equals size,
+    //       as long as there is at most 1 unused bit pattern.
+    // if Element is BitwiseEquatable {
+    // return _swift_stdlib_memcmp(lhs.baseAddress, rhs.baseAddress, count) == 0
+    // }
+    for o in 0..<count {
+      if self[unchecked: o] != other[unchecked: o] { return false }
+    }
+    return true
+  }
+
+  @inlinable
+  public func elementsEqual(_ other: some Collection<Element>) -> Bool {
+    guard count == other.count else { return false }
+    if count == 0 { return true }
+
+    return elementsEqual(AnySequence(other))
+  }
+
+  @inlinable
+  public func elementsEqual(_ other: some Sequence<Element>) -> Bool {
+    var offset = 0
+    for otherElement in other {
+      if offset >= count { return false }
+      if self[unchecked: offset] != otherElement { return false }
+      offset += 1
+    }
+    return offset == count
+  }
+}
+
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+
+  @inlinable @inline(__always)
+  public var count: Int { _count }
+
+  @inlinable @inline(__always)
+  public var isEmpty: Bool { _count == 0 }
+
+  @inlinable @inline(__always)
+  public var indices: Range<Int> {
+    .init(uncheckedBounds: (0, _count))
+  }
+}
+
+//MARK: Bounds Checking
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+
+  /// Traps if `offset` is not a valid offset into this `Span`
+  ///
+  /// - Parameters:
+  ///   - position: an Index to validate
+  @inlinable @inline(__always)
+  public func boundsCheckPrecondition(_ offset: Int) {
+    precondition(
+      0 <= offset && offset < count,
+      "Offset out of bounds"
+    )
+  }
+
+  /// Traps if `offsets` is not a valid range of offsets into this `Span`
+  ///
+  /// - Parameters:
+  ///   - offsets: a range of indices to validate
+  @inlinable @inline(__always)
+  public func boundsCheckPrecondition(_ offsets: Range<Int>) {
+    precondition(
+      0 <= offsets.lowerBound && offsets.upperBound <= count,
+      "Range of offsets out of bounds"
+    )
+  }
+}
+
+extension Span where Element: BitwiseCopyable {
+
+  @inlinable @inline(__always)
+  public var rawSpan: RawSpan { RawSpan(self) }
+}
+
+//MARK: integer offset subscripts
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+
+  /// Accesses the element at the specified position in the `Span`.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @inlinable @inline(__always)
+  public subscript(_ position: Int) -> Element {
+    borrowing _read {
+      boundsCheckPrecondition(position)
+      yield self[unchecked: position]
+    }
+  }
+
+  /// Accesses the element at the specified position in the `Span`.
+  ///
+  /// This subscript does not validate `position`; this is an unsafe operation.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @inlinable @inline(__always)
+  public subscript(unchecked position: Int) -> Element {
+    borrowing _read {
+      yield _start.advanced(by: position).pointee
+    }
+  }
+}
+
+extension Span where Element: BitwiseCopyable {
+
+  /// Accesses the element at the specified position in the `Span`.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @inlinable @inline(__always)
+  public subscript(_ position: Int) -> Element {
+    get {
+      boundsCheckPrecondition(position)
+      return self[unchecked: position]
+    }
+  }
+
+  /// Accesses the element at the specified position in the `Span`.
+  ///
+  /// This subscript does not validate `position`; this is an unsafe operation.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @inlinable @inline(__always)
+  public subscript(unchecked position: Int) -> Element {
+    get {
+      UnsafeRawPointer(_start + position).loadUnaligned(as: Element.self)
+    }
+  }
+}
+
+//MARK: extracting sub-spans
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+
+  /// Constructs a new span over the items within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not generally share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `Span`.
+  ///
+  /// - Returns: A `Span` over the items at `bounds`
+  ///
+  /// - Complexity: O(1)
+  @inlinable @inline(__always)
+  public func extracting(_ bounds: Range<Int>) -> Self {
+    boundsCheckPrecondition(bounds)
+    return extracting(uncheckedBounds: bounds)
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not generally share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `Span`.
+  ///
+  /// - Returns: A `Span` over the items at `bounds`
+  ///
+  /// - Complexity: O(1)
+  @inlinable @inline(__always)
+  public func extracting(uncheckedBounds bounds: Range<Int>) -> Self {
+    Span(
+      _unchecked: _start.advanced(by: bounds.lowerBound),
+      count: bounds.count,
+      owner: self
+    )
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not generally share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `Span`.
+  ///
+  /// - Returns: A `Span` over the items at `bounds`
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func extracting(_ bounds: some RangeExpression<Int>) -> Self {
+    extracting(bounds.relative(to: indices))
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// positions within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not generally share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `Span`.
+  ///
+  /// - Returns: A `Span` over the items at `bounds`
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func extracting(
+    uncheckedBounds bounds: some RangeExpression<Int>
+  ) -> Self {
+    extracting(uncheckedBounds: bounds.relative(to: indices))
+  }
+
+  /// Constructs a new span over all the items of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not generally share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Returns: A `Span` over all the items of this span.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func extracting(_: UnboundedRange) -> Self {
+    self
+  }
+}
+
+//MARK: withUnsafePointer, etc.
+extension Span where Element: ~Copyable {
+
+  //FIXME: mark closure parameter as non-escaping
+  /// Calls a closure with a pointer to the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBufferPointer(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Parameter body: A closure with an `UnsafeBufferPointer` parameter
+  ///   that points to the viewed contiguous storage. If `body` has
+  ///   a return value, that value is also used as the return value
+  ///   for the `withUnsafeBufferPointer(_:)` method. The closure's
+  ///   parameter is valid only for the duration of its execution.
+  /// - Returns: The return value of the `body` closure parameter.
+  borrowing public func withUnsafeBufferPointer<
+    E: Error, Result: ~Copyable & ~Escapable
+  >(
+    _ body: (_ buffer: borrowing UnsafeBufferPointer<Element>) throws(E) -> Result
+  ) throws(E) -> dependsOn(self) Result {
+    try body(.init(start: (count==0) ? nil : _start, count: count))
+  }
+}
+
+extension Span where Element: BitwiseCopyable {
+
+  //FIXME: mark closure parameter as non-escaping
+  /// Calls the given closure with a pointer to the underlying bytes of
+  /// the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBytes(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  ///   If `body` has a return value, that value is also
+  ///   used as the return value for the `withUnsafeBytes(_:)` method.
+  ///   The closure's parameter is valid only for the duration of
+  ///   its execution.
+  /// - Returns: The return value of the `body` closure parameter.
+  borrowing public func withUnsafeBytes<
+    E: Error, Result: ~Copyable & ~Escapable
+  >(
+    _ body: (_ buffer: borrowing UnsafeRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
+    try RawSpan(self).withUnsafeBytes(body)
+  }
+}
+
+// `first` and `last` can't exist where Element: ~Copyable
+// because we can't construct an Optional of a borrow
+extension Span where Element: Copyable {
+  @inlinable
+  public var first: Element? {
+    isEmpty ? nil : self[unchecked: 0]
+  }
+
+  @inlinable
+  public var last: Element? {
+    isEmpty ? nil : self[unchecked: count &- 1]
+  }
+}
+
+//MARK: one-sided slicing operations
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+
+  borrowing public func prefix(upTo offset: Int) -> dependsOn(self) Self {
+    if offset != 0 {
+      boundsCheckPrecondition(offset &- 1)
+    }
+    return Self(_unchecked: _start, count: offset, owner: self)
+  }
+
+  borrowing public func prefix(through offset: Int) -> dependsOn(self) Self {
+    boundsCheckPrecondition(offset)
+    return Self(_unchecked: _start, count: offset &+ 1, owner: self)
+  }
+
+  borrowing public func prefix(_ maxLength: Int) -> dependsOn(self) Self {
+    precondition(maxLength >= 0, "Can't have a prefix of negative length.")
+    let nc = maxLength < count ? maxLength : count
+    return Self(_unchecked: _start, count: nc, owner: self)
+  }
+
+  borrowing public func dropLast(_ k: Int = 1) -> dependsOn(self) Self {
+    precondition(k >= 0, "Can't drop a negative number of elements.")
+    let nc = k < count ? count&-k : 0
+    return Self(_unchecked: _start, count: nc, owner: self)
+  }
+
+  borrowing public func suffix(from offset: Int) -> dependsOn(self) Self {
+    if offset != count {
+      boundsCheckPrecondition(offset)
+    }
+    return Self(
+      _unchecked: _start.advanced(by: offset),
+      count: count &- offset,
+      owner: self
+    )
+  }
+
+  borrowing public func suffix(_ maxLength: Int) -> dependsOn(self) Self {
+    precondition(maxLength >= 0, "Can't have a suffix of negative length.")
+    let nc = maxLength < count ? maxLength : count
+    let newStart = _start.advanced(by: count&-nc)
+    return Self(_unchecked: newStart, count: nc, owner: self)
+  }
+
+  borrowing public func dropFirst(_ k: Int = 1) -> dependsOn(self) Self {
+    precondition(k >= 0, "Can't drop a negative number of elements.")
+    let dc = k < count ? k : count
+    let newStart = _start.advanced(by: dc)
+    return Self(_unchecked: newStart, count: count&-dc, owner: self)
+  }
+}

--- a/Tests/FutureTests/ContiguousStorageTests.swift
+++ b/Tests/FutureTests/ContiguousStorageTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+import Future
+
+final class ContiguousStorageTests: XCTestCase {
+
+  func testBorrowArrayStorage() throws {
+
+    let capacity = 10
+    var a: [Int] = []
+    a = Array(0..<capacity)
+
+    let span = a.storage
+    XCTAssertEqual(span.count, capacity)
+
+    for i in span.indices {
+      XCTAssertEqual(span[i], a[i])
+    }
+
+    // This should end the borrow, and the mutation should work rdar://126298676
+//    _ = consume span
+//    a = []
+  }
+
+  private struct Skipper: ~Escapable {
+    private var span: Span<Int>
+
+    var startIndex: Int { 0 }
+    var endIndex: Int { span.count }
+    func index(after i: Int) -> Int { i+2 }
+
+    init(_ contiguous: borrowing Span<Int>) {
+      span = copy contiguous
+    }
+
+    subscript(_ p: Int) -> Int { span[p] }
+  }
+
+  @inline(never)
+  private func skip(
+    along array: borrowing Array<Int>
+  ) -> dependsOn(array) Skipper {
+    Skipper(array.storage)
+  }
+
+  func testSpanWrapper() {
+    let capacity = 8
+    let a = Array(0..<capacity)
+
+    let skipper = skip(along: a)
+    var i = skipper.startIndex
+    var s: [Int] = []
+    while i < skipper.endIndex {
+      s.append(skipper[i])
+      i = skipper.index(after: i)
+    }
+    XCTAssertEqual(s, [0, 2, 4, 6])
+  }
+}

--- a/Tests/FutureTests/RawSpanTests.swift
+++ b/Tests/FutureTests/RawSpanTests.swift
@@ -184,7 +184,7 @@ final class RawSpanTests: XCTestCase {
       XCTAssertTrue(span.prefix(upTo: 0).isEmpty)
       XCTAssertEqual(
         span.prefix(upTo: span.count).load(
-          fromByteOffset: span.offsets.last!, as: UInt8.self
+          fromByteOffset: span.indices.last!, as: UInt8.self
         ),
         UInt8(capacity-1)
       )
@@ -217,7 +217,7 @@ final class RawSpanTests: XCTestCase {
     let capacity = 4
     let a = Array(0..<capacity)
     let span = RawSpan(a.storage)
-    for o in span.offsets {
+    for o in span.indices {
       span.boundsCheckPrecondition(o)
     }
     // span.boundsCheckPrecondition(span.count)

--- a/Tests/FutureTests/RawSpanTests.swift
+++ b/Tests/FutureTests/RawSpanTests.swift
@@ -104,13 +104,13 @@ final class RawSpanTests: XCTestCase {
       let sub3 = span[offsets: ...]
       let sub4 = span[uncheckedOffsets: 2...]
       XCTAssertTrue(
-        sub1.view(as: UInt8.self).elementsEqual(sub2.view(as: UInt8.self))
+        sub1.view(as: UInt8.self)._elementsEqual(sub2.view(as: UInt8.self))
       )
       XCTAssertTrue(
-        sub3.view(as: Int8.self).elementsEqual(span.view(as: Int8.self))
+        sub3.view(as: Int8.self)._elementsEqual(span.view(as: Int8.self))
       )
       XCTAssertFalse(
-        sub4.view(as: Int8.self).elementsEqual(sub3.view(as: Int8.self))
+        sub4.view(as: Int8.self)._elementsEqual(sub3.view(as: Int8.self))
       )
     }
   }

--- a/Tests/FutureTests/RawSpanTests.swift
+++ b/Tests/FutureTests/RawSpanTests.swift
@@ -1,0 +1,225 @@
+//===--- RawSpanTests.swift -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Future
+
+final class RawSpanTests: XCTestCase {
+
+  func testOptionalStorage() {
+//    XCTAssertEqual(
+//      MemoryLayout<RawSpan>.size, MemoryLayout<RawSpan?>.size
+//    )
+//    XCTAssertEqual(
+//      MemoryLayout<RawSpan>.stride, MemoryLayout<RawSpan?>.stride
+//    )
+//    XCTAssertEqual(
+//      MemoryLayout<RawSpan>.alignment, MemoryLayout<RawSpan?>.alignment
+//    )
+  }
+
+  func testInitWithSpanOfIntegers() {
+    let capacity = 4
+    let a = Array(0..<capacity)
+    let span = RawSpan(a.storage)
+    XCTAssertEqual(span.count, capacity*MemoryLayout<Int>.stride)
+    XCTAssertFalse(span.isEmpty)
+  }
+
+  func testInitWithEmptySpanOfIntegers() {
+    let a: [Int] = []
+    let span = RawSpan(a.storage)
+    XCTAssertTrue(span.isEmpty)
+  }
+
+  func testInitWithRawBytes() {
+    let capacity = 4
+    let a = Array(0..<capacity)
+    a.withUnsafeBytes {
+      let span = RawSpan(unsafeBytes: $0, owner: a)
+      XCTAssertEqual(span.count, capacity*MemoryLayout<Int>.stride)
+    }
+  }
+
+  func testWithRawPointer() {
+    let capacity = 4
+    let a = Array(0..<capacity)
+    a.withUnsafeBytes {
+      let pointer = $0.baseAddress!
+      let span = RawSpan(
+        unsafeRawPointer: pointer, count: capacity*MemoryLayout<Int>.stride, owner: a
+      )
+      XCTAssertEqual(span.count, capacity*MemoryLayout<Int>.stride)
+    }
+  }
+
+  func testLoad() {
+    let capacity = 4
+    let s = (0..<capacity).map({ "\(#file)+\(#function) #\($0)" })
+    s.withUnsafeBytes {
+      let span = RawSpan(unsafeBytes: $0, owner: $0)
+      let stride = MemoryLayout<String>.stride
+
+      let s0 = span.load(as: String.self)
+      XCTAssertEqual(s0.contains("0"), true)
+      let s1 = span.load(fromByteOffset: stride, as: String.self)
+      XCTAssertEqual(s1.contains("1"), true)
+      let s2 = span.load(fromUncheckedByteOffset: 2*stride, as: String.self)
+      XCTAssertEqual(s2.contains("2"), true)
+    }
+  }
+
+  func testLoadUnaligned() {
+    let capacity = 64
+    let a = Array(0..<UInt8(capacity))
+    a.withUnsafeBytes {
+      let span = RawSpan(unsafeBytes: $0, owner: $0)
+
+      let u0 = span.dropFirst(2).loadUnaligned(as: UInt64.self)
+      XCTAssertEqual(u0 & 0xff, 2)
+      XCTAssertEqual(u0.byteSwapped & 0xff, 9)
+      let u1 = span.loadUnaligned(fromByteOffset: 6, as: UInt64.self)
+      XCTAssertEqual(u1 & 0xff, 6)
+      let u3 = span.loadUnaligned(fromUncheckedByteOffset: 7, as: UInt32.self)
+      XCTAssertEqual(u3 & 0xff, 7)
+    }
+  }
+
+  func testSubscript() {
+    let capacity = 4
+    let b = (0..<capacity).map(Int8.init)
+    b.withUnsafeBytes {
+      let span = RawSpan(unsafeBytes: $0, owner: $0)
+      let sub1 = span[offsets: 0..<2]
+      let sub2 = span[offsets: ..<2]
+      let sub3 = span[offsets: ...]
+      let sub4 = span[uncheckedOffsets: 2...]
+      XCTAssertTrue(
+        sub1.view(as: UInt8.self).elementsEqual(sub2.view(as: UInt8.self))
+      )
+      XCTAssertTrue(
+        sub3.view(as: Int8.self).elementsEqual(span.view(as: Int8.self))
+      )
+      XCTAssertFalse(
+        sub4.view(as: Int8.self).elementsEqual(sub3.view(as: Int8.self))
+      )
+    }
+  }
+
+  func testUncheckedSubscript() {
+    let capacity = 32
+    let b = (0..<capacity).map(UInt8.init)
+    b.withUnsafeBytes {
+      let span = RawSpan(unsafeBytes: $0, owner: $0)
+      let prefix = span[offsets: 0..<8]
+      let beyond = prefix[uncheckedOffsets: 16..<24]
+      XCTAssertEqual(beyond.count, 8)
+      XCTAssertEqual(beyond.load(as: UInt8.self), 16)
+    }
+  }
+
+  func testUnsafeBytes() {
+    let capacity = 4
+    let array = Array(0..<capacity)
+    let span = RawSpan(array.storage)
+    array.withUnsafeBytes {  b1 in
+      span.withUnsafeBytes { b2 in
+        XCTAssertTrue(b1.elementsEqual(b2))
+      }
+    }
+
+//FIXME: rdar://128694495 (Faulty escape diagnostic)
+// Should we be able to derive a non-escapable value from a Span via unsafe pointers?
+//    let copy = span.withUnsafeBytes {
+//      RawSpan(unsafeBytes: copy $0, owner: span)
+//    }
+//    _ = copy
+  }
+
+  func testStrangeBorrow() {
+    let array: [String] = ["0", "1", "2", "3"]
+    _ = array
+
+//    let rs = RawSpan(array.storage) // Initializer 'init(_:)' requires that 'String' conform to 'BitwiseCopyable'
+
+//    let rs1 = array.storage.withUnsafeBufferPointer {
+//      RawSpan(unsafeBytes: UnsafeRawBufferPointer($0), owner: array)
+//    }                               // Lifetime-dependent value escapes its scope
+//    _ = rs1
+
+//    let rs2 = array.storage.withUnsafeBufferPointer {
+//      UnsafeRawBufferPointer($0).withMemoryRebound(to: UInt8.self) { // requires that `Span` conform to `Escapable`
+//        return Span(unsafeBufferPointer: $0, owner: array)
+//      }
+//    }
+//    _ = rs2
+  }
+
+  func testPrefix() {
+    let capacity = 4
+    let a = Array(0..<UInt8(capacity))
+    a.withUnsafeBytes {
+      let span = RawSpan(unsafeBytes: $0, owner: $0)
+      XCTAssertEqual(span.count, capacity)
+      XCTAssertEqual(span.prefix(1).load(as: UInt8.self), 0)
+      XCTAssertEqual(
+        span.prefix(capacity).load(fromByteOffset: capacity-1, as: UInt8.self),
+        UInt8(capacity-1)
+      )
+      XCTAssertTrue(span.dropLast(capacity).isEmpty)
+      XCTAssertEqual(
+        span.dropLast(1).load(fromByteOffset: capacity-2, as: UInt8.self),
+        UInt8(capacity-2)
+      )
+
+      XCTAssertTrue(span.prefix(upTo: 0).isEmpty)
+      XCTAssertEqual(
+        span.prefix(upTo: span.count).load(
+          fromByteOffset: span.offsets.last!, as: UInt8.self
+        ),
+        UInt8(capacity-1)
+      )
+
+      XCTAssertFalse(span.prefix(through: 0).isEmpty)
+      XCTAssertEqual(
+        span.prefix(through: 2).load(fromByteOffset: 2, as: UInt8.self), 2
+      )
+    }
+  }
+
+  func testSuffix() {
+    let capacity = 4
+    let a = Array(0..<UInt8(capacity))
+    a.withUnsafeBytes {
+      let span = RawSpan(unsafeBytes: $0, owner: $0)
+      XCTAssertEqual(span.count, capacity)
+      XCTAssertEqual(span.suffix(capacity).load(as: UInt8.self), 0)
+      XCTAssertEqual(span.suffix(capacity-1).load(as: UInt8.self), 1)
+      XCTAssertEqual(span.suffix(1).load(as: UInt8.self), UInt8(capacity-1))
+      XCTAssertTrue(span.dropFirst(capacity).isEmpty)
+      XCTAssertEqual(span.dropFirst(1).load(as: UInt8.self), 1)
+
+      XCTAssertEqual(span.suffix(from: 0).count, a.count)
+      XCTAssertTrue(span.suffix(from: span.count).isEmpty)
+    }
+  }
+
+  func testBoundsChecking() {
+    let capacity = 4
+    let a = Array(0..<capacity)
+    let span = RawSpan(a.storage)
+    for o in span.offsets {
+      span.boundsCheckPrecondition(o)
+    }
+    // span.boundsCheckPrecondition(span.count)
+  }
+}

--- a/Tests/FutureTests/SpanTests.swift
+++ b/Tests/FutureTests/SpanTests.swift
@@ -300,32 +300,4 @@ final class SpanTests: XCTestCase {
     XCTAssertEqual(span.count, capacity-1)
     XCTAssertEqual(prefix.count, 2)
   }
-
-  func testSpanWrapper() {
-    let capacity = 8
-    let a = Array(0..<capacity)
-
-    struct Skipper: ~Escapable {
-      var span: Span<Int>
-
-      var startIndex: Int { 0 }
-      var endIndex: Int { span.count }
-      func index(after i: Int) -> Int { i+2 }
-
-      init(_ contiguous: borrowing Span<Int>) {
-        span = copy contiguous
-      }
-
-      subscript(_ p: Int) -> Int { span[p] }
-    }
-
-    let skipper = Skipper(a.storage)
-    var i = skipper.startIndex
-    var s: [Int] = []
-    while i < skipper.endIndex {
-      s.append(skipper[i])
-      i = skipper.index(after: i)
-    }
-    XCTAssertEqual(s, [0, 2, 4, 6])
-  }
 }

--- a/Tests/FutureTests/SpanTests.swift
+++ b/Tests/FutureTests/SpanTests.swift
@@ -103,10 +103,10 @@ final class SpanTests: XCTestCase {
     a.withUnsafeBufferPointer {
       let span = Span(unsafeBufferPointer: $0, owner: $0)
 
-      XCTAssertEqual(span._elementsEqual(span.prefix(1)), false)
-      XCTAssertEqual(span.prefix(0)._elementsEqual(span.suffix(0)), true)
+      XCTAssertEqual(span._elementsEqual(span.extracting(first: 1)), false)
+      XCTAssertEqual(span.extracting(0..<0)._elementsEqual(span.extracting(last: 0)), true)
       XCTAssertEqual(span._elementsEqual(span), true)
-      XCTAssertEqual(span.prefix(3)._elementsEqual(span.suffix(3)), false)
+      XCTAssertEqual(span.extracting(0..<3)._elementsEqual(span.extracting(last: 3)), false)
 
       let copy = span.withUnsafeBufferPointer(Array.init)
       copy.withUnsafeBufferPointer {
@@ -123,7 +123,7 @@ final class SpanTests: XCTestCase {
       let span = Span(unsafeBufferPointer: $0, owner: $0)
 
       XCTAssertEqual(span._elementsEqual(a), true)
-      XCTAssertEqual(span.prefix(0)._elementsEqual([]), true)
+      XCTAssertEqual(span.extracting(0..<0)._elementsEqual([]), true)
       XCTAssertEqual(span._elementsEqual(a.dropLast()), false)
     }
   }
@@ -136,7 +136,7 @@ final class SpanTests: XCTestCase {
 
       let s = AnySequence(a)
       XCTAssertEqual(span._elementsEqual(s), true)
-      XCTAssertEqual(span.dropLast()._elementsEqual(s), false)
+      XCTAssertEqual(span.extracting(0..<(capacity-1))._elementsEqual(s), false)
       XCTAssertEqual(span._elementsEqual(s.dropFirst()), false)
     }
   }
@@ -214,16 +214,10 @@ final class SpanTests: XCTestCase {
     a.withUnsafeBufferPointer {
       let span = Span(unsafeBufferPointer: $0, owner: $0)
       XCTAssertEqual(span.count, capacity)
-      XCTAssertEqual(span.prefix(1).last, 0)
-      XCTAssertEqual(span.prefix(capacity).last, capacity-1)
-      XCTAssertEqual(span.dropLast(capacity).last, nil)
-      XCTAssertEqual(span.dropLast(1).last, capacity-2)
-
-      XCTAssertTrue(span.prefix(upTo: 0).isEmpty)
-      XCTAssertTrue(span.prefix(upTo: span.count)._elementsEqual(span))
-
-      XCTAssertFalse(span.prefix(through: 0).isEmpty)
-      XCTAssertTrue(span.prefix(through: 2)._elementsEqual(span.prefix(3)))
+      XCTAssertEqual(span.extracting(first: 1).last, 0)
+      XCTAssertEqual(span.extracting(first: capacity).last, capacity-1)
+      XCTAssertEqual(span.extracting(droppingLast: capacity).last, nil)
+      XCTAssertEqual(span.extracting(droppingLast: 1).last, capacity-2)
     }
   }
 
@@ -233,14 +227,11 @@ final class SpanTests: XCTestCase {
     a.withUnsafeBufferPointer {
       let span = Span<Int>(unsafeBufferPointer: $0, owner: $0)
       XCTAssertEqual(span.count, capacity)
-      XCTAssertEqual(span.suffix(capacity).first, 0)
-      XCTAssertEqual(span.suffix(capacity-1).first, 1)
-      XCTAssertEqual(span.suffix(1).first, capacity-1)
-      XCTAssertEqual(span.dropFirst(capacity).first, nil)
-      XCTAssertEqual(span.dropFirst(1).first, 1)
-
-      XCTAssertEqual(span.suffix(from: 0)._elementsEqual(a), true)
-      XCTAssertEqual(span.suffix(from: span.count).isEmpty, true)
+      XCTAssertEqual(span.extracting(last: capacity).first, 0)
+      XCTAssertEqual(span.extracting(last: capacity-1).first, 1)
+      XCTAssertEqual(span.extracting(last: 1).first, capacity-1)
+      XCTAssertEqual(span.extracting(droppingFirst: capacity).first, nil)
+      XCTAssertEqual(span.extracting(droppingFirst: 1).first, 1)
     }
   }
 
@@ -294,8 +285,8 @@ final class SpanTests: XCTestCase {
     let capacity = 8
     let a = Array(0..<capacity)
     var span = a.storage
-    let prefix = span.prefix(2)
-    span = span.dropFirst()
+    let prefix = span.extracting(0..<2)
+    span = span.extracting(1...)
     XCTAssertEqual(span.count, capacity-1)
     XCTAssertEqual(prefix.count, 2)
   }

--- a/Tests/FutureTests/SpanTests.swift
+++ b/Tests/FutureTests/SpanTests.swift
@@ -31,7 +31,7 @@ final class SpanTests: XCTestCase {
     let capacity = 4
     let s = (0..<capacity).map({ "\(#file)+\(#function)--\($0)" })
     s.withUnsafeBufferPointer {
-      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let span = Span(unsafeElements: $0, owner: $0)
       _ = span
     }
   }
@@ -40,15 +40,15 @@ final class SpanTests: XCTestCase {
     let capacity = 4
     let a = Array(0..<capacity)
     a.withUnsafeBufferPointer {
-      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let span = Span(unsafeElements: $0, owner: $0)
       XCTAssertEqual(span.count, capacity)
     }
 
     a.withUnsafeBytes {
-      let b = Span<UInt>(unsafeBytes: $0, as: UInt.self, owner: $0)
+      let b = Span<UInt>(unsafeBytes: $0, owner: $0)
       XCTAssertEqual(b.count, capacity)
 
-      let r = Span<Int8>(unsafeBytes: $0, as: Int8.self, owner: $0)
+      let r = Span<Int8>(unsafeBytes: $0, owner: $0)
       XCTAssertEqual(r.count, capacity*MemoryLayout<Int>.stride)
     }
   }
@@ -57,11 +57,11 @@ final class SpanTests: XCTestCase {
     let capacity = 4
     let a = Array(0..<capacity)
     a.withUnsafeBufferPointer {
-      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let span = Span(unsafeElements: $0, owner: $0)
       XCTAssertFalse(span.isEmpty)
 
       let empty = Span(
-        unsafeBufferPointer: .init(rebasing: $0.dropFirst(capacity)), owner: $0
+        unsafeElements: .init(rebasing: $0.dropFirst(capacity)), owner: $0
       )
       XCTAssertTrue(empty.isEmpty)
     }
@@ -71,7 +71,7 @@ final class SpanTests: XCTestCase {
     let count = 4
     let array = Array(0..<count)
     array.withUnsafeBufferPointer {
-      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let span = Span(unsafeElements: $0, owner: $0)
       let raw  = span.rawSpan
       XCTAssertEqual(raw.count, span.count*MemoryLayout<Int>.stride)
     }
@@ -81,7 +81,7 @@ final class SpanTests: XCTestCase {
     let capacity = 4
     let a = Array(0..<capacity)
     a.withUnsafeBufferPointer {
-      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let span = Span(unsafeElements: $0, owner: $0)
       XCTAssertEqual(span.count, span.indices.count)
 
       var i = 0
@@ -101,7 +101,7 @@ final class SpanTests: XCTestCase {
       $1 = $0.count
     }
     a.withUnsafeBufferPointer {
-      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let span = Span(unsafeElements: $0, owner: $0)
 
       XCTAssertEqual(span._elementsEqual(span.extracting(first: 1)), false)
       XCTAssertEqual(span.extracting(0..<0)._elementsEqual(span.extracting(last: 0)), true)
@@ -110,7 +110,7 @@ final class SpanTests: XCTestCase {
 
       let copy = span.withUnsafeBufferPointer(Array.init)
       copy.withUnsafeBufferPointer {
-        let spanOfCopy = Span(unsafeBufferPointer: $0, owner: $0)
+        let spanOfCopy = Span(unsafeElements: $0, owner: $0)
         XCTAssertTrue(span._elementsEqual(spanOfCopy))
       }
     }
@@ -120,7 +120,7 @@ final class SpanTests: XCTestCase {
     let capacity = 4
     let a = Array(0..<capacity)
     a.withUnsafeBufferPointer {
-      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let span = Span(unsafeElements: $0, owner: $0)
 
       XCTAssertEqual(span._elementsEqual(a), true)
       XCTAssertEqual(span.extracting(0..<0)._elementsEqual([]), true)
@@ -132,7 +132,7 @@ final class SpanTests: XCTestCase {
     let capacity = 4
     let a = Array(0..<capacity)
     a.withUnsafeBufferPointer {
-      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let span = Span(unsafeElements: $0, owner: $0)
 
       let s = AnySequence(a)
       XCTAssertEqual(span._elementsEqual(s), true)
@@ -145,7 +145,7 @@ final class SpanTests: XCTestCase {
     let capacity = 4
     let a = (0..<capacity).map(String.init)
     a.withUnsafeBufferPointer {
-      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let span = Span(unsafeElements: $0, owner: $0)
       XCTAssertTrue(span._elementsEqual(span.extracting(0..<span.count)))
       XCTAssertTrue(span._elementsEqual(span.extracting(0...)))
       XCTAssertTrue(span._elementsEqual(span.extracting(uncheckedBounds: ..<span.count)))
@@ -157,7 +157,7 @@ final class SpanTests: XCTestCase {
     let capacity = 4
     let a = Array(0..<capacity)
     a.withUnsafeBufferPointer {
-      let v = Span(unsafeBufferPointer: $0, owner: $0)
+      let v = Span(unsafeElements: $0, owner: $0)
       XCTAssertTrue(v._elementsEqual(v.extracting(0..<v.count)))
       XCTAssertTrue(v._elementsEqual(v.extracting(0...)))
       XCTAssertTrue(v._elementsEqual(v.extracting(uncheckedBounds: ..<v.count)))
@@ -169,7 +169,7 @@ final class SpanTests: XCTestCase {
     let capacity = 4
     let a = (0..<capacity).map(String.init)
     a.withUnsafeBufferPointer {
-      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let span = Span(unsafeElements: $0, owner: $0)
       XCTAssertEqual(span[3], String(3))
     }
   }
@@ -178,7 +178,7 @@ final class SpanTests: XCTestCase {
     let capacity = 4
     let a = Array(0..<capacity)
     a.withUnsafeBufferPointer {
-      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let span = Span(unsafeElements: $0, owner: $0)
       XCTAssertEqual(span[3], 3)
     }
   }
@@ -187,7 +187,7 @@ final class SpanTests: XCTestCase {
     let capacity = 4
     let a = (0..<capacity).map(String.init)
     a.withUnsafeBufferPointer {
-      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let span = Span(unsafeElements: $0, owner: $0)
       XCTAssertTrue(span._elementsEqual(span.extracting(0..<capacity)))
       XCTAssertTrue(span._elementsEqual(span.extracting(0...)))
       XCTAssertTrue(span._elementsEqual(span.extracting(uncheckedBounds: ..<capacity)))
@@ -198,7 +198,7 @@ final class SpanTests: XCTestCase {
     let r = Int.random(in: 0..<1000)
     let a = [r]
     a.withUnsafeBufferPointer {
-      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let span = Span(unsafeElements: $0, owner: $0)
       XCTAssertEqual(span.first, r)
       XCTAssertEqual(span.last, r)
 
@@ -212,7 +212,7 @@ final class SpanTests: XCTestCase {
     let capacity = 4
     let a = Array(0..<capacity)
     a.withUnsafeBufferPointer {
-      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let span = Span(unsafeElements: $0, owner: $0)
       XCTAssertEqual(span.count, capacity)
       XCTAssertEqual(span.extracting(first: 1).last, 0)
       XCTAssertEqual(span.extracting(first: capacity).last, capacity-1)
@@ -225,7 +225,7 @@ final class SpanTests: XCTestCase {
     let capacity = 4
     let a = Array(0..<capacity)
     a.withUnsafeBufferPointer {
-      let span = Span<Int>(unsafeBufferPointer: $0, owner: $0)
+      let span = Span<Int>(unsafeElements: $0, owner: $0)
       XCTAssertEqual(span.count, capacity)
       XCTAssertEqual(span.extracting(last: capacity).first, 0)
       XCTAssertEqual(span.extracting(last: capacity-1).first, 1)
@@ -240,7 +240,7 @@ final class SpanTests: XCTestCase {
     let a = Array(0..<capacity)
     a.withUnsafeBufferPointer {
       ub in
-      let span = Span(unsafeBufferPointer: ub, owner: ub)
+      let span = Span(unsafeElements: ub, owner: ub)
 
       span.withUnsafeBytes {
         let i = Int.random(in: 0..<$0.count)
@@ -259,7 +259,7 @@ final class SpanTests: XCTestCase {
     let a = Array(0..<capacity)
     a.withUnsafeBufferPointer {
       ub in
-      let span = Span(unsafeBufferPointer: ub, owner: ub)
+      let span = Span(unsafeElements: ub, owner: ub)
 
       span.withUnsafeBytes {
         let i = Int.random(in: 0..<$0.count)
@@ -274,7 +274,7 @@ final class SpanTests: XCTestCase {
       let emptyBuffer = UnsafeBufferPointer(rebasing: ub[0..<0])
       XCTAssertEqual(emptyBuffer.baseAddress, ub.baseAddress)
 
-      let empty = Span(unsafeBufferPointer: emptyBuffer, owner: ub)
+      let empty = Span(unsafeElements: emptyBuffer, owner: ub)
       empty.withUnsafeBufferPointer {
         XCTAssertNil($0.baseAddress)
       }

--- a/Tests/FutureTests/SpanTests.swift
+++ b/Tests/FutureTests/SpanTests.swift
@@ -103,15 +103,15 @@ final class SpanTests: XCTestCase {
     a.withUnsafeBufferPointer {
       let span = Span(unsafeBufferPointer: $0, owner: $0)
 
-      XCTAssertEqual(span.elementsEqual(span.prefix(1)), false)
-      XCTAssertEqual(span.prefix(0).elementsEqual(span.suffix(0)), true)
-      XCTAssertEqual(span.elementsEqual(span), true)
-      XCTAssertEqual(span.prefix(3).elementsEqual(span.suffix(3)), false)
+      XCTAssertEqual(span._elementsEqual(span.prefix(1)), false)
+      XCTAssertEqual(span.prefix(0)._elementsEqual(span.suffix(0)), true)
+      XCTAssertEqual(span._elementsEqual(span), true)
+      XCTAssertEqual(span.prefix(3)._elementsEqual(span.suffix(3)), false)
 
       let copy = span.withUnsafeBufferPointer(Array.init)
       copy.withUnsafeBufferPointer {
         let spanOfCopy = Span(unsafeBufferPointer: $0, owner: $0)
-        XCTAssertTrue(span.elementsEqual(spanOfCopy))
+        XCTAssertTrue(span._elementsEqual(spanOfCopy))
       }
     }
   }
@@ -122,9 +122,9 @@ final class SpanTests: XCTestCase {
     a.withUnsafeBufferPointer {
       let span = Span(unsafeBufferPointer: $0, owner: $0)
 
-      XCTAssertEqual(span.elementsEqual(a), true)
-      XCTAssertEqual(span.prefix(0).elementsEqual([]), true)
-      XCTAssertEqual(span.elementsEqual(a.dropLast()), false)
+      XCTAssertEqual(span._elementsEqual(a), true)
+      XCTAssertEqual(span.prefix(0)._elementsEqual([]), true)
+      XCTAssertEqual(span._elementsEqual(a.dropLast()), false)
     }
   }
 
@@ -135,9 +135,9 @@ final class SpanTests: XCTestCase {
       let span = Span(unsafeBufferPointer: $0, owner: $0)
 
       let s = AnySequence(a)
-      XCTAssertEqual(span.elementsEqual(s), true)
-      XCTAssertEqual(span.dropLast().elementsEqual(s), false)
-      XCTAssertEqual(span.elementsEqual(s.dropFirst()), false)
+      XCTAssertEqual(span._elementsEqual(s), true)
+      XCTAssertEqual(span.dropLast()._elementsEqual(s), false)
+      XCTAssertEqual(span._elementsEqual(s.dropFirst()), false)
     }
   }
 
@@ -146,10 +146,10 @@ final class SpanTests: XCTestCase {
     let a = (0..<capacity).map(String.init)
     a.withUnsafeBufferPointer {
       let span = Span(unsafeBufferPointer: $0, owner: $0)
-      XCTAssertTrue(span.elementsEqual(span.extracting(0..<span.count)))
-      XCTAssertTrue(span.elementsEqual(span.extracting(0...)))
-      XCTAssertTrue(span.elementsEqual(span.extracting(uncheckedBounds: ..<span.count)))
-      XCTAssertTrue(span.elementsEqual(span.extracting(...)))
+      XCTAssertTrue(span._elementsEqual(span.extracting(0..<span.count)))
+      XCTAssertTrue(span._elementsEqual(span.extracting(0...)))
+      XCTAssertTrue(span._elementsEqual(span.extracting(uncheckedBounds: ..<span.count)))
+      XCTAssertTrue(span._elementsEqual(span.extracting(...)))
     }
   }
 
@@ -158,10 +158,10 @@ final class SpanTests: XCTestCase {
     let a = Array(0..<capacity)
     a.withUnsafeBufferPointer {
       let v = Span(unsafeBufferPointer: $0, owner: $0)
-      XCTAssertTrue(v.elementsEqual(v.extracting(0..<v.count)))
-      XCTAssertTrue(v.elementsEqual(v.extracting(0...)))
-      XCTAssertTrue(v.elementsEqual(v.extracting(uncheckedBounds: ..<v.count)))
-      XCTAssertTrue(v.elementsEqual(v.extracting(...)))
+      XCTAssertTrue(v._elementsEqual(v.extracting(0..<v.count)))
+      XCTAssertTrue(v._elementsEqual(v.extracting(0...)))
+      XCTAssertTrue(v._elementsEqual(v.extracting(uncheckedBounds: ..<v.count)))
+      XCTAssertTrue(v._elementsEqual(v.extracting(...)))
     }
   }
 
@@ -188,9 +188,9 @@ final class SpanTests: XCTestCase {
     let a = (0..<capacity).map(String.init)
     a.withUnsafeBufferPointer {
       let span = Span(unsafeBufferPointer: $0, owner: $0)
-      XCTAssertTrue(span.elementsEqual(span.extracting(0..<capacity)))
-      XCTAssertTrue(span.elementsEqual(span.extracting(0...)))
-      XCTAssertTrue(span.elementsEqual(span.extracting(uncheckedBounds: ..<capacity)))
+      XCTAssertTrue(span._elementsEqual(span.extracting(0..<capacity)))
+      XCTAssertTrue(span._elementsEqual(span.extracting(0...)))
+      XCTAssertTrue(span._elementsEqual(span.extracting(uncheckedBounds: ..<capacity)))
     }
   }
 
@@ -220,10 +220,10 @@ final class SpanTests: XCTestCase {
       XCTAssertEqual(span.dropLast(1).last, capacity-2)
 
       XCTAssertTrue(span.prefix(upTo: 0).isEmpty)
-      XCTAssertTrue(span.prefix(upTo: span.count).elementsEqual(span))
+      XCTAssertTrue(span.prefix(upTo: span.count)._elementsEqual(span))
 
       XCTAssertFalse(span.prefix(through: 0).isEmpty)
-      XCTAssertTrue(span.prefix(through: 2).elementsEqual(span.prefix(3)))
+      XCTAssertTrue(span.prefix(through: 2)._elementsEqual(span.prefix(3)))
     }
   }
 
@@ -239,7 +239,7 @@ final class SpanTests: XCTestCase {
       XCTAssertEqual(span.dropFirst(capacity).first, nil)
       XCTAssertEqual(span.dropFirst(1).first, 1)
 
-      XCTAssertEqual(span.suffix(from: 0).elementsEqual(a), true)
+      XCTAssertEqual(span.suffix(from: 0)._elementsEqual(a), true)
       XCTAssertEqual(span.suffix(from: span.count).isEmpty, true)
     }
   }

--- a/Tests/FutureTests/SpanTests.swift
+++ b/Tests/FutureTests/SpanTests.swift
@@ -1,0 +1,340 @@
+//===--- SpanTests.swift --------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Future
+
+final class SpanTests: XCTestCase {
+
+  func testOptionalStorage() {
+//    XCTAssertEqual(
+//      MemoryLayout<Span<UInt8>>.size, MemoryLayout<Span<UInt8>?>.size
+//    )
+//    XCTAssertEqual(
+//      MemoryLayout<Span<UInt8>>.stride, MemoryLayout<Span<UInt8>?>.stride
+//    )
+//    XCTAssertEqual(
+//      MemoryLayout<Span<UInt8>>.alignment, MemoryLayout<Span<UInt8>?>.alignment
+//    )
+  }
+
+  func testInitWithOrdinaryElement() {
+    let capacity = 4
+    let s = (0..<capacity).map({ "\(#file)+\(#function)--\($0)" })
+    s.withUnsafeBufferPointer {
+      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      _ = span
+    }
+  }
+
+  func testInitWithBitwiseCopyableElement() {
+    let capacity = 4
+    let a = Array(0..<capacity)
+    a.withUnsafeBufferPointer {
+      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      XCTAssertEqual(span.count, capacity)
+    }
+
+    a.withUnsafeBytes {
+      let b = Span<UInt>(unsafeBytes: $0, as: UInt.self, owner: $0)
+      XCTAssertEqual(b.count, capacity)
+
+      let r = Span<Int8>(unsafeBytes: $0, as: Int8.self, owner: $0)
+      XCTAssertEqual(r.count, capacity*MemoryLayout<Int>.stride)
+    }
+  }
+
+  func testIsEmpty() {
+    let capacity = 4
+    let a = Array(0..<capacity)
+    a.withUnsafeBufferPointer {
+      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      XCTAssertFalse(span.isEmpty)
+
+      let empty = Span(
+        unsafeBufferPointer: .init(rebasing: $0.dropFirst(capacity)), owner: $0
+      )
+      XCTAssertTrue(empty.isEmpty)
+    }
+  }
+
+  func testRawSpanFromSpan() {
+    let count = 4
+    let array = Array(0..<count)
+    array.withUnsafeBufferPointer {
+      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      let raw  = span.rawSpan
+      XCTAssertEqual(raw.count, span.count*MemoryLayout<Int>.stride)
+    }
+  }
+
+  func testSpanIndices() {
+    let capacity = 4
+    let a = Array(0..<capacity)
+    a.withUnsafeBufferPointer {
+      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      XCTAssertEqual(span.count, span.indices.count)
+
+      var i = 0
+      for j in span.indices {
+        XCTAssertEqual(i, j)
+        i += 1
+      }
+    }
+  }
+
+  func testElementsEqual() {
+    let capacity = 4
+    let a = Array<Int>(unsafeUninitializedCapacity: capacity) {
+      for i in $0.indices {
+        $0.initializeElement(at: i, to: .random(in: 0..<10))
+      }
+      $1 = $0.count
+    }
+    a.withUnsafeBufferPointer {
+      let span = Span(unsafeBufferPointer: $0, owner: $0)
+
+      XCTAssertEqual(span.elementsEqual(span.prefix(1)), false)
+      XCTAssertEqual(span.prefix(0).elementsEqual(span.suffix(0)), true)
+      XCTAssertEqual(span.elementsEqual(span), true)
+      XCTAssertEqual(span.prefix(3).elementsEqual(span.suffix(3)), false)
+
+      let copy = span.withUnsafeBufferPointer(Array.init)
+      copy.withUnsafeBufferPointer {
+        let spanOfCopy = Span(unsafeBufferPointer: $0, owner: $0)
+        XCTAssertTrue(span.elementsEqual(spanOfCopy))
+      }
+    }
+  }
+
+  func testElementsEqualCollection() {
+    let capacity = 4
+    let a = Array(0..<capacity)
+    a.withUnsafeBufferPointer {
+      let span = Span(unsafeBufferPointer: $0, owner: $0)
+
+      XCTAssertEqual(span.elementsEqual(a), true)
+      XCTAssertEqual(span.prefix(0).elementsEqual([]), true)
+      XCTAssertEqual(span.elementsEqual(a.dropLast()), false)
+    }
+  }
+
+  func testElementsEqualSequence() {
+    let capacity = 4
+    let a = Array(0..<capacity)
+    a.withUnsafeBufferPointer {
+      let span = Span(unsafeBufferPointer: $0, owner: $0)
+
+      let s = AnySequence(a)
+      XCTAssertEqual(span.elementsEqual(s), true)
+      XCTAssertEqual(span.dropLast().elementsEqual(s), false)
+      XCTAssertEqual(span.elementsEqual(s.dropFirst()), false)
+    }
+  }
+
+  func testRangeOfIndicesSubscript() {
+    let capacity = 4
+    let a = (0..<capacity).map(String.init)
+    a.withUnsafeBufferPointer {
+      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      XCTAssertTrue(span.elementsEqual(span.extracting(0..<span.count)))
+      XCTAssertTrue(span.elementsEqual(span.extracting(0...)))
+      XCTAssertTrue(span.elementsEqual(span.extracting(uncheckedBounds: ..<span.count)))
+      XCTAssertTrue(span.elementsEqual(span.extracting(...)))
+    }
+  }
+
+  func testRangeOfIndicesSubscriptBitwiseCopyable() {
+    let capacity = 4
+    let a = Array(0..<capacity)
+    a.withUnsafeBufferPointer {
+      let v = Span(unsafeBufferPointer: $0, owner: $0)
+      XCTAssertTrue(v.elementsEqual(v.extracting(0..<v.count)))
+      XCTAssertTrue(v.elementsEqual(v.extracting(0...)))
+      XCTAssertTrue(v.elementsEqual(v.extracting(uncheckedBounds: ..<v.count)))
+      XCTAssertTrue(v.elementsEqual(v.extracting(...)))
+    }
+  }
+
+  func testOffsetSubscript() {
+    let capacity = 4
+    let a = (0..<capacity).map(String.init)
+    a.withUnsafeBufferPointer {
+      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      XCTAssertEqual(span[3], String(3))
+    }
+  }
+
+  func testOffsetSubscriptBitwiseCopyable() {
+    let capacity = 4
+    let a = Array(0..<capacity)
+    a.withUnsafeBufferPointer {
+      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      XCTAssertEqual(span[3], 3)
+    }
+  }
+
+  func testRangeOfOffsetsSubscript() {
+    let capacity = 4
+    let a = (0..<capacity).map(String.init)
+    a.withUnsafeBufferPointer {
+      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      XCTAssertTrue(span.elementsEqual(span.extracting(0..<capacity)))
+      XCTAssertTrue(span.elementsEqual(span.extracting(0...)))
+      XCTAssertTrue(span.elementsEqual(span.extracting(uncheckedBounds: ..<capacity)))
+    }
+  }
+
+  func testFirstAndLast() {
+    let r = Int.random(in: 0..<1000)
+    let a = [r]
+    a.withUnsafeBufferPointer {
+      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      XCTAssertEqual(span.first, r)
+      XCTAssertEqual(span.last, r)
+
+      let emptySpan = span.extracting(0..<0)
+      XCTAssertEqual(emptySpan.first, nil)
+      XCTAssertEqual(emptySpan.last, nil)
+    }
+  }
+
+  func testPrefix() {
+    let capacity = 4
+    let a = Array(0..<capacity)
+    a.withUnsafeBufferPointer {
+      let span = Span(unsafeBufferPointer: $0, owner: $0)
+      XCTAssertEqual(span.count, capacity)
+      XCTAssertEqual(span.prefix(1).last, 0)
+      XCTAssertEqual(span.prefix(capacity).last, capacity-1)
+      XCTAssertEqual(span.dropLast(capacity).last, nil)
+      XCTAssertEqual(span.dropLast(1).last, capacity-2)
+
+      XCTAssertTrue(span.prefix(upTo: 0).isEmpty)
+      XCTAssertTrue(span.prefix(upTo: span.count).elementsEqual(span))
+
+      XCTAssertFalse(span.prefix(through: 0).isEmpty)
+      XCTAssertTrue(span.prefix(through: 2).elementsEqual(span.prefix(3)))
+    }
+  }
+
+  func testSuffix() {
+    let capacity = 4
+    let a = Array(0..<capacity)
+    a.withUnsafeBufferPointer {
+      let span = Span<Int>(unsafeBufferPointer: $0, owner: $0)
+      XCTAssertEqual(span.count, capacity)
+      XCTAssertEqual(span.suffix(capacity).first, 0)
+      XCTAssertEqual(span.suffix(capacity-1).first, 1)
+      XCTAssertEqual(span.suffix(1).first, capacity-1)
+      XCTAssertEqual(span.dropFirst(capacity).first, nil)
+      XCTAssertEqual(span.dropFirst(1).first, 1)
+
+      XCTAssertEqual(span.suffix(from: 0).elementsEqual(a), true)
+      XCTAssertEqual(span.suffix(from: span.count).isEmpty, true)
+    }
+  }
+
+  public func testWithUnsafeBytes() {
+    let capacity: UInt8 = 64
+    let a = Array(0..<capacity)
+    a.withUnsafeBufferPointer {
+      ub in
+      let span = Span(unsafeBufferPointer: ub, owner: ub)
+
+      span.withUnsafeBytes {
+        let i = Int.random(in: 0..<$0.count)
+        XCTAssertEqual($0.load(fromByteOffset: i, as: UInt8.self), ub[i])
+      }
+
+      span.withUnsafeBufferPointer {
+        let i = Int.random(in: 0..<$0.count)
+        XCTAssertEqual($0[i], ub[i])
+      }
+    }
+  }
+
+  public func testWithUnsafeBuffer() {
+    let capacity: UInt8 = 64
+    let a = Array(0..<capacity)
+    a.withUnsafeBufferPointer {
+      ub in
+      let span = Span(unsafeBufferPointer: ub, owner: ub)
+
+      span.withUnsafeBytes {
+        let i = Int.random(in: 0..<$0.count)
+        XCTAssertEqual($0[i], ub[i])
+      }
+
+      span.withUnsafeBufferPointer {
+        let i = Int.random(in: 0..<$0.count)
+        XCTAssertEqual($0[i], ub[i])
+      }
+
+      let emptyBuffer = UnsafeBufferPointer(rebasing: ub[0..<0])
+      XCTAssertEqual(emptyBuffer.baseAddress, ub.baseAddress)
+
+      let empty = Span(unsafeBufferPointer: emptyBuffer, owner: ub)
+      empty.withUnsafeBufferPointer {
+        XCTAssertNil($0.baseAddress)
+      }
+    }
+  }
+
+  public func testBorrowing1() {
+    let capacity = 8
+    let a = Array(0..<capacity)
+    var span = a.storage
+    let prefix = span.prefix(2)
+    span = span.dropFirst()
+    XCTAssertEqual(span.count, capacity-1)
+    XCTAssertEqual(prefix.count, 2)
+  }
+
+  public func testBorrowing2() {
+    let capacity = 8
+    let a = Array(0..<capacity)
+    var span = a.storage
+    let prefix = span.extracting(0..<2)
+    span = span.extracting(1...)
+    XCTAssertEqual(span.count, capacity-1)
+    XCTAssertEqual(prefix.count, 2)
+  }
+
+  func testSpanWrapper() {
+    let capacity = 8
+    let a = Array(0..<capacity)
+
+    struct Skipper: ~Escapable {
+      var span: Span<Int>
+
+      var startIndex: Int { 0 }
+      var endIndex: Int { span.count }
+      func index(after i: Int) -> Int { i+2 }
+
+      init(_ contiguous: borrowing Span<Int>) {
+        span = copy contiguous
+      }
+
+      subscript(_ p: Int) -> Int { span[p] }
+    }
+
+    let skipper = Skipper(a.storage)
+    var i = skipper.startIndex
+    var s: [Int] = []
+    while i < skipper.endIndex {
+      s.append(skipper[i])
+      i = skipper.index(after: i)
+    }
+    XCTAssertEqual(s, [0, 2, 4, 6])
+  }
+}


### PR DESCRIPTION
This adds prototypes of `Span` and `RawSpan`, types proposed and discussed in "[Safe Access to Contiguous Storage](https://forums.swift.org/t/69888)"

These additions require a recent Swift development toolchain [snapshot](https://www.swift.org/download/#snapshots), June 8th 2024 or newer.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
