### PR TITLE
Optimize unspecialized `OrderedSet.init` and `OrderedSet.firstIndex(of:)`

### DIFF
--- a/Sources/OrderedCollections/HashTable/_HashTable+UnsafeHandle.swift
+++ b/Sources/OrderedCollections/HashTable/_HashTable+UnsafeHandle.swift
@@ -292,11 +292,21 @@ extension _HashTable.UnsafeHandle {
 
 extension _UnsafeHashTable {
   @inlinable
-  internal func _find<Base: RandomAccessCollection>(
-    _ item: Base.Element,
-    in elements: Base
+  internal func _find<Element>(
+    _ item: Element,
+    in elements: ContiguousArray<Element>
   ) -> (index: Int?, bucket: Bucket)
-  where Base.Element: Hashable {
+  where Element: Hashable {
+    elements.withUnsafeBufferPointer { buffer in
+      _find(item, in: buffer)
+    }
+  }
+  @inlinable
+  internal func _find<Element>(
+    _ item: Element,
+    in elements: UnsafeBufferPointer<Element>
+  ) -> (index: Int?, bucket: Bucket)
+  where Element: Hashable {
     let start = idealBucket(for: item)
     var (iterator, value) = startFind(start)
     while let index = value {
@@ -502,6 +512,24 @@ extension _UnsafeHashTable {
   ) where C.Element: Hashable {
     assertMutable()
     assert(elements.count <= capacity)
+    // fast path that doesn't allocate per element if _read accessor can't
+    // be inlined because this function doesn't get specialized e.g.
+    // if `Element` isn't known at compile time.
+    let fastPath: Void? = elements.withContiguousStorageIfAvailable { elements in
+      // Iterate over elements and insert their offset into the hash table.
+      var offset = 0
+      for index in elements.indices {
+        // Find the insertion position. We know that we're inserting a new item,
+        // so there is no need to compare it with any of the existing ones.
+        var it = bucketIterator(for: elements[index])
+        it.advanceToNextUnoccupiedBucket()
+        it.currentValue = offset
+        offset += 1
+      }
+    }
+    if fastPath != nil {
+      return
+    }
     // Iterate over elements and insert their offset into the hash table.
     var offset = 0
     for index in elements.indices {
@@ -527,6 +555,30 @@ extension _UnsafeHashTable {
     assertMutable()
     assert(elements.count <= capacity)
     // Iterate over elements and insert their offset into the hash table.
+    
+    // fast path that doesn't allocate per element if _read accessor can't
+    // be inlined because this function doesn't get specialized e.g.
+    // if `Element` isn't known at compile time.
+    let fastPath: (success: Bool, end: Int)? = elements.withContiguousStorageIfAvailable { elements in
+      var offset = 0
+      for index in elements.indices {
+        // Find the insertion position. We know that we're inserting a new item,
+        // so there is no need to compare it with any of the existing ones.
+        var it = bucketIterator(for: elements[index])
+        while let offset = it.currentValue {
+          guard elements[_offset: offset] != elements[index] else {
+            return (false, index)
+          }
+          it.advance()
+        }
+        it.currentValue = offset
+        offset += 1
+      }
+      return (true, elements.endIndex)
+    }
+    if let fastPath {
+      return (fastPath.success, elements.index(elements.startIndex, offsetBy: fastPath.end))
+    }
     var offset = 0
     for index in elements.indices {
       // Find the insertion position. We know that we're inserting a new item,

--- a/Sources/OrderedCollections/HashTable/_HashTable+UnsafeHandle.swift
+++ b/Sources/OrderedCollections/HashTable/_HashTable+UnsafeHandle.swift
@@ -292,21 +292,20 @@ extension _HashTable.UnsafeHandle {
 
 extension _UnsafeHashTable {
   @inlinable
-  internal func _find<Element>(
+  internal func _find<Element: Hashable>(
     _ item: Element,
     in elements: ContiguousArray<Element>
-  ) -> (index: Int?, bucket: Bucket)
-  where Element: Hashable {
+  ) -> (index: Int?, bucket: Bucket) {
     elements.withUnsafeBufferPointer { buffer in
       _find(item, in: buffer)
     }
   }
+
   @inlinable
-  internal func _find<Element>(
+  internal func _find<Element: Hashable>(
     _ item: Element,
     in elements: UnsafeBufferPointer<Element>
-  ) -> (index: Int?, bucket: Bucket)
-  where Element: Hashable {
+  ) -> (index: Int?, bucket: Bucket) {
     let start = idealBucket(for: item)
     var (iterator, value) = startFind(start)
     while let index = value {

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
@@ -433,7 +433,7 @@ extension OrderedSet {
   internal func _find_inlined(_ item: Element) -> (index: Int?, bucket: _Bucket) {
     _elements.withUnsafeBufferPointer { elements in
       guard let table = _table else {
-        return (elements.firstIndex(of: item), _Bucket(offset: 0))
+        return (elements._firstIndex(of: item), _Bucket(offset: 0))
       }
       return table.read { hashTable in
         hashTable._find(item, in: elements)
@@ -478,6 +478,22 @@ extension OrderedSet {
   @inline(__always)
   public func lastIndex(of element: Element) -> Int? {
     _find(element).index
+  }
+}
+
+/// copy of the standard library implementation of `Collection.firstIndex(of:)`
+/// to allow partial specialization if `Element` is not known at compile time
+extension UnsafeBufferPointer where Element: Equatable {
+  @inlinable
+  func _firstIndex(of element: Element) -> Index? {
+    var i = self.startIndex
+    while i != self.endIndex {
+      if self[i] == element {
+        return i
+      }
+      self.formIndex(after: &i)
+    }
+    return nil
   }
 }
 


### PR DESCRIPTION
I have noticed that OrderedSet performance is slower than Dictionary if the `Element` isn't known at compile time and therefore the compiler can't specialize the implementations.

This PR replaces some of the generic functions that are generic with manual partial specialized variations that are only generic over the `Element` type.

### Checklist
- [ ] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections) 
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
