### PR TITLE
Span: add utilities to test span containment relationships

### DIFF
--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -172,7 +172,7 @@ extension RawSpan {
   /// positions within this span.
   ///
   /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not generally share their indices with the
+  /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
@@ -191,7 +191,7 @@ extension RawSpan {
   /// positions within this span.
   ///
   /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not generally share their indices with the
+  /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
@@ -215,7 +215,7 @@ extension RawSpan {
   /// positions within this span.
   ///
   /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not generally share their indices with the
+  /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
@@ -233,7 +233,7 @@ extension RawSpan {
   /// positions within this span.
   ///
   /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not generally share their indices with the
+  /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
@@ -254,7 +254,7 @@ extension RawSpan {
   /// Constructs a new span over all the bytes of this span.
   ///
   /// The returned span's first byte is always at offset 0; unlike buffer
-  /// slices, extracted spans do not generally share their indices with the
+  /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// - Returns: A span over all the bytes of this span.

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -391,6 +391,23 @@ extension RawSpan {
   }
 }
 
+extension RawSpan {
+
+  @inlinable @inline(__always)
+  public func contains(_ span: borrowing Self) -> Bool {
+    _start <= span._start &&
+    span._start.advanced(by: span._count) <= _start.advanced(by: _count)
+  }
+
+  @inlinable @inline(__always)
+  public func offsets(of span: borrowing Self) -> Range<Int> {
+    precondition(contains(span))
+    let s = _start.distance(to: span._start)
+    let e = s + span._count
+    return Range(uncheckedBounds: (s, e))
+  }
+}
+
 //MARK: one-sided slicing operations
 extension RawSpan {
 

--- a/Sources/Future/Span.swift
+++ b/Sources/Future/Span.swift
@@ -579,6 +579,23 @@ extension Span where Element: Copyable {
   }
 }
 
+extension Span where Element: ~Copyable /*& ~Escapable*/ {
+
+  @inlinable @inline(__always)
+  public func contains(_ span: borrowing Self) -> Bool {
+    _start <= span._start &&
+    span._start.advanced(by: span._count) <= _start.advanced(by: _count)
+  }
+
+  @inlinable @inline(__always)
+  public func offsets(of span: borrowing Self) -> Range<Int> {
+    precondition(contains(span))
+    let s = _start.distance(to: span._start)
+    let e = s + span._count
+    return Range(uncheckedBounds: (s, e))
+  }
+}
+
 //MARK: one-sided slicing operations
 extension Span where Element: ~Copyable /*& ~Escapable*/ {
 

--- a/Sources/Future/Span.swift
+++ b/Sources/Future/Span.swift
@@ -411,7 +411,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not generally share their indices with the
+  /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
@@ -430,7 +430,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not generally share their indices with the
+  /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
@@ -454,7 +454,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not generally share their indices with the
+  /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// - Parameter bounds: A valid range of positions. Every position in
@@ -472,7 +472,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not generally share their indices with the
+  /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
@@ -493,7 +493,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// Constructs a new span over all the items of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
-  /// slices, extracted spans do not generally share their indices with the
+  /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
   /// - Returns: A `Span` over all the items of this span.

--- a/Tests/FutureTests/RawSpanTests.swift
+++ b/Tests/FutureTests/RawSpanTests.swift
@@ -212,4 +212,38 @@ final class RawSpanTests: XCTestCase {
     }
     // span.assertValidity(span.count)
   }
+
+  func testContainment() {
+    let b = UnsafeMutableRawBufferPointer.allocate(byteCount: 8, alignment: 8)
+    defer { b.deallocate() }
+
+    let span = RawSpan(unsafeBytes: .init(b), owner: b)
+    let subSpan = span.extracting(last: 2)
+    let emptySpan = span.extracting(first: 0)
+    let fakeSpan = RawSpan(
+      unsafeStart: b.baseAddress!.advanced(by: 8), byteCount: 8, owner: b
+    )
+
+    XCTAssertTrue(span.contains(subSpan))
+    XCTAssertFalse(subSpan.contains(span))
+    XCTAssertTrue(span.contains(emptySpan))
+    XCTAssertFalse(emptySpan.contains(span))
+    XCTAssertFalse(span.contains(fakeSpan))
+    XCTAssertFalse(fakeSpan.contains(span))
+  }
+
+  func testOffsets() {
+    let b = UnsafeMutableRawBufferPointer.allocate(byteCount: 8, alignment: 8)
+    defer { b.deallocate() }
+
+    let span = RawSpan(unsafeBytes: .init(b), owner: b)
+    let subSpan = span.extracting(last: 2)
+    let emptySpan = span.extracting(first: 0)
+
+    var bounds: Range<Int>
+    bounds = span.offsets(of: subSpan)
+    XCTAssertEqual(bounds, span._byteOffsets.suffix(2))
+    bounds = span.offsets(of: emptySpan)
+    XCTAssertEqual(bounds, span._byteOffsets.prefix(0))
+  }
 }


### PR DESCRIPTION
The function names are probably bad.
```swift
extension RawSpan {
  func contains(other span: borrowing Self) -> Bool
  func offsets(of span: borrowing Self) -> Range<Int> // traps if self.contains(span) is false
}
```

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
