### PR TITLE
Better document the unsafe operations of RawSpan

### DIFF
--- a/Tests/FutureTests/RawSpanTests.swift
+++ b/Tests/FutureTests/RawSpanTests.swift
@@ -71,11 +71,11 @@ final class RawSpanTests: XCTestCase {
       let span = RawSpan(unsafeBytes: $0, owner: $0)
       let stride = MemoryLayout<String>.stride
 
-      let s0 = span.load(as: String.self)
+      let s0 = span.unsafeLoad(as: String.self)
       XCTAssertEqual(s0.contains("0"), true)
-      let s1 = span.load(fromByteOffset: stride, as: String.self)
+      let s1 = span.unsafeLoad(fromByteOffset: stride, as: String.self)
       XCTAssertEqual(s1.contains("1"), true)
-      let s2 = span.load(fromUncheckedByteOffset: 2*stride, as: String.self)
+      let s2 = span.unsafeLoad(fromUncheckedByteOffset: 2*stride, as: String.self)
       XCTAssertEqual(s2.contains("2"), true)
     }
   }
@@ -86,12 +86,12 @@ final class RawSpanTests: XCTestCase {
     a.withUnsafeBytes {
       let span = RawSpan(unsafeBytes: $0, owner: $0)
 
-      let u0 = span.extracting(droppingFirst: 2).loadUnaligned(as: UInt64.self)
+      let u0 = span.extracting(droppingFirst: 2).unsafeLoadUnaligned(as: UInt64.self)
       XCTAssertEqual(u0 & 0xff, 2)
       XCTAssertEqual(u0.byteSwapped & 0xff, 9)
-      let u1 = span.loadUnaligned(fromByteOffset: 6, as: UInt64.self)
+      let u1 = span.unsafeLoadUnaligned(fromByteOffset: 6, as: UInt64.self)
       XCTAssertEqual(u1 & 0xff, 6)
-      let u3 = span.loadUnaligned(fromUncheckedByteOffset: 7, as: UInt32.self)
+      let u3 = span.unsafeLoadUnaligned(fromUncheckedByteOffset: 7, as: UInt32.self)
       XCTAssertEqual(u3 & 0xff, 7)
     }
   }
@@ -106,13 +106,13 @@ final class RawSpanTests: XCTestCase {
       let sub3 = span.extracting(...)
       let sub4 = span.extracting(uncheckedBounds: 2...)
       XCTAssertTrue(
-        sub1.view(as: UInt8.self)._elementsEqual(sub2.view(as: UInt8.self))
+        sub1.unsafeView(as: UInt8.self)._elementsEqual(sub2.unsafeView(as: UInt8.self))
       )
       XCTAssertTrue(
-        sub3.view(as: Int8.self)._elementsEqual(span.view(as: Int8.self))
+        sub3.unsafeView(as: Int8.self)._elementsEqual(span.unsafeView(as: Int8.self))
       )
       XCTAssertFalse(
-        sub4.view(as: Int8.self)._elementsEqual(sub3.view(as: Int8.self))
+        sub4.unsafeView(as: Int8.self)._elementsEqual(sub3.unsafeView(as: Int8.self))
       )
     }
   }
@@ -125,7 +125,7 @@ final class RawSpanTests: XCTestCase {
       let prefix = span.extracting(0..<8)
       let beyond = prefix.extracting(uncheckedBounds: 16..<24)
       XCTAssertEqual(beyond.byteCount, 8)
-      XCTAssertEqual(beyond.load(as: UInt8.self), 16)
+      XCTAssertEqual(beyond.unsafeLoad(as: UInt8.self), 16)
     }
   }
 
@@ -172,16 +172,16 @@ final class RawSpanTests: XCTestCase {
     a.withUnsafeBytes {
       let span = RawSpan(unsafeBytes: $0, owner: $0)
       XCTAssertEqual(span.byteCount, capacity)
-      XCTAssertEqual(span.extracting(first: 1).load(as: UInt8.self), 0)
+      XCTAssertEqual(span.extracting(first: 1).unsafeLoad(as: UInt8.self), 0)
       XCTAssertEqual(
-        span.extracting(first: capacity).load(
+        span.extracting(first: capacity).unsafeLoad(
           fromByteOffset: capacity-1, as: UInt8.self
         ),
         UInt8(capacity-1)
       )
       XCTAssertTrue(span.extracting(droppingLast: capacity).isEmpty)
       XCTAssertEqual(
-        span.extracting(droppingLast: 1).load(
+        span.extracting(droppingLast: 1).unsafeLoad(
           fromByteOffset: capacity-2, as: UInt8.self
         ),
         UInt8(capacity-2)
@@ -195,11 +195,11 @@ final class RawSpanTests: XCTestCase {
     a.withUnsafeBytes {
       let span = RawSpan(unsafeBytes: $0, owner: $0)
       XCTAssertEqual(span.byteCount, capacity)
-      XCTAssertEqual(span.extracting(last: capacity).load(as: UInt8.self), 0)
-      XCTAssertEqual(span.extracting(last: capacity-1).load(as: UInt8.self), 1)
-      XCTAssertEqual(span.extracting(last: 1).load(as: UInt8.self), UInt8(capacity-1))
+      XCTAssertEqual(span.extracting(last: capacity).unsafeLoad(as: UInt8.self), 0)
+      XCTAssertEqual(span.extracting(last: capacity-1).unsafeLoad(as: UInt8.self), 1)
+      XCTAssertEqual(span.extracting(last: 1).unsafeLoad(as: UInt8.self), UInt8(capacity-1))
       XCTAssertTrue(span.extracting(droppingFirst: capacity).isEmpty)
-      XCTAssertEqual(span.extracting(droppingFirst: 1).load(as: UInt8.self), 1)
+      XCTAssertEqual(span.extracting(droppingFirst: 1).unsafeLoad(as: UInt8.self), 1)
     }
   }
 


### PR DESCRIPTION
Rename the `load`, `loadUnaligned`, and `view(as:)` functions, and improve their documentation.