### PR TITLE
Changed 'count == 0' to 'isEmpty' and add 'final' keyword to class

### DIFF
--- a/Sources/DequeModule/Deque._UnsafeHandle.swift
+++ b/Sources/DequeModule/Deque._UnsafeHandle.swift
@@ -188,8 +188,8 @@ extension Deque._UnsafeHandle {
     assert(offsets.lowerBound >= 0 && offsets.upperBound <= count)
     let lower = slot(forOffset: offsets.lowerBound)
     let upper = slot(forOffset: offsets.upperBound)
-    if offsets.count == 0 || lower < upper {
-      return .init(start: ptr(at: lower), count: offsets.count)
+    if offsets.isEmpty || lower < upper {
+    return .init(start: ptr(at: lower), count: offsets.count)
     }
     return .init(first: ptr(at: lower), count: capacity - lower.position,
                  second: ptr(at: .zero), count: upper.position)

--- a/Sources/DequeModule/_DequeBuffer.swift
+++ b/Sources/DequeModule/_DequeBuffer.swift
@@ -11,7 +11,7 @@
 
 @_fixed_layout
 @usableFromInline
-internal class _DequeBuffer<Element>: ManagedBuffer<_DequeBufferHeader, Element> {
+internal final class _DequeBuffer<Element>: ManagedBuffer<_DequeBufferHeader, Element> {
   @inlinable
   deinit {
     self.withUnsafeMutablePointers { header, elements in

--- a/Sources/HashTreeCollections/HashNode/_HashNode+Initializers.swift
+++ b/Sources/HashTreeCollections/HashNode/_HashNode+Initializers.swift
@@ -57,7 +57,7 @@ extension _HashNode {
       childMap: .empty,
       count: 1
     ) { children, items in
-      assert(items.count == 1 && children.count == 0)
+      assert(items.count == 1 && children.isEmpty)
       items.initializeElement(at: 0, to: item)
     }
     r.node._invariantCheck()
@@ -89,7 +89,7 @@ extension _HashNode {
       childMap: .empty,
       count: 2
     ) { children, items -> (_HashSlot, _HashSlot) in
-      assert(items.count == 2 && children.count == 0)
+      assert(items.count == 2 && children.isEmpty)
       let i1 = bucket1 < bucket2 ? 1 : 0
       let i2 = 1 &- i1
       items.initializeElement(at: i1, to: item1)
@@ -110,7 +110,7 @@ extension _HashNode {
       childMap: _Bitmap(bucket),
       count: child.count
     ) { children, items in
-      assert(items.count == 0 && children.count == 1)
+      assert(items.isEmpty && children.count == 1)
       children.initializeElement(at: 0, to: child)
     }
     r.node._invariantCheck()
@@ -163,7 +163,7 @@ extension _HashNode {
       childMap: _Bitmap(child1Bucket, child2Bucket),
       count: child1.count &+ child2.count
     ) { children, items in
-      assert(items.count == 0 && children.count == 2)
+      assert(items.isEmpty && children.count == 2)
       children.initializeElement(at: 0, to: child1)
       children.initializeElement(at: 1, to: child2)
     }

--- a/Tests/CollectionsTestSupportTests/CombinatoricsChecks.swift
+++ b/Tests/CollectionsTestSupportTests/CombinatoricsChecks.swift
@@ -14,7 +14,7 @@ import XCTest
 import _CollectionsTestSupport
 #endif
 
-class CombinatoricsTests: CollectionTestCase {
+final class CombinatoricsTests: CollectionTestCase {
   func testEverySubset_smoke() {
     func collectSubsets(of set: [Int]) -> Set<[Int]> {
       var result: Set<[Int]> = []

--- a/Tests/HashTreeCollectionsTests/TreeDictionary Tests.swift
+++ b/Tests/HashTreeCollectionsTests/TreeDictionary Tests.swift
@@ -18,7 +18,7 @@ import HashTreeCollections
 
 extension TreeDictionary: DictionaryAPIExtras {}
 
-class TreeDictionaryTests: CollectionTestCase {
+final class TreeDictionaryTests: CollectionTestCase {
   func test_empty() {
     let d = TreeDictionary<String, Int>()
     expectEqualElements(d, [])

--- a/Tests/HashTreeCollectionsTests/TreeDictionary.Keys Tests.swift
+++ b/Tests/HashTreeCollectionsTests/TreeDictionary.Keys Tests.swift
@@ -17,7 +17,7 @@ import _CollectionsTestSupport
 import HashTreeCollections
 #endif
 
-class TreeDictionaryKeysTests: CollectionTestCase {
+final class TreeDictionaryKeysTests: CollectionTestCase {
   func test_BidirectionalCollection_fixtures() {
     withEachFixture { fixture in
       withLifetimeTracking { tracker in

--- a/Tests/HashTreeCollectionsTests/TreeDictionary.Values Tests.swift
+++ b/Tests/HashTreeCollectionsTests/TreeDictionary.Values Tests.swift
@@ -17,7 +17,7 @@ import _CollectionsTestSupport
 import HashTreeCollections
 #endif
 
-class TreeDictionaryValuesTests: CollectionTestCase {
+final class TreeDictionaryValuesTests: CollectionTestCase {
   func test_BidirectionalCollection_fixtures() {
     withEachFixture { fixture in
       withLifetimeTracking { tracker in

--- a/Tests/HashTreeCollectionsTests/TreeSet Tests.swift
+++ b/Tests/HashTreeCollectionsTests/TreeSet Tests.swift
@@ -18,7 +18,7 @@ import HashTreeCollections
 
 extension TreeSet: SetAPIExtras {}
 
-class TreeSetTests: CollectionTestCase {
+final class TreeSetTests: CollectionTestCase {
   func test_init_empty() {
     let set = TreeSet<Int>()
     expectEqual(set.count, 0)

--- a/Tests/HeapTests/HeapNodeTests.swift
+++ b/Tests/HeapTests/HeapNodeTests.swift
@@ -17,7 +17,7 @@ import XCTest
 @testable import HeapModule
 #endif
 
-class HeapNodeTests: XCTestCase {
+final class HeapNodeTests: XCTestCase {
   func test_levelCalculation() {
     // Check alternating min and max levels in the heap
     var isMin = true

--- a/Tests/OrderedCollectionsTests/HashTable/HashTableTests.swift
+++ b/Tests/OrderedCollectionsTests/HashTable/HashTableTests.swift
@@ -20,7 +20,7 @@ import _CollectionsTestSupport
 @_spi(Testing) @testable import OrderedCollections
 #endif
 
-class HashTableTests: CollectionTestCase {
+final class HashTableTests: CollectionTestCase {
   typealias Bucket = _HashTable.Bucket
 
   func test_capacity() {

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
@@ -19,7 +19,7 @@ import _CollectionsTestSupport
 
 extension OrderedDictionary: DictionaryAPIExtras {}
 
-class OrderedDictionaryTests: CollectionTestCase {
+final class OrderedDictionaryTests: CollectionTestCase {
   func test_empty() {
     let d = OrderedDictionary<String, Int>()
     expectEqualElements(d, [])

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Elements Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Elements Tests.swift
@@ -17,7 +17,7 @@ import XCTest
 import _CollectionsTestSupport
 #endif
 
-class OrderedDictionaryElementsTests: CollectionTestCase {
+final class OrderedDictionaryElementsTests: CollectionTestCase {
   func test_elements_getter() {
     withEvery("count", in: 0 ..< 30) { count in
       withLifetimeTracking { tracker in

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Values Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Values Tests.swift
@@ -17,7 +17,7 @@ import Collections
 import _CollectionsTestSupport
 #endif
 
-class OrderedDictionaryValueTests: CollectionTestCase {
+final class OrderedDictionaryValueTests: CollectionTestCase {
   func test_values_getter_equal() {
     let left: OrderedDictionary = [
       "one": 1,

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSet Diffing Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSet Diffing Tests.swift
@@ -17,7 +17,7 @@ import OrderedCollections
 import _CollectionsTestSupport
 #endif
 
-class MeasuringHashable: Hashable {
+final class MeasuringHashable: Hashable {
   static var equalityChecks = 0
   static func == (lhs: MeasuringHashable, rhs: MeasuringHashable) -> Bool {
     MeasuringHashable.equalityChecks += 1
@@ -38,7 +38,7 @@ class MeasuringHashable: Hashable {
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-class OrderedSetDiffingTests: CollectionTestCase {
+final class OrderedSetDiffingTests: CollectionTestCase {
 
   func _validatePerformance<T: Hashable>(from a: OrderedSet<T>, to b: OrderedSet<T>) {
     MeasuringHashable.equalityChecks = 0

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSet.UnorderedView Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSet.UnorderedView Tests.swift
@@ -20,7 +20,7 @@ import _CollectionsTestSupport
 // Note: This cannot really work unless `UnorderedView` becomes a Collection.
 // extension OrderedSet.UnorderedView: SetAPIChecker {}
 
-class OrderedSetUnorderedViewTests: CollectionTestCase {
+final class OrderedSetUnorderedViewTests: CollectionTestCase {
   func test_unordered_insert() {
     withEvery("count", in: 0 ..< 20) { count in
       withEvery("dupes", in: 1 ... 3) { dupes in

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -19,7 +19,7 @@ import _CollectionsTestSupport
 
 extension OrderedSet: SetAPIExtras {}
 
-class OrderedSetTests: CollectionTestCase {
+final class OrderedSetTests: CollectionTestCase {
   func test_init_uncheckedUniqueElements_concrete() {
     withEvery("count", in: 0 ..< 20) { count in
       let contents = Array(0 ..< count)

--- a/Tests/RopeModuleTests/TestBigString.swift
+++ b/Tests/RopeModuleTests/TestBigString.swift
@@ -19,7 +19,7 @@ import _RopeModule
 #endif
 
 @available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *)
-class TestBigString: CollectionTestCase {
+final class TestBigString: CollectionTestCase {
   override var isAvailable: Bool { isRunningOnSwiftStdlib5_8 }
 
   override class func setUp() {

--- a/Tests/RopeModuleTests/TestRope.swift
+++ b/Tests/RopeModuleTests/TestRope.swift
@@ -114,7 +114,7 @@ struct Chunk: RopeElement, Equatable, CustomStringConvertible {
   }
 }
 
-class TestRope: CollectionTestCase {
+final class TestRope: CollectionTestCase {
   override func setUp() {
     super.setUp()
     print("Global seed: \(RepeatableRandomNumberGenerator.globalSeed)")

--- a/Tests/_CollectionsTestSupport/MinimalTypes/MinimalDecoder.swift
+++ b/Tests/_CollectionsTestSupport/MinimalTypes/MinimalDecoder.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public class MinimalDecoder {
+public final class MinimalDecoder {
   public typealias Value = MinimalEncoder.Value
   typealias _Key = MinimalEncoder._Key
 
@@ -356,7 +356,7 @@ extension MinimalDecoder.KeyedContainer: KeyedDecodingContainerProtocol {
 }
 
 extension MinimalDecoder {
-  class UnkeyedContainer {
+  final class UnkeyedContainer {
     typealias Value = MinimalEncoder.Value
 
     unowned let base: MinimalDecoder
@@ -598,7 +598,7 @@ extension MinimalDecoder.UnkeyedContainer: UnkeyedDecodingContainer {
 }
 
 extension MinimalDecoder {
-  class SingleValueContainer {
+  final class SingleValueContainer {
     typealias Value = MinimalEncoder.Value
 
     unowned let base: MinimalDecoder

--- a/Tests/_CollectionsTestSupport/MinimalTypes/MinimalEncoder.swift
+++ b/Tests/_CollectionsTestSupport/MinimalTypes/MinimalEncoder.swift
@@ -104,7 +104,7 @@ extension MinimalEncoder.Value: CustomStringConvertible {
     case .double(let v): return ".double(\(v))"
     case .string(let v): return ".string(\(String(reflecting: v)))"
     case .array(let value):
-      if value.count == 0 { return ".array([])" }
+      if value.isEmpty { return ".array([])" }
       var result = ".array([\n"
       for v in value {
         result += prefix
@@ -115,7 +115,7 @@ extension MinimalEncoder.Value: CustomStringConvertible {
       result += prefix + "])"
       return result
     case .dictionary(let value):
-      if value.count == 0 { return ".dictionary([:])" }
+      if value.isEmpty { return ".dictionary([:])" }
       var result = ".dictionary([\n"
       for (k, v) in value.sorted(by: { $0.key < $1.key }) {
         result += prefix

--- a/Tests/_CollectionsTestSupport/MinimalTypes/MinimalIterator.swift
+++ b/Tests/_CollectionsTestSupport/MinimalTypes/MinimalIterator.swift
@@ -13,7 +13,7 @@
 // Loosely adapted from https://github.com/apple/swift/tree/main/stdlib/private/StdlibCollectionUnittest
 
 /// State shared by all iterators of a MinimalSequence instance.
-internal class _MinimalIteratorSharedState<Element> {
+internal final class _MinimalIteratorSharedState<Element> {
   internal init(_ data: [Element]) {
     self.data = data
   }

--- a/Tests/_CollectionsTestSupport/MinimalTypes/ResettableValue.swift
+++ b/Tests/_CollectionsTestSupport/MinimalTypes/ResettableValue.swift
@@ -12,7 +12,7 @@
 
 // Loosely adapted from https://github.com/apple/swift/tree/main/stdlib/private/StdlibUnittest
 
-public class ResettableValue<Value> {
+public final class ResettableValue<Value> {
   public init(_ value: Value) {
     self.defaultValue = value
     self.value = value

--- a/Tests/_CollectionsTestSupport/Utilities/LifetimeTracked.swift
+++ b/Tests/_CollectionsTestSupport/Utilities/LifetimeTracked.swift
@@ -26,7 +26,7 @@
 ///          }
 ///        }
 ///      }
-public class LifetimeTracked<Payload> {
+public final class LifetimeTracked<Payload> {
   public let tracker: LifetimeTracker
   internal var serialNumber: Int = 0
   public let payload: Payload

--- a/Tests/_CollectionsTestSupport/Utilities/LifetimeTracker.swift
+++ b/Tests/_CollectionsTestSupport/Utilities/LifetimeTracker.swift
@@ -17,7 +17,7 @@
 ///     instantiate or deinitialize instances belonging to the same tracker
 ///     from multiple concurrent threads (or reentrantly) will lead to
 ///     exclusivity violations and therefore undefined behavior.
-public class LifetimeTracker {
+public final class LifetimeTracker {
   public internal(set) var instances = 0
   var _nextSerialNumber = 0
 


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Collections!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Hello, when checking whether the value of Collection Types is empty, how about using 'isEmpty' instead of 'count == 0' considering time complexity and readability?
And How about adding the final keyword to classes that do not inherit?

Thanks for reading.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
