### PR TITLE
Install the Foundation toolchain module during the static swift build

### DIFF
--- a/Sources/Collections/CMakeLists.txt
+++ b/Sources/Collections/CMakeLists.txt
@@ -52,13 +52,18 @@ if(COLLECTIONS_SINGLE_MODULE)
     INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 
   if(COLLECTIONS_FOUNDATION_TOOLCHAIN_MODULE)
-    # Install only the swift module and not the library
+    get_swift_host_os(swift_os)
     if(BUILD_SHARED_LIBS)
+      # Install only the swift module and not the library
       set(swift swift)
     else()
+      # Install both the swift module and the binary
       set(swift swift_static)
+      install(TARGETS ${COLLECTIONS_MODULE_NAME}
+          ARCHIVE DESTINATION lib/swift_static/${swift_os}
+          LIBRARY DESTINATION lib/swift_static/${swift_os}
+          RUNTIME DESTINATION bin)
     endif()
-    get_swift_host_os(swift_os)
     get_swift_host_arch(swift_arch)
     install(FILES $<TARGET_PROPERTY:${COLLECTIONS_MODULE_NAME},Swift_MODULE_DIRECTORY>/${COLLECTIONS_MODULE_NAME}.swiftdoc
       DESTINATION lib/${swift}/${swift_os}/${COLLECTIONS_MODULE_NAME}.swiftmodule


### PR DESCRIPTION
This updates the cmake build (specifically the single-module, foundation toolchain build section) to install the `_FoundationCollections.a` library for the static swift build (but not install it for the non-static build). This ensures the library is present in the static swift SDK in the toolchain (as needed) but not in the standard directory. The usage of this module is still guarded by the `-allowable-client` flag written into the swift module.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
