### PR TITLE
Updates: clean up keywords, improve bounds checking

### DIFF
--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -122,27 +122,45 @@ extension RawSpan {
 //MARK: Bounds Checking
 extension RawSpan {
 
+  /// Return true if `offset` is a valid offset into this `RawSpan`
+  ///
+  /// - Parameters:
+  ///   - position: an index to validate
+  /// - Returns: true if `offset` is a valid index
+  @inlinable @inline(__always)
+  public func validateBounds(_ offset: Int) -> Bool {
+    0 <= offset && offset < byteCount
+  }
+
   /// Traps if `offset` is not a valid offset into this `RawSpan`
   ///
   /// - Parameters:
-  ///   - position: an offset to validate
+  ///   - position: an index to validate
   @inlinable @inline(__always)
-  public func boundsCheckPrecondition(_ offset: Int) {
+  public func assertValidity(_ offset: Int) {
     precondition(
-      0 <= offset && offset < byteCount,
-      "Offset out of bounds"
+      validateBounds(offset), "Offset out of bounds"
     )
   }
 
-  /// Traps if `bounds` is not a valid range of offsets into this `RawSpan`
+  /// Return true if `offsets` is a valid range of offsets into this `RawSpan`
   ///
   /// - Parameters:
-  ///   - offsets: a range of offsets to validate
+  ///   - offsets: a range of indices to validate
+  /// - Returns: true if `offsets` is a valid range of indices
   @inlinable @inline(__always)
-  public func boundsCheckPrecondition(_ offsets: Range<Int>) {
+  public func validateBounds(_ offsets: Range<Int>) -> Bool {
+    0 <= offsets.lowerBound && offsets.upperBound <= byteCount
+  }
+
+  /// Traps if `offsets` is not a valid range of offsets into this `RawSpan`
+  ///
+  /// - Parameters:
+  ///   - offsets: a range of indices to validate
+  @inlinable @inline(__always)
+  public func assertValidity(_ offsets: Range<Int>) {
     precondition(
-      0 <= offsets.lowerBound && offsets.upperBound <= byteCount,
-      "Range of offsets out of bounds"
+      validateBounds(offsets), "Range of offsets out of bounds"
     )
   }
 }
@@ -165,7 +183,7 @@ extension RawSpan {
   /// - Complexity: O(1)
   @inlinable @inline(__always)
   public func extracting(_ bounds: Range<Int>) -> Self {
-    boundsCheckPrecondition(bounds)
+    assertValidity(bounds)
     return extracting(uncheckedBounds: bounds)
   }
 
@@ -305,7 +323,7 @@ extension RawSpan {
   public func load<T>(
     fromByteOffset offset: Int = 0, as: T.Type
   ) -> T {
-    boundsCheckPrecondition(
+    assertValidity(
       Range(uncheckedBounds: (offset, offset+MemoryLayout<T>.size))
     )
     return load(fromUncheckedByteOffset: offset, as: T.self)
@@ -347,7 +365,7 @@ extension RawSpan {
   public func loadUnaligned<T: BitwiseCopyable>(
     fromByteOffset offset: Int = 0, as: T.Type
   ) -> T {
-    boundsCheckPrecondition(
+    assertValidity(
       Range(uncheckedBounds: (offset, offset+MemoryLayout<T>.size))
     )
     return loadUnaligned(fromUncheckedByteOffset: offset, as: T.self)
@@ -507,7 +525,7 @@ extension RawSpan {
 
     @inlinable
     public init(_ base: RawSpan, in range: Range<Int>) {
-      base.boundsCheckPrecondition(range)
+      base.assertValidity(range)
       position = 0
       self.base = base
       parseRange = range

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -35,7 +35,7 @@ extension RawSpan: Sendable {}
 
 extension RawSpan {
 
-  //FIXME: make failable once Optional can be non-escapable
+  //FIXME: make properly non-failable
   /// Unsafely create a `RawSpan` over initialized memory.
   ///
   /// The memory in `buffer` must be owned by the instance `owner`,
@@ -160,7 +160,7 @@ extension RawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `RawSpan`.
   ///
-  /// - Returns: A `Span` over the bytes within `bounds`
+  /// - Returns: A span over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @inlinable @inline(__always)
@@ -181,7 +181,7 @@ extension RawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `RawSpan`.
   ///
-  /// - Returns: A `Span` over the bytes within `bounds`
+  /// - Returns: A span over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @inlinable @inline(__always)
@@ -203,7 +203,7 @@ extension RawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `RawSpan`.
   ///
-  /// - Returns: A `Span` over the bytes within `bounds`
+  /// - Returns: A span over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -223,7 +223,7 @@ extension RawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `RawSpan`.
   ///
-  /// - Returns: A `Span` over the bytes within `bounds`
+  /// - Returns: A span over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -239,7 +239,7 @@ extension RawSpan {
   /// slices, extracted spans do not generally share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Returns: A `RawSpan` over all the items of this span.
+  /// - Returns: A span over all the bytes of this span.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -24,7 +24,7 @@ public struct RawSpan: Copyable, ~Escapable {
     _unchecked start: UnsafeRawPointer,
     byteCount: Int,
     owner: borrowing Owner
-  ) -> dependsOn(owner) Self {
+  ) {
     self._start = start
     self._count = byteCount
   }
@@ -265,11 +265,9 @@ extension RawSpan {
   ///   The closure's parameter is valid only for the duration of
   ///   its execution.
   /// - Returns: The return value of the `body` closure parameter.
-  borrowing public func withUnsafeBytes<
-    E: Error, Result: ~Copyable & ~Escapable
-  >(
-    _ body: (_ buffer: borrowing UnsafeRawBufferPointer) throws(E) -> Result
-  ) throws(E) -> dependsOn(self) Result {
+  public func withUnsafeBytes<E: Error, Result: ~Copyable & ~Escapable>(
+    _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
     try body(.init(start: (byteCount==0) ? nil : _start, count: byteCount))
   }
 }
@@ -279,9 +277,9 @@ extension RawSpan {
   ///
   /// - Parameter type: The type as which we should view <reword>
   /// - Returns: A typed span viewing these bytes as T
-  borrowing public func view<T: BitwiseCopyable>(
+  public func view<T: BitwiseCopyable>(
     as type: T.Type
-  ) -> dependsOn(self) Span<T> {
+  ) -> Span<T> {
     Span(unsafeStart: _start, byteCount: byteCount, owner: self)
   }
 }
@@ -388,7 +386,7 @@ extension RawSpan {
   /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
-  borrowing public func extracting(first maxLength: Int) -> Self {
+  public func extracting(first maxLength: Int) -> Self {
     precondition(maxLength >= 0, "Can't have a prefix of negative length.")
     let nc = maxLength < byteCount ? maxLength : byteCount
     return Self(_unchecked: _start, byteCount: nc, owner: self)
@@ -404,7 +402,7 @@ extension RawSpan {
   /// - Returns: A span leaving off the specified number of bytes at the end.
   ///
   /// - Complexity: O(1)
-  borrowing public func extracting(droppingLast k: Int) -> Self {
+  public func extracting(droppingLast k: Int) -> Self {
     precondition(k >= 0, "Can't drop a negative number of elements.")
     let nc = k < byteCount ? byteCount&-k : 0
     return Self(_unchecked: _start, byteCount: nc, owner: self)
@@ -421,7 +419,7 @@ extension RawSpan {
   /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
-  borrowing public func extracting(last maxLength: Int) -> Self {
+  public func extracting(last maxLength: Int) -> Self {
     precondition(maxLength >= 0, "Can't have a suffix of negative length.")
     let nc = maxLength < byteCount ? maxLength : byteCount
     let newStart = _start.advanced(by: byteCount&-nc)
@@ -438,7 +436,7 @@ extension RawSpan {
   /// - Returns: A span starting after the specified number of bytes.
   ///
   /// - Complexity: O(1)
-  borrowing public func extracting(droppingFirst k: Int = 1) -> Self {
+  public func extracting(droppingFirst k: Int = 1) -> Self {
     precondition(k >= 0, "Can't drop a negative number of elements.")
     let dc = k < byteCount ? k : byteCount
     let newStart = _start.advanced(by: dc)

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -265,6 +265,7 @@ extension RawSpan {
   ///   The closure's parameter is valid only for the duration of
   ///   its execution.
   /// - Returns: The return value of the `body` closure parameter.
+  @_alwaysEmitIntoClient
   public func withUnsafeBytes<E: Error, Result: ~Copyable & ~Escapable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {

--- a/Sources/Future/Span.swift
+++ b/Sources/Future/Span.swift
@@ -287,16 +287,35 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
 //MARK: Bounds Checking
 extension Span where Element: ~Copyable /*& ~Escapable*/ {
 
+  /// Return true if `offset` is a valid offset into this `Span`
+  ///
+  /// - Parameters:
+  ///   - position: an index to validate
+  /// - Returns: true if `offset` is a valid index
+  @inlinable @inline(__always)
+  public func validateBounds(_ offset: Int) -> Bool {
+    0 <= offset && offset < count
+  }
+
   /// Traps if `offset` is not a valid offset into this `Span`
   ///
   /// - Parameters:
-  ///   - position: an Index to validate
+  ///   - position: an index to validate
   @inlinable @inline(__always)
-  public func boundsCheckPrecondition(_ offset: Int) {
+  public func assertValidity(_ offset: Int) {
     precondition(
-      0 <= offset && offset < count,
-      "Offset out of bounds"
+      validateBounds(offset), "Offset out of bounds"
     )
+  }
+
+  /// Return true if `offsets` is a valid range of offsets into this `Span`
+  ///
+  /// - Parameters:
+  ///   - offsets: a range of indices to validate
+  /// - Returns: true if `offsets` is a valid range of indices
+  @inlinable @inline(__always)
+  public func validateBounds(_ offsets: Range<Int>) -> Bool {
+    0 <= offsets.lowerBound && offsets.upperBound <= count
   }
 
   /// Traps if `offsets` is not a valid range of offsets into this `Span`
@@ -304,10 +323,9 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Parameters:
   ///   - offsets: a range of indices to validate
   @inlinable @inline(__always)
-  public func boundsCheckPrecondition(_ offsets: Range<Int>) {
+  public func assertValidity(_ offsets: Range<Int>) {
     precondition(
-      0 <= offsets.lowerBound && offsets.upperBound <= count,
-      "Range of offsets out of bounds"
+      validateBounds(offsets), "Range of offsets out of bounds"
     )
   }
 }
@@ -333,7 +351,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   @inlinable @inline(__always)
   public subscript(_ position: Int) -> Element {
     _read {
-      boundsCheckPrecondition(position)
+      assertValidity(position)
       yield self[unchecked: position]
     }
   }
@@ -365,7 +383,7 @@ extension Span where Element: BitwiseCopyable {
   @inlinable @inline(__always)
   public subscript(_ position: Int) -> Element {
     get {
-      boundsCheckPrecondition(position)
+      assertValidity(position)
       return self[unchecked: position]
     }
   }
@@ -404,7 +422,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Complexity: O(1)
   @inlinable @inline(__always)
   public func extracting(_ bounds: Range<Int>) -> Self {
-    boundsCheckPrecondition(bounds)
+    assertValidity(bounds)
     return extracting(uncheckedBounds: bounds)
   }
 

--- a/Sources/Future/Span.swift
+++ b/Sources/Future/Span.swift
@@ -503,6 +503,7 @@ extension Span where Element: ~Copyable  /*& ~Escapable*/ {
   ///   for the `withUnsafeBufferPointer(_:)` method. The closure's
   ///   parameter is valid only for the duration of its execution.
   /// - Returns: The return value of the `body` closure parameter.
+  @_alwaysEmitIntoClient
   public func withUnsafeBufferPointer<E: Error, Result: ~Copyable & ~Escapable>(
     _ body: (_ buffer: UnsafeBufferPointer<Element>) throws(E) -> Result
   ) throws(E) -> Result {
@@ -527,6 +528,7 @@ extension Span where Element: BitwiseCopyable {
   ///   The closure's parameter is valid only for the duration of
   ///   its execution.
   /// - Returns: The return value of the `body` closure parameter.
+  @_alwaysEmitIntoClient
   public func withUnsafeBytes<E: Error, Result: ~Copyable & ~Escapable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {

--- a/Sources/Future/Span.swift
+++ b/Sources/Future/Span.swift
@@ -43,7 +43,7 @@ extension UnsafePointer where Pointee: ~Copyable /*& ~Escapable*/ {
 
 extension Span where Element: ~Copyable /*& ~Escapable*/ {
 
-  //FIXME: make failable once Optional can be non-escapable
+  //FIXME: make properly non-failable
   /// Unsafely create a `Span` over initialized memory.
   ///
   /// The memory in `buffer` must be owned by the instance `owner`,
@@ -90,7 +90,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
 
 extension Span where Element: BitwiseCopyable {
 
-  //FIXME: make failable once Optional can be non-escapable
+  //FIXME: make properly non-failable
   /// Unsafely create a `Span` over initialized memory.
   ///
   /// The memory in `buffer` must be owned by the instance `owner`,
@@ -130,7 +130,7 @@ extension Span where Element: BitwiseCopyable {
     self.init(_unchecked: start, count: count, owner: owner)
   }
 
-  //FIXME: make failable once Optional can be non-escapable
+  //FIXME: make properly non-failable
   /// Unsafely create a `Span` over initialized memory.
   ///
   /// The memory in `unsafeBytes` must be owned by the instance `owner`
@@ -399,7 +399,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `Span`.
   ///
-  /// - Returns: A `Span` over the items at `bounds`
+  /// - Returns: A `Span` over the items within `bounds`
   ///
   /// - Complexity: O(1)
   @inlinable @inline(__always)
@@ -420,7 +420,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `Span`.
   ///
-  /// - Returns: A `Span` over the items at `bounds`
+  /// - Returns: A `Span` over the items within `bounds`
   ///
   /// - Complexity: O(1)
   @inlinable @inline(__always)
@@ -442,7 +442,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `Span`.
   ///
-  /// - Returns: A `Span` over the items at `bounds`
+  /// - Returns: A `Span` over the items within `bounds`
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -462,7 +462,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `Span`.
   ///
-  /// - Returns: A `Span` over the items at `bounds`
+  /// - Returns: A `Span` over the items within `bounds`
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient

--- a/Tests/FutureTests/RawSpanTests.swift
+++ b/Tests/FutureTests/RawSpanTests.swift
@@ -208,8 +208,8 @@ final class RawSpanTests: XCTestCase {
     let a = Array(0..<capacity)
     let span = RawSpan(a.storage)
     for o in span._byteOffsets {
-      span.boundsCheckPrecondition(o)
+      span.assertValidity(o)
     }
-    // span.boundsCheckPrecondition(span.count)
+    // span.assertValidity(span.count)
   }
 }


### PR DESCRIPTION
- Remove lifetime-dependency annotations when they are the inferred default.
- Various corrections in doc-comments
- Better name for bounds-checking functions, and adding non-failing counterparts.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
