### PR TITLE
[Future] Add Box and Cell

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,6 +56,7 @@ let _settings: [SwiftSetting] = defines.map { .define($0) } + [
   .enableExperimentalFeature("BuiltinModule"),
   .enableExperimentalFeature("NonescapableTypes"),
   .enableExperimentalFeature("BitwiseCopyable"),
+  .enableExperimentalFeature("RawLayout")
 //  .swiftLanguageVersion(.v5)
 ]
 

--- a/Sources/Future/Box.swift
+++ b/Sources/Future/Box.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@frozen
+public struct Box<T: ~Copyable>: ~Copyable {
+  @usableFromInline
+  let pointer: UnsafeMutablePointer<T>
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  public init(_ value: consuming T) {
+    pointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
+    pointer.initialize(to: value)
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  public init(_ fromInout: consuming Inout<T>) {
+    pointer = fromInout.pointer
+  }
+
+  @_alwaysEmitIntoClient
+  @inlinable
+  deinit {
+    pointer.deinitialize(count: 1)
+    pointer.deallocate()
+  }
+}
+
+extension Box where T: ~Copyable {
+  @_alwaysEmitIntoClient
+  @_transparent
+  public consuming func consume() -> T {
+    let result = pointer.move()
+    pointer.deallocate()
+    discard self
+    return result
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  public consuming func leak() -> dependsOn(immortal) Inout<T> {
+    Inout<T>(unsafeImmortalAddress: pointer)
+  }
+
+  @_alwaysEmitIntoClient
+  public subscript() -> T {
+    @_transparent
+    unsafeAddress {
+      UnsafePointer<T>(pointer)
+    }
+
+    @_transparent
+    nonmutating unsafeMutableAddress {
+      pointer
+    }
+  }
+}

--- a/Sources/Future/Box.swift
+++ b/Sources/Future/Box.swift
@@ -48,7 +48,9 @@ extension Box where T: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public consuming func leak() -> dependsOn(immortal) Inout<T> {
-    Inout<T>(unsafeImmortalAddress: pointer)
+    let result = Inout<T>(unsafeImmortalAddress: pointer)
+    discard self
+    return result
   }
 
   @_alwaysEmitIntoClient

--- a/Sources/Future/Box.swift
+++ b/Sources/Future/Box.swift
@@ -66,3 +66,11 @@ extension Box where T: ~Copyable {
     }
   }
 }
+
+extension Box where T: Copyable {
+  @_alwaysEmitIntoClient
+  @_transparent
+  public borrowing func copy() -> T {
+    pointer.pointee
+  }
+}

--- a/Sources/Future/CMakeLists.txt
+++ b/Sources/Future/CMakeLists.txt
@@ -8,10 +8,12 @@ See https://swift.org/LICENSE.txt for license information
 #]]
 
 add_library(Future
-  "Inout.swift"
-  "Span.swift"
-  "RawSpan.swift"
+  "Box.swift"
+  "Cell.swift"
   "ContiguousStorage.swift"
+  "Inout.swift"
+  "RawSpan.swift"
+  "Span.swift"
 )
 
 target_link_libraries(Future PRIVATE

--- a/Sources/Future/Cell.swift
+++ b/Sources/Future/Cell.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Builtin
+
+@frozen
+@_rawLayout(like: T, movesAsLike)
+public struct Cell<T: ~Copyable>: ~Copyable {
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var unsafeAddress: UnsafeMutablePointer<T> {
+    UnsafeMutablePointer<T>(Builtin.addressOfRawLayout(self))
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  public init(_ value: consuming T) {
+    unsafeAddress.initialize(to: value)
+  }
+}
+
+extension Cell where T: ~Copyable {
+  @_alwaysEmitIntoClient
+  @_transparent
+  public func asInout() -> Inout<T> {
+    Inout<T>(unsafeAddress: unsafeAddress, owner: self)
+  }
+
+  @_alwaysEmitIntoClient
+  public subscript() -> T {
+    @_transparent
+    unsafeAddress {
+      UnsafePointer<T>(unsafeAddress)
+    }
+
+    @_transparent
+    nonmutating unsafeMutableAddress {
+      unsafeAddress
+    }
+  }
+}
+
+extension Cell where T: Copyable {
+  @_alwaysEmitIntoClient
+  @_transparent
+  public borrowing func copy() -> T {
+    unsafeAddress.pointee
+  }
+}

--- a/Sources/Future/Cell.swift
+++ b/Sources/Future/Cell.swift
@@ -30,7 +30,7 @@ public struct Cell<T: ~Copyable>: ~Copyable {
 extension Cell where T: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
-  public func asInout() -> Inout<T> {
+  public borrowing func asInout() -> Inout<T> {
     Inout<T>(unsafeAddress: unsafeAddress, owner: self)
   }
 

--- a/Sources/Future/Cell.swift
+++ b/Sources/Future/Cell.swift
@@ -30,8 +30,8 @@ public struct Cell<T: ~Copyable>: ~Copyable {
 extension Cell where T: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
-  public borrowing func asInout() -> Inout<T> {
-    Inout<T>(unsafeAddress: unsafeAddress, owner: self)
+  public mutating func asInout() -> Inout<T> {
+    Inout<T>(unsafeAddress: unsafeAddress, owner: &self)
   }
 
   @_alwaysEmitIntoClient

--- a/Sources/Future/Inout.swift
+++ b/Sources/Future/Inout.swift
@@ -48,11 +48,26 @@ public struct Inout<T: ~Copyable>: ~Copyable, ~Escapable {
   ) {
     pointer = unsafeAddress
   }
+
+  /// Unsafely initializes an instance of 'Inout' using the given
+  /// 'unsafeImmortalAddress' as the mutable reference acting as though its
+  /// lifetime is immortal.
+  ///
+  /// - Parameter unsafeImmortalAddress: The address to use to mutably reference
+  ///                                    an immortal instance of type 'T'.
+  @_alwaysEmitIntoClient
+  @_transparent
+  public init(
+    unsafeImmortalAddress: UnsafeMutablePointer<T>
+  ) -> dependsOn(immortal) Self {
+    pointer = unsafeImmortalAddress
+  }
 }
 
 extension Inout where T: ~Copyable {
   /// Dereferences the mutable reference allowing for in-place reads and writes
   /// to the underlying instance.
+  @_alwaysEmitIntoClient
   public subscript() -> T {
     @_transparent
     unsafeAddress {

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -520,96 +520,96 @@ public struct OutOfBoundsError: Error {
   }
 }
 
-extension RawSpan {
-  /// Parse an instance of `T`, advancing `position`.
-  @inlinable
-  public func parse<T: BitwiseCopyable>(
-    _ position: inout Int, as t: T.Type = T.self
-  ) throws(OutOfBoundsError) -> T {
-    let length = MemoryLayout<T>.size
-    guard position >= 0 else {
-      throw OutOfBoundsError(expected: length, has: 0)
-    }
-    let end = position &+ length
-    guard end <= length else {
-      throw OutOfBoundsError(expected: length, has: byteCount&-position)
-    }
-    return unsafeLoadUnaligned(fromUncheckedByteOffset: position, as: T.self)
-  }
+// extension RawSpan {
+//   /// Parse an instance of `T`, advancing `position`.
+//   @inlinable
+//   public func parse<T: BitwiseCopyable>(
+//     _ position: inout Int, as t: T.Type = T.self
+//   ) throws(OutOfBoundsError) -> T {
+//     let length = MemoryLayout<T>.size
+//     guard position >= 0 else {
+//       throw OutOfBoundsError(expected: length, has: 0)
+//     }
+//     let end = position &+ length
+//     guard end <= length else {
+//       throw OutOfBoundsError(expected: length, has: byteCount&-position)
+//     }
+//     return unsafeLoadUnaligned(fromUncheckedByteOffset: position, as: T.self)
+//   }
 
-  /// Parse `numBytes` of data, advancing `position`.
-  @inlinable
-  public func parse(
-    _ position: inout Int, numBytes: some FixedWidthInteger
-  ) throws (OutOfBoundsError) -> Self {
-    let length = Int(numBytes)
-    guard position >= 0 else {
-      throw OutOfBoundsError(expected: length, has: 0)
-    }
-    let end = position &+ length
-    guard end <= length else {
-      throw OutOfBoundsError(expected: length, has: byteCount&-position)
-    }
-    return extracting(position..<end)
-  }
-}
+//   /// Parse `numBytes` of data, advancing `position`.
+//   @inlinable
+//   public func parse(
+//     _ position: inout Int, numBytes: some FixedWidthInteger
+//   ) throws (OutOfBoundsError) -> Self {
+//     let length = Int(numBytes)
+//     guard position >= 0 else {
+//       throw OutOfBoundsError(expected: length, has: 0)
+//     }
+//     let end = position &+ length
+//     guard end <= length else {
+//       throw OutOfBoundsError(expected: length, has: byteCount&-position)
+//     }
+//     return extracting(position..<end)
+//   }
+// }
 
-extension RawSpan {
-  @frozen
-  public struct Cursor: Copyable, ~Escapable {
-    public let base: RawSpan
+// extension RawSpan {
+//   @frozen
+//   public struct Cursor: Copyable, ~Escapable {
+//     public let base: RawSpan
 
-    /// The range within which we parse
-    public let parseRange: Range<Int>
+//     /// The range within which we parse
+//     public let parseRange: Range<Int>
 
-    /// The current parsing position
-    public var position: Int
+//     /// The current parsing position
+//     public var position: Int
 
-    @inlinable
-    public init(_ base: RawSpan, in range: Range<Int>) {
-      base.assertValidity(range)
-      position = 0
-      self.base = base
-      parseRange = range
-    }
+//     @inlinable
+//     public init(_ base: RawSpan, in range: Range<Int>) {
+//       base.assertValidity(range)
+//       position = 0
+//       self.base = base
+//       parseRange = range
+//     }
 
-    @inlinable
-    public init(_ base: RawSpan) {
-      position = 0
-      self.base = base
-      parseRange = base._byteOffsets
-    }
+//     @inlinable
+//     public init(_ base: RawSpan) {
+//       position = 0
+//       self.base = base
+//       parseRange = base._byteOffsets
+//     }
 
-    /// Parse an instance of `T` and advance
-    @inlinable
-    public mutating func parse<T: BitwiseCopyable>(
-      _ t: T.Type = T.self
-    ) throws(OutOfBoundsError) -> T {
-      try base.parse(&position, as: T.self)
-    }
+//     /// Parse an instance of `T` and advance
+//     @inlinable
+//     public mutating func parse<T: BitwiseCopyable>(
+//       _ t: T.Type = T.self
+//     ) throws(OutOfBoundsError) -> T {
+//       try base.parse(&position, as: T.self)
+//     }
 
-    /// Parse `numBytes`and advance
-    @inlinable
-    public mutating func parse(
-      numBytes: some FixedWidthInteger
-    ) throws (OutOfBoundsError) -> RawSpan {
-      try base.parse(&position, numBytes: numBytes)
-    }
+//     /// Parse `numBytes`and advance
+//     @inlinable
+//     public mutating func parse(
+//       numBytes: some FixedWidthInteger
+//     ) throws (OutOfBoundsError) -> RawSpan {
+//       try base.parse(&position, numBytes: numBytes)
+//     }
 
-    /// The bytes that we've parsed so far
-    @inlinable
-    public var parsedBytes: RawSpan { base.extracting(..<position) }
+//     /// The bytes that we've parsed so far
+//     @inlinable
+//     public var parsedBytes: RawSpan { base.extracting(..<position) }
 
-    /// The number of bytes left to parse
-    @inlinable
-    public var remainingBytes: Int { base.byteCount &- position }
-  }
+//     /// The number of bytes left to parse
+//     @inlinable
+//     public var remainingBytes: Int { base.byteCount &- position }
+//   }
 
-  @inlinable
-  public func makeCursor() -> Cursor { Cursor(self) }
+//   @inlinable
+//   public func makeCursor() -> Cursor { Cursor(self) }
 
-  @inlinable
-  public func makeCursor(in range: Range<Int>) -> Cursor {
-    Cursor(self, in: range)
-  }
-}
+//   @inlinable
+//   public func makeCursor(in range: Range<Int>) -> Cursor {
+//     Cursor(self, in: range)
+//   }
+// }

--- a/Tests/FutureTests/BoxTests.swift
+++ b/Tests/FutureTests/BoxTests.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Future
+
+final class FutureBoxTests: XCTestCase {
+  func test_basic() {
+    let intOnHeap = Box<Int>(0)
+
+    XCTAssertEqual(intOnHeap[], 0)
+
+    intOnHeap[] = 123
+
+    XCTAssertEqual(intOnHeap[], 123)
+
+    let inoutToIntOnHeap = intOnHeap.leak()
+
+    XCTAssertEqual(inoutToIntOnHeap[], 123)
+
+    inoutToIntOnHeap[] = 321
+
+    XCTAssertEqual(inoutToIntOnHeap[], 321)
+
+    let intOnHeapAgain = Box<Int>(inoutToIntOnHeap)
+
+    XCTAssertEqual(intOnHeapAgain[], 321)
+
+    XCTAssertEqual(intOnHeapAgain.copy(), 321)
+
+    let intInRegister = intOnHeapAgain.consume()
+
+    XCTAssertEqual(intInRegister, 321)
+  }
+}

--- a/Tests/FutureTests/CellTests.swift
+++ b/Tests/FutureTests/CellTests.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Future
+
+final class FutureCellTests: XCTestCase {
+  struct IntOnStack: ~Copyable {
+    var value = Cell<Int>(0)
+  }
+
+  func test_basic() {
+    var myInt = IntOnStack()
+
+    XCTAssertEqual(myInt.value[], 0)
+
+    myInt.value[] = 123
+
+    XCTAssertEqual(myInt.value[], 123)
+
+    let inoutToIntOnStack = myInt.value.asInout()
+
+    inoutToIntOnStack[] = 321
+
+    XCTAssertEqual(myInt.value[], 321)
+
+    XCTAssertEqual(myInt.value.copy(), 321)
+  }
+}


### PR DESCRIPTION
This adds a `Box` type who is a noncopyable type that provides a safe abstraction for owning a heap allocated value as well as a `Cell` type who is a noncopyable type that provides an inline value with interior mutability and addressability.

Note: None of this builds right now as we're lacking a recent toolchain and most likely missing `dependsOn(immortal)`