### PR TITLE
add 'final' keyword to class

### DIFF
--- a/Sources/DequeModule/_DequeBuffer.swift
+++ b/Sources/DequeModule/_DequeBuffer.swift
@@ -11,7 +11,7 @@
 
 @_fixed_layout
 @usableFromInline
-internal class _DequeBuffer<Element>: ManagedBuffer<_DequeBufferHeader, Element> {
+internal final class _DequeBuffer<Element>: ManagedBuffer<_DequeBufferHeader, Element> {
   @inlinable
   deinit {
     self.withUnsafeMutablePointers { header, elements in


### PR DESCRIPTION
Hello, How about adding the final keyword to classes that do not inherit?

Thanks for reading.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
