### PR TITLE
doc-comment improvements, argument label fix

### DIFF
--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -64,7 +64,7 @@ extension RawSpan {
   ///
   /// - Parameters:
   ///   - pointer: a pointer to the first initialized element.
-  ///   - count: the number of initialized elements in the view.
+  ///   - byteCount: the number of initialized bytes in the span.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `RawSpan`.
   @inlinable @inline(__always)

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -442,6 +442,10 @@ extension RawSpan {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
   ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A span with at most `maxLength` bytes.
@@ -457,6 +461,10 @@ extension RawSpan {
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
   ///
   /// - Parameter k: The number of bytes to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
@@ -475,6 +483,10 @@ extension RawSpan {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
   ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
   /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A span with at most `maxLength` bytes.
@@ -491,6 +503,10 @@ extension RawSpan {
   ///
   /// If the number of elements to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
+  ///
+  /// The returned span's first byte is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
   ///
   /// - Parameter k: The number of bytes to drop from the beginning of
   ///   the span. `k` must be greater than or equal to zero.

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -63,7 +63,7 @@ extension RawSpan {
   /// meaning that as long as `owner` is alive the memory will remain valid.
   ///
   /// - Parameters:
-  ///   - pointer: a pointer to the first initialized element.
+  ///   - pointer: a pointer to the first initialized byte.
   ///   - byteCount: the number of initialized bytes in the span.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `RawSpan`.
@@ -302,7 +302,7 @@ extension RawSpan {
   /// to instances of `T` must be surjective.
   ///
   /// This is an unsafe operation. Failure to meet the preconditions
-  /// above may produce an invalid value of `T`.
+  /// above may produce invalid values of `T`.
   ///
   /// - Parameters:
   ///   - type: The type as which to view the bytes of this span.

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -184,7 +184,7 @@ extension RawSpan {
   @inlinable @inline(__always)
   public func extracting(_ bounds: Range<Int>) -> Self {
     assertValidity(bounds)
-    return extracting(uncheckedBounds: bounds)
+    return extracting(unchecked: bounds)
   }
 
   /// Constructs a new span over the bytes within the supplied range of
@@ -203,7 +203,7 @@ extension RawSpan {
   ///
   /// - Complexity: O(1)
   @inlinable @inline(__always)
-  public func extracting(uncheckedBounds bounds: Range<Int>) -> Self {
+  public func extracting(unchecked bounds: Range<Int>) -> Self {
     RawSpan(
       _unchecked: _start.advanced(by: bounds.lowerBound),
       byteCount: bounds.count,
@@ -246,9 +246,9 @@ extension RawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public func extracting(
-    uncheckedBounds bounds: some RangeExpression<Int>
+    unchecked bounds: some RangeExpression<Int>
   ) -> Self {
-    extracting(uncheckedBounds: bounds.relative(to: _byteOffsets))
+    extracting(unchecked: bounds.relative(to: _byteOffsets))
   }
 
   /// Constructs a new span over all the bytes of this span.

--- a/Sources/Future/Span.swift
+++ b/Sources/Future/Span.swift
@@ -71,7 +71,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   ///
   /// - Parameters:
   ///   - pointer: a pointer to the first initialized element.
-  ///   - count: the number of initialized elements in the view.
+  ///   - count: the number of initialized elements in the span.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `Span`.
   public init<Owner: ~Copyable & ~Escapable>(
@@ -118,7 +118,7 @@ extension Span where Element: BitwiseCopyable {
   ///
   /// - Parameters:
   ///   - pointer: a pointer to the first initialized element.
-  ///   - count: the number of initialized elements in the view.
+  ///   - count: the number of initialized elements in the span.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `Span`.
   public init<Owner: ~Copyable & ~Escapable>(
@@ -170,7 +170,7 @@ extension Span where Element: BitwiseCopyable {
   ///
   /// - Parameters:
   ///   - pointer: a pointer to the first initialized element.
-  ///   - count: the number of initialized elements in the view.
+  ///   - count: the number of initialized elements in the span.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `Span`.
   public init<Owner: ~Copyable & ~Escapable>(

--- a/Sources/Future/Span.swift
+++ b/Sources/Future/Span.swift
@@ -423,7 +423,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   @inlinable @inline(__always)
   public func extracting(_ bounds: Range<Int>) -> Self {
     assertValidity(bounds)
-    return extracting(uncheckedBounds: bounds)
+    return extracting(unchecked: bounds)
   }
 
   /// Constructs a new span over the items within the supplied range of
@@ -442,7 +442,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   ///
   /// - Complexity: O(1)
   @inlinable @inline(__always)
-  public func extracting(uncheckedBounds bounds: Range<Int>) -> Self {
+  public func extracting(unchecked bounds: Range<Int>) -> Self {
     Span(
       _unchecked: _start.advanced(by: bounds.lowerBound),
       count: bounds.count,
@@ -487,7 +487,7 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   public func extracting(
     uncheckedBounds bounds: some RangeExpression<Int>
   ) -> Self {
-    extracting(uncheckedBounds: bounds.relative(to: _indices))
+    extracting(unchecked: bounds.relative(to: _indices))
   }
 
   /// Constructs a new span over all the items of this span.

--- a/Sources/Future/Span.swift
+++ b/Sources/Future/Span.swift
@@ -605,6 +605,10 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
   ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A span with at most `maxLength` elements.
@@ -620,6 +624,10 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
   ///
   /// - Parameter k: The number of elements to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
@@ -638,6 +646,10 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
   ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
   /// - Parameter maxLength: The maximum number of elements to return.
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A span with at most `maxLength` elements.
@@ -654,6 +666,10 @@ extension Span where Element: ~Copyable /*& ~Escapable*/ {
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
   ///
   /// - Parameter k: The number of elements to drop from the beginning of
   ///   the span. `k` must be greater than or equal to zero.

--- a/Tests/FutureTests/RawSpanTests.swift
+++ b/Tests/FutureTests/RawSpanTests.swift
@@ -104,7 +104,7 @@ final class RawSpanTests: XCTestCase {
       let sub1 = span.extracting(0..<2)
       let sub2 = span.extracting(..<2)
       let sub3 = span.extracting(...)
-      let sub4 = span.extracting(uncheckedBounds: 2...)
+      let sub4 = span.extracting(unchecked: 2...)
       XCTAssertTrue(
         sub1.unsafeView(as: UInt8.self)._elementsEqual(sub2.unsafeView(as: UInt8.self))
       )
@@ -123,7 +123,7 @@ final class RawSpanTests: XCTestCase {
     b.withUnsafeBytes {
       let span = RawSpan(unsafeBytes: $0, owner: $0)
       let prefix = span.extracting(0..<8)
-      let beyond = prefix.extracting(uncheckedBounds: 16..<24)
+      let beyond = prefix.extracting(unchecked: 16..<24)
       XCTAssertEqual(beyond.byteCount, 8)
       XCTAssertEqual(beyond.unsafeLoad(as: UInt8.self), 16)
     }


### PR DESCRIPTION
Mostly improvements to doc-comments.
The `uncheckedBounds` argument label for overloads of `extracting()` is changed to simply `unchecked`.
(`uncheckedBounds` is the label for a `Range` initializer, but it doesn't work as well here.)
