### PR TITLE
Span updates

### DIFF
--- a/Sources/Future/Box.swift
+++ b/Sources/Future/Box.swift
@@ -47,7 +47,8 @@ extension Box where T: ~Copyable {
 
   @_alwaysEmitIntoClient
   @_transparent
-  public consuming func leak() -> dependsOn(immortal) Inout<T> {
+  @lifetime(immortal)
+  public consuming func leak() -> Inout<T> {
     let result = Inout<T>(unsafeImmortalAddress: _pointer)
     discard self
     return result

--- a/Sources/Future/Containers/Container.swift
+++ b/Sources/Future/Containers/Container.swift
@@ -12,7 +12,8 @@
 public protocol BorrowingIteratorProtocol: ~Escapable {
   associatedtype Element: ~Copyable
 
-  mutating func nextChunk(maximumCount: Int) -> dependsOn(scoped self) Span<Element>
+  @lifetime(self)
+  mutating func nextChunk(maximumCount: Int) -> Span<Element>
 }
 
 public protocol Container: ~Copyable, ~Escapable {
@@ -141,7 +142,8 @@ extension RandomAccessContainer where Index: Strideable, Index.Stride == Int, Se
 public protocol Muterator: ~Copyable, ~Escapable {
   associatedtype Element: ~Copyable
 
-  mutating func nextChunk(maximumCount: Int) -> dependsOn(scoped state) MutableSpan<Element>
+  @lifetime(self)
+  mutating func nextChunk(maximumCount: Int) -> MutableSpan<Element>
 }
 
 public protocol MutableContainer: Container, ~Copyable, ~Escapable {

--- a/Sources/Future/Containers/RigidArray.swift
+++ b/Sources/Future/Containers/RigidArray.swift
@@ -78,9 +78,10 @@ extension RigidArray: RandomAccessContainer where Element: ~Copyable {
       self._offset = startOffset
     }
 
+    @lifetime(self)
     public mutating func nextChunk(
       maximumCount: Int
-    ) -> dependsOn(scoped self) Span<Element> {
+    ) -> Span<Element> {
       let end = _offset + Swift.min(maximumCount, _items.count - _offset)
       defer { _offset = end }
       let chunk = _items.extracting(Range(uncheckedBounds: (_offset, end)))

--- a/Sources/Future/Containers/Shared.swift
+++ b/Sources/Future/Containers/Shared.swift
@@ -121,7 +121,8 @@ extension Shared where Storage: ~Copyable {
 
   // FIXME: This builds, but attempts to use it don't: they fail with an unexpected exclusivity violation.
   @inlinable
-  public subscript() -> dependsOn(self) Storage {
+  @lifetime(self)
+  public subscript() -> Storage {
     //@_transparent
     unsafeAddress {
       _address
@@ -159,7 +160,8 @@ extension Shared where Storage: ~Copyable {
 extension Shared where Storage: ~Copyable {
   // This is the actual shape we want. There is currently no way to express it.
   @inlinable
-  public borrowing func read() -> dependsOn(self) Borrow<Storage> {
+  @lifetime(borrow self)
+  public borrowing func read() -> Borrow<Storage> {
     // This is gloriously (and very explicitly) unsafe, as it should be.
     // `Shared` is carefully constructed to guarantee that
     // lifetime(self) == lifetime(_box.storage); but we have not

--- a/Sources/Future/Inout.swift
+++ b/Sources/Future/Inout.swift
@@ -57,9 +57,10 @@ public struct Inout<T: ~Copyable>: ~Copyable, ~Escapable {
   ///                                    an immortal instance of type 'T'.
   @_alwaysEmitIntoClient
   @_transparent
+  @lifetime(immortal)
   public init(
     unsafeImmortalAddress: UnsafeMutablePointer<T>
-  ) -> dependsOn(immortal) Self {
+  ) {
     _pointer = unsafeImmortalAddress
   }
 }

--- a/Sources/Future/LifetimeOverride.swift
+++ b/Sources/Future/LifetimeOverride.swift
@@ -14,12 +14,13 @@ import Builtin
 
 @_unsafeNonescapableResult
 @inlinable @inline(__always)
+@lifetime(borrow source)
 public func unsafelyOverrideLifetime<
   T: ~Copyable & ~Escapable,
   U: ~Copyable & ~Escapable
 >(
   of dependent: consuming T,
   to source: borrowing U
-) -> dependsOn(source) T {
+) -> T {
   dependent
 }

--- a/Sources/Future/MutableSpan.swift
+++ b/Sources/Future/MutableSpan.swift
@@ -505,7 +505,7 @@ extension MutableSpan {
       "destination span cannot contain every element from source."
     )
     _start.withMemoryRebound(to: Element.self, capacity: source.count) { dest in
-      source._start.withMemoryRebound(to: Element.self, capacity: source.count) {
+      source._start().withMemoryRebound(to: Element.self, capacity: source.count) {
         dest.update(from: $0, count: source.count)
       }
     }
@@ -657,7 +657,7 @@ extension MutableSpan where Element: BitwiseCopyable {
       "destination span cannot contain every element from source."
     )
     _start.copyMemory(
-      from: source._start, byteCount: source.count&*MemoryLayout<Element>.stride
+      from: source._start(), byteCount: source.count&*MemoryLayout<Element>.stride
     )
     return source.count
   }

--- a/Sources/Future/MutableSpan.swift
+++ b/Sources/Future/MutableSpan.swift
@@ -676,7 +676,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   public mutating func update(
     fromContentsOf source: RawSpan
   ) -> Int where Element: BitwiseCopyable {
-    self.update(fromContentsOf: source.unsafeView(as: Element.self))
+    self.update(fromContentsOf: source._unsafeView(as: Element.self))
   }
 
   // We have to define the overloads for raw buffers and their slices,

--- a/Sources/Future/MutableSpan.swift
+++ b/Sources/Future/MutableSpan.swift
@@ -26,10 +26,11 @@ public struct MutableSpan<Element: ~Copyable>: ~Copyable & ~Escapable {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @usableFromInline @inline(__always)
+  @lifetime(borrow start)
   init(
     _unchecked start: UnsafeMutableRawPointer?,
     count: Int
-  ) -> dependsOn(immortal) Self {
+  ) {
     _pointer = start
     _count = count
   }
@@ -44,18 +45,20 @@ extension MutableSpan where Element: ~Copyable {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @usableFromInline @inline(__always)
+  @lifetime(borrow elements)
   internal init(
     _unchecked elements: UnsafeMutableBufferPointer<Element>
-  ) -> dependsOn(immortal) Self {
+  ) {
     _pointer = .init(elements.baseAddress)
     _count = elements.count
   }
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
   public init(
     _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
-  ) -> dependsOn(immortal) Self {
+  ) {
     precondition(
       ((Int(bitPattern: buffer.baseAddress) &
         (MemoryLayout<Element>.alignment&-1)) == 0),
@@ -66,10 +69,11 @@ extension MutableSpan where Element: ~Copyable {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(borrow start)
   public init(
     _unsafeStart start: UnsafeMutablePointer<Element>,
     count: Int
-  ) -> dependsOn(immortal) Self {
+  ) {
     precondition(count >= 0, "Count must not be negative")
     self.init(_unsafeElements: .init(start: start, count: count))
   }
@@ -80,9 +84,10 @@ extension MutableSpan {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(borrow elements)
   public init(
-    _unsafeElements elements: Slice<UnsafeMutableBufferPointer<Element>>
-  ) -> dependsOn(immortal) Self {
+    _unsafeElements elements: borrowing Slice<UnsafeMutableBufferPointer<Element>>
+  ) {
     self.init(_unsafeElements: UnsafeMutableBufferPointer(rebasing: elements))
   }
 }
@@ -92,9 +97,10 @@ extension MutableSpan where Element: BitwiseCopyable {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: UnsafeMutableRawBufferPointer
-  ) -> dependsOn(immortal) Self {
+  ) {
     precondition(
       ((Int(bitPattern: buffer.baseAddress) &
         (MemoryLayout<Element>.alignment&-1)) == 0),
@@ -108,19 +114,21 @@ extension MutableSpan where Element: BitwiseCopyable {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(borrow pointer)
   public init(
     _unsafeStart pointer: UnsafeMutableRawPointer,
     byteCount: Int
-  ) -> dependsOn(immortal) Self {
+  ) {
     precondition(byteCount >= 0, "Count must not be negative")
     self.init(_unsafeBytes: .init(start: pointer, count: byteCount))
   }
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
   public init(
-    _unsafeBytes buffer: Slice<UnsafeMutableRawBufferPointer>
-  ) -> dependsOn(immortal) Self {
+    _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
+  ) {
     self.init(_unsafeBytes: UnsafeMutableRawBufferPointer(rebasing: buffer))
   }
 }

--- a/Sources/Future/OutputSpan.swift
+++ b/Sources/Future/OutputSpan.swift
@@ -291,7 +291,7 @@ extension OutputSpan {
       "destination span cannot contain every element from source."
     )
     let tail = _start.advanced(by: _initialized&*MemoryLayout<Element>.stride)
-    source._start.withMemoryRebound(to: Element.self, capacity: source.count) {
+    source._start().withMemoryRebound(to: Element.self, capacity: source.count) {
       _ = tail.initializeMemory(as: Element.self, from: $0, count: source.count)
     }
     _initialized += source.count

--- a/Sources/Future/OutputSpan.swift
+++ b/Sources/Future/OutputSpan.swift
@@ -45,11 +45,12 @@ public struct OutputSpan<Element: ~Copyable>: ~Copyable, ~Escapable {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @usableFromInline @inline(__always)
+  @lifetime(borrow start)
   init(
     _unchecked start: UnsafeMutableRawPointer?,
     capacity: Int,
     initialized: Int
-  ) -> dependsOn(immortal) Self {
+  ) {
     _pointer = start
     self.capacity = capacity
     _initialized = initialized
@@ -65,10 +66,11 @@ extension OutputSpan where Element: ~Copyable  {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @usableFromInline @inline(__always)
+  @lifetime(borrow buffer)
   init(
     _unchecked buffer: UnsafeMutableBufferPointer<Element>,
     initialized: Int
-  ) -> dependsOn(immortal) Self {
+  ) {
     _pointer = .init(buffer.baseAddress)
     capacity = buffer.count
     _initialized = initialized
@@ -76,10 +78,11 @@ extension OutputSpan where Element: ~Copyable  {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
   public init(
     _initializing buffer: UnsafeMutableBufferPointer<Element>,
     initialized: Int = 0
-  ) -> dependsOn(immortal) Self {
+  ) {
     precondition(
       ((Int(bitPattern: buffer.baseAddress) &
         (MemoryLayout<Element>.alignment&-1)) == 0),
@@ -90,11 +93,12 @@ extension OutputSpan where Element: ~Copyable  {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(borrow pointer)
   public init(
     _initializing pointer: UnsafeMutablePointer<Element>,
     capacity: Int,
     initialized: Int = 0
-  ) -> dependsOn(immortal) Self {
+  ) {
     precondition(capacity >= 0, "Capacity must be 0 or greater")
     self.init(
       _initializing: .init(start: pointer, count: capacity),
@@ -108,10 +112,11 @@ extension OutputSpan {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
   public init(
-    _initializing buffer: Slice<UnsafeMutableBufferPointer<Element>>,
+    _initializing buffer: borrowing Slice<UnsafeMutableBufferPointer<Element>>,
     initialized: Int = 0
-  ) -> dependsOn(immortal) Self {
+  ) {
     self.init(_initializing: .init(rebasing: buffer), initialized: initialized)
   }
 }
@@ -121,10 +126,11 @@ extension OutputSpan where Element: BitwiseCopyable {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(borrow bytes)
   public init(
     _initializing bytes: UnsafeMutableRawBufferPointer,
     initialized: Int = 0
-  ) -> dependsOn(immortal) Self {
+  ) {
     precondition(
       ((Int(bitPattern: bytes.baseAddress) &
         (MemoryLayout<Element>.alignment&-1)) == 0),
@@ -140,11 +146,12 @@ extension OutputSpan where Element: BitwiseCopyable {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(borrow pointer)
   public init(
     _initializing pointer: UnsafeMutableRawPointer,
     capacity: Int,
     initialized: Int = 0
-  ) -> dependsOn(immortal) Self {
+  ) {
     precondition(capacity >= 0, "Capacity must be 0 or greater")
     self.init(
       _initializing: .init(start: pointer, count: capacity),
@@ -154,10 +161,11 @@ extension OutputSpan where Element: BitwiseCopyable {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
   public init(
-    _initializing buffer: Slice<UnsafeMutableRawBufferPointer>,
+    _initializing buffer: borrowing Slice<UnsafeMutableRawBufferPointer>,
     initialized: Int = 0
-  ) -> dependsOn(immortal) Self {
+  ) {
     self.init(
       _initializing: UnsafeMutableRawBufferPointer(rebasing: buffer),
       initialized: initialized

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -138,6 +138,15 @@ extension RawSpan {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(buffer))
   }
 
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
+  public init<T: BitwiseCopyable>(
+    _unsafeElements buffer: borrowing Slice<UnsafeBufferPointer<T>>
+  ) {
+    self.init(_unsafeBytes: .init(UnsafeBufferPointer(rebasing: buffer)))
+  }
+
   /// Unsafely create a `RawSpan` over initialized memory.
   ///
   /// The memory in `buffer` must be owned by the instance `owner`,
@@ -154,6 +163,15 @@ extension RawSpan {
     _unsafeElements buffer: UnsafeMutableBufferPointer<T>
   ) {
     self.init(_unsafeElements: UnsafeBufferPointer(buffer))
+  }
+
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
+  public init<T: BitwiseCopyable>(
+    _unsafeElements buffer: borrowing Slice<UnsafeMutableBufferPointer<T>>
+  ) {
+    self.init(_unsafeBytes: .init(UnsafeBufferPointer(rebasing: buffer)))
   }
 
   /// Unsafely create a `RawSpan` over initialized memory.

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -26,7 +26,7 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow pointer)
   internal init(
     _unchecked pointer: UnsafeRawPointer?,
     byteCount: Int
@@ -53,9 +53,9 @@ extension RawSpan {
   ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
-    _unsafeBytes buffer: UnsafeRawBufferPointer
+    _unsafeBytes buffer: borrowing UnsafeRawBufferPointer
   ) {
     self.init(
       _unchecked: buffer.baseAddress, byteCount: buffer.count
@@ -64,9 +64,9 @@ extension RawSpan {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
-    _unsafeBytes buffer: Slice<UnsafeRawBufferPointer>
+    _unsafeBytes buffer: borrowing Slice<UnsafeRawBufferPointer>
   ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(rebasing: buffer))
   }
@@ -82,7 +82,7 @@ extension RawSpan {
   ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: UnsafeMutableRawBufferPointer
   ) {
@@ -91,9 +91,9 @@ extension RawSpan {
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
-    _unsafeBytes buffer: Slice<UnsafeMutableRawBufferPointer>
+    _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
   ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(rebasing: buffer))
   }
@@ -111,7 +111,7 @@ extension RawSpan {
   ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow pointer)
   public init(
     _unsafeStart pointer: UnsafeRawPointer,
     byteCount: Int
@@ -131,7 +131,7 @@ extension RawSpan {
   ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: UnsafeBufferPointer<T>
   ) {
@@ -149,7 +149,7 @@ extension RawSpan {
   ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: UnsafeMutableBufferPointer<T>
   ) {
@@ -169,7 +169,7 @@ extension RawSpan {
   ///            the newly created `RawSpan`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow pointer)
   public init<T: BitwiseCopyable>(
     _unsafeStart pointer: UnsafePointer<T>,
     count: Int
@@ -188,7 +188,7 @@ extension RawSpan {
   @_disallowFeatureSuppression(NonescapableTypes)
   @unsafe // remove when fixing the lifetime annotation
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(span)
   public init<Element: BitwiseCopyable>(
     _unsafeSpan span: borrowing Span<Element>
   ) {
@@ -395,7 +395,7 @@ extension RawSpan {
   @_disallowFeatureSuppression(NonescapableTypes)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(self)
   public func _unsafeView<T: BitwiseCopyable>(
     as type: T.Type
   ) -> Span<T> {

--- a/Sources/Future/RawSpan.swift
+++ b/Sources/Future/RawSpan.swift
@@ -12,8 +12,9 @@
 
 // A RawSpan represents a span of initialized memory
 // of unspecified type.
+@_disallowFeatureSuppression(NonescapableTypes)
 @frozen
-public struct RawSpan: Copyable, ~Escapable {
+public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   @usableFromInline let _pointer: UnsafeRawPointer?
 
   @usableFromInline @inline(__always)
@@ -21,19 +22,22 @@ public struct RawSpan: Copyable, ~Escapable {
 
   @usableFromInline let _count: Int
 
-  @_alwaysEmitIntoClient
-  internal init(
-    _unchecked start: UnsafeRawPointer?,
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @usableFromInline @inline(__always)
+  @lifetime(immortal)
+  init(
+    _unchecked pointer: UnsafeRawPointer?,
     byteCount: Int
-  ) -> dependsOn(immortal) Self {
-    _pointer = start
+  ) {
+    _pointer = pointer
     _count = byteCount
   }
 }
 
-@available(*, unavailable)
-extension RawSpan: Sendable {}
+@_disallowFeatureSuppression(NonescapableTypes)
+extension RawSpan: @unchecked Sendable {}
 
+@_disallowFeatureSuppression(NonescapableTypes)
 extension RawSpan {
 
   /// Unsafely create a `RawSpan` over initialized memory.
@@ -45,19 +49,23 @@ extension RawSpan {
   ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `RawSpan`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init(
     _unsafeBytes buffer: UnsafeRawBufferPointer
-  ) -> dependsOn(immortal) Self {
+  ) {
     self.init(
       _unchecked: buffer.baseAddress, byteCount: buffer.count
     )
   }
 
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init(
     _unsafeBytes buffer: Slice<UnsafeRawBufferPointer>
-  ) -> dependsOn(immortal) Self {
+  ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(rebasing: buffer))
   }
 
@@ -70,17 +78,21 @@ extension RawSpan {
   ///   - buffer: an `UnsafeMutableRawBufferPointer` to initialized memory.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `RawSpan`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init(
     _unsafeBytes buffer: UnsafeMutableRawBufferPointer
-  ) -> dependsOn(immortal) Self {
+  ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(buffer))
   }
 
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init(
     _unsafeBytes buffer: Slice<UnsafeMutableRawBufferPointer>
-  ) -> dependsOn(immortal) Self {
+  ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(rebasing: buffer))
   }
 
@@ -95,11 +107,13 @@ extension RawSpan {
   ///   - byteCount: the number of initialized bytes in the span.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `RawSpan`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init(
     _unsafeStart pointer: UnsafeRawPointer,
     byteCount: Int
-  ) -> dependsOn(immortal) Self {
+  ) {
     precondition(byteCount >= 0, "Count must not be negative")
     self.init(_unchecked: pointer, byteCount: byteCount)
   }
@@ -113,10 +127,12 @@ extension RawSpan {
   ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `RawSpan`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: UnsafeBufferPointer<T>
-  ) -> dependsOn(immortal) Self {
+  ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(buffer))
   }
 
@@ -129,10 +145,12 @@ extension RawSpan {
   ///   - buffer: an `UnsafeMutableRawBufferPointer` to initialized memory.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `RawSpan`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: UnsafeMutableBufferPointer<T>
-  ) -> dependsOn(immortal) Self {
+  ) {
     self.init(_unsafeElements: UnsafeBufferPointer(buffer))
   }
 
@@ -147,11 +165,13 @@ extension RawSpan {
   ///   - byteCount: the number of initialized bytes in the span.
   ///   - owner: a binding whose lifetime must exceed that of
   ///            the newly created `RawSpan`.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init<T: BitwiseCopyable>(
     _unsafeStart pointer: UnsafePointer<T>,
     count: Int
-  ) -> dependsOn(immortal) Self {
+  ) {
     precondition(count >= 0, "Count must not be negative")
     self.init(
       _unchecked: pointer, byteCount: count*MemoryLayout<T>.stride
@@ -163,10 +183,13 @@ extension RawSpan {
   /// - Parameters:
   ///   - span: An existing `Span<T>`, which will define both this
   ///           `RawSpan`'s lifetime and the memory it represents.
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe // remove when fixing the lifetime annotation
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public init<Element: BitwiseCopyable>(
     _unsafeSpan span: borrowing Span<Element>
-  ) -> dependsOn(immortal) Self {
+  ) {
     self.init(
       _unchecked: UnsafeRawPointer(span._start),
       byteCount: span.count &* MemoryLayout<Element>.stride
@@ -176,15 +199,14 @@ extension RawSpan {
 
 extension RawSpan {
 
-  private var _address: String {
-    String(UInt(bitPattern: _pointer), radix: 16, uppercase: false)
-  }
-
-  public var _description: String {
-    "(0x\(_address), \(_count))"
+  @_alwaysEmitIntoClient
+  public var description: String {
+    let addr = String(UInt(bitPattern: _pointer), radix: 16, uppercase: false)
+    return "(0x\(addr), \(_count))"
   }
 }
 
+@_disallowFeatureSuppression(NonescapableTypes)
 extension RawSpan {
 
   /// The number of bytes in the span.
@@ -213,6 +235,7 @@ extension RawSpan {
 }
 
 //MARK: extracting sub-spans
+@_disallowFeatureSuppression(NonescapableTypes)
 extension RawSpan {
 
   /// Constructs a new span over the bytes within the supplied range of
@@ -228,16 +251,18 @@ extension RawSpan {
   /// - Returns: A span over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @usableFromInline func _extracting(_ bounds: Range<Int>) -> Self {
+  public func _extracting(_ bounds: Range<Int>) -> Self {
     precondition(
-      UInt(bitPattern: bounds.lowerBound) <  UInt(bitPattern: _count) &&
+      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
       UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
       "byte offset range out of bounds"
     )
     return _extracting(unchecked: bounds)
   }
 
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   public mutating func _shrink(to bounds: Range<Int>) {
     self = _extracting(bounds)
@@ -258,14 +283,18 @@ extension RawSpan {
   /// - Returns: A span over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
   @_alwaysEmitIntoClient
-  @usableFromInline func _extracting(unchecked bounds: Range<Int>) -> Self {
+  public func _extracting(unchecked bounds: Range<Int>) -> Self {
     RawSpan(
       _unchecked: _pointer?.advanced(by: bounds.lowerBound),
       byteCount: bounds.count
     )
   }
 
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
   @_alwaysEmitIntoClient
   public mutating func _shrink(toUnchecked bounds: Range<Int>) {
     self = _extracting(unchecked: bounds)
@@ -284,11 +313,13 @@ extension RawSpan {
   /// - Returns: A span over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @usableFromInline func _extracting(_ bounds: some RangeExpression<Int>) -> Self {
+  public func _extracting(_ bounds: some RangeExpression<Int>) -> Self {
     _extracting(bounds.relative(to: byteOffsets))
   }
 
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   public mutating func _shrink(_ bounds: some RangeExpression<Int>) {
     self = _extracting(bounds)
@@ -309,13 +340,17 @@ extension RawSpan {
   /// - Returns: A span over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
   @_alwaysEmitIntoClient
-  @usableFromInline func _extracting(
+  public func _extracting(
     unchecked bounds: some RangeExpression<Int>
   ) -> Self {
     _extracting(unchecked: bounds.relative(to: byteOffsets))
   }
 
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
   @_alwaysEmitIntoClient
   public mutating func _shrink(toUnchecked bounds: some RangeExpression<Int>) {
     self = _extracting(unchecked: bounds)
@@ -330,12 +365,14 @@ extension RawSpan {
   /// - Returns: A span over all the bytes of this span.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @usableFromInline func _extracting(_: UnboundedRange) -> Self {
+  public func _extracting(_: UnboundedRange) -> Self {
     self
   }
 }
 
+@_disallowFeatureSuppression(NonescapableTypes)
 extension RawSpan {
 
   //FIXME: mark closure parameter as non-escaping
@@ -353,14 +390,16 @@ extension RawSpan {
   ///   The closure's parameter is valid only for the duration of
   ///   its execution.
   /// - Returns: The return value of the `body` closure parameter.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  public func withUnsafeBytes<E: Error, Result: ~Copyable & ~Escapable>(
+  public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
     try body(.init(start: (byteCount==0) ? nil : _start, count: byteCount))
   }
 }
 
+@_disallowFeatureSuppression(NonescapableTypes)
 extension RawSpan {
 
   /// View the bytes of this span as type `T`
@@ -377,15 +416,19 @@ extension RawSpan {
   /// - Parameters:
   ///   - type: The type as which to view the bytes of this span.
   /// - Returns: A typed span viewing these bytes as instances of `T`.
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
   @_alwaysEmitIntoClient
+  @lifetime(immortal)
   public func unsafeView<T: BitwiseCopyable>(
     as type: T.Type
   ) -> Span<T> {
-    Span(_unsafeStart: _start, byteCount: byteCount)
+    Span(_unsafeBytes: .init(start: _pointer, count: _count))
   }
 }
 
 //MARK: load
+@_disallowFeatureSuppression(NonescapableTypes)
 extension RawSpan {
 
   /// Returns a new instance of the given type, constructed from the raw memory
@@ -405,6 +448,8 @@ extension RawSpan {
   /// - Returns: A new instance of type `T`, read from the raw bytes at
   ///     `offset`. The returned instance is memory-managed and unassociated
   ///     with the value in the memory referenced by this pointer.
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
   @_alwaysEmitIntoClient
   public func unsafeLoad<T>(
     fromByteOffset offset: Int = 0, as: T.Type
@@ -435,6 +480,8 @@ extension RawSpan {
   /// - Returns: A new instance of type `T`, read from the raw bytes at
   ///     `offset`. The returned instance is memory-managed and unassociated
   ///     with the value in the memory referenced by this pointer.
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
   @_alwaysEmitIntoClient
   public func unsafeLoad<T>(
     fromUncheckedByteOffset offset: Int, as: T.Type
@@ -458,6 +505,8 @@ extension RawSpan {
   /// - Returns: A new instance of type `T`, read from the raw bytes at
   ///     `offset`. The returned instance isn't associated
   ///     with the value in the range of memory referenced by this pointer.
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
   @_alwaysEmitIntoClient
   public func unsafeLoadUnaligned<T: BitwiseCopyable>(
     fromByteOffset offset: Int = 0, as: T.Type
@@ -487,6 +536,8 @@ extension RawSpan {
   /// - Returns: A new instance of type `T`, read from the raw bytes at
   ///     `offset`. The returned instance isn't associated
   ///     with the value in the range of memory referenced by this pointer.
+  @_disallowFeatureSuppression(NonescapableTypes)
+  @unsafe
   @_alwaysEmitIntoClient
   public func unsafeLoadUnaligned<T: BitwiseCopyable>(
     fromUncheckedByteOffset offset: Int, as: T.Type
@@ -495,9 +546,11 @@ extension RawSpan {
   }
 }
 
+@_disallowFeatureSuppression(NonescapableTypes)
 extension RawSpan {
   /// Returns a Boolean value indicating whether two `RawSpan` instances
   /// refer to the same region in memory.
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   public func isIdentical(to other: Self) -> Bool {
     (self._pointer == other._pointer) && (self._count == other._count)
@@ -511,6 +564,7 @@ extension RawSpan {
   /// Parameters:
   /// - span: a subrange of `self`
   /// Returns: A range of offsets within `self`
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   public func byteOffsets(of span: borrowing Self) -> Range<Int>? {
     if span._count > _count { return nil }
@@ -526,6 +580,7 @@ extension RawSpan {
 }
 
 //MARK: one-sided slicing operations
+@_disallowFeatureSuppression(NonescapableTypes)
 extension RawSpan {
 
   /// Returns a span containing the initial bytes of this span,
@@ -543,13 +598,15 @@ extension RawSpan {
   /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @usableFromInline func _extracting(first maxLength: Int) -> Self {
+  public func _extracting(first maxLength: Int) -> Self {
     precondition(maxLength >= 0, "Can't have a prefix of negative length.")
     let newCount = min(maxLength, byteCount)
     return Self(_unchecked: _pointer, byteCount: newCount)
   }
 
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   public mutating func _shrink(toFirst maxLength: Int) {
     self = _extracting(first: maxLength)
@@ -569,13 +626,15 @@ extension RawSpan {
   /// - Returns: A span leaving off the specified number of bytes at the end.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @usableFromInline func _extracting(droppingLast k: Int) -> Self {
+  public func _extracting(droppingLast k: Int) -> Self {
     precondition(k >= 0, "Can't drop a negative number of elements.")
     let dc = min(k, byteCount)
     return Self(_unchecked: _pointer, byteCount: byteCount&-dc)
   }
 
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   public mutating func _shrink(droppingLast k: Int) {
     self = _extracting(droppingLast: k)
@@ -596,14 +655,16 @@ extension RawSpan {
   /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @usableFromInline func _extracting(last maxLength: Int) -> Self {
+  public func _extracting(last maxLength: Int) -> Self {
     precondition(maxLength >= 0, "Can't have a suffix of negative length.")
     let newCount = min(maxLength, byteCount)
     let newStart = _pointer?.advanced(by: byteCount&-newCount)
     return Self(_unchecked: newStart, byteCount: newCount)
   }
 
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   public mutating func _shrink(toLast maxLength: Int) {
     self = _extracting(last: maxLength)
@@ -623,14 +684,16 @@ extension RawSpan {
   /// - Returns: A span starting after the specified number of bytes.
   ///
   /// - Complexity: O(1)
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @usableFromInline func _extracting(droppingFirst k: Int) -> Self {
+  public func _extracting(droppingFirst k: Int) -> Self {
     precondition(k >= 0, "Can't drop a negative number of elements.")
     let dc = min(k, byteCount)
     let newStart = _pointer?.advanced(by: dc)
     return Self(_unchecked: newStart, byteCount: byteCount&-dc)
   }
 
+  @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
   public mutating func _shrink(droppingFirst k: Int) {
     self = _extracting(droppingFirst: k)

--- a/Sources/Future/Span+Iterator.swift
+++ b/Sources/Future/Span+Iterator.swift
@@ -16,7 +16,8 @@ extension Span where Element: ~Copyable {
     var curPointer: UnsafeRawPointer?
     let endPointer: UnsafeRawPointer?
 
-    public init(from span: consuming Span<Element>) -> dependsOn(immortal) Self {
+    @lifetime(span)
+    public init(from span: consuming Span<Element>) {
       curPointer = span._pointer
       endPointer = span._pointer?.advanced(
         by: span.count*MemoryLayout<Element>.stride

--- a/Sources/Future/Span.swift
+++ b/Sources/Future/Span.swift
@@ -410,7 +410,7 @@ extension Span where Element: BitwiseCopyable {
   @_disallowFeatureSuppression(NonescapableTypes)
   @unsafe //FIXME: remove when the lifetime inference is fixed
   @_alwaysEmitIntoClient
-  public var _unsafeRawSpan: RawSpan { RawSpan(_unsafeSpan: self) }
+  public var _unsafeRawSpan: RawSpan { RawSpan(_elements: self) }
 }
 
 @_disallowFeatureSuppression(NonescapableTypes)
@@ -664,7 +664,7 @@ extension Span where Element: BitwiseCopyable {
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
-    try RawSpan(_unsafeSpan: self).withUnsafeBytes(body)
+    try RawSpan(_elements: self).withUnsafeBytes(body)
   }
 }
 

--- a/Sources/Future/Span.swift
+++ b/Sources/Future/Span.swift
@@ -29,7 +29,7 @@ public struct Span<Element: ~Copyable & ~Escapable>
 
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow pointer)
   internal init(
     _unchecked pointer: UnsafeRawPointer?,
     count: Int
@@ -56,7 +56,7 @@ extension Span where Element: ~Copyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeElements buffer: UnsafeBufferPointer<Element>
   ) {
@@ -79,7 +79,7 @@ extension Span where Element: ~Copyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
   ) {
@@ -99,13 +99,13 @@ extension Span where Element: ~Copyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow pointer)
   public init(
-    _unsafeStart start: UnsafePointer<Element>,
+    _unsafeStart pointer: UnsafePointer<Element>,
     count: Int
   ) {
     precondition(count >= 0, "Count must not be negative")
-    self.init(_unsafeElements: .init(start: start, count: count))
+    self.init(_unsafeElements: .init(start: pointer, count: count))
   }
 }
 
@@ -123,9 +123,9 @@ extension Span {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
-    _unsafeElements buffer: Slice<UnsafeBufferPointer<Element>>
+    _unsafeElements buffer: borrowing Slice<UnsafeBufferPointer<Element>>
   ) {
     self.init(_unsafeElements: UnsafeBufferPointer(rebasing: buffer))
   }
@@ -141,9 +141,9 @@ extension Span {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
-    _unsafeElements buffer: Slice<UnsafeMutableBufferPointer<Element>>
+    _unsafeElements buffer: borrowing Slice<UnsafeMutableBufferPointer<Element>>
   ) {
     self.init(_unsafeElements: UnsafeBufferPointer(rebasing: buffer))
   }
@@ -168,7 +168,7 @@ extension Span where Element: BitwiseCopyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: UnsafeRawBufferPointer
   ) {
@@ -201,7 +201,7 @@ extension Span where Element: BitwiseCopyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: UnsafeMutableRawBufferPointer
   ) {
@@ -225,7 +225,7 @@ extension Span where Element: BitwiseCopyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow pointer)
   public init(
     _unsafeStart pointer: UnsafeRawPointer,
     byteCount: Int
@@ -250,9 +250,9 @@ extension Span where Element: BitwiseCopyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
-    _unsafeBytes buffer: Slice<UnsafeRawBufferPointer>
+    _unsafeBytes buffer: borrowing Slice<UnsafeRawBufferPointer>
   ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(rebasing: buffer))
   }
@@ -273,9 +273,9 @@ extension Span where Element: BitwiseCopyable {
   ///            the newly created `Span`.
   @_disallowFeatureSuppression(NonescapableTypes)
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @lifetime(borrow buffer)
   public init(
-    _unsafeBytes buffer: Slice<UnsafeMutableRawBufferPointer>
+    _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
   ) {
     self.init(_unsafeBytes: UnsafeRawBufferPointer(rebasing: buffer))
   }

--- a/Sources/Future/StdlibSpanExtensions.swift
+++ b/Sources/Future/StdlibSpanExtensions.swift
@@ -487,7 +487,7 @@ extension Span where Element: BitwiseCopyable {
   public consuming func withBytes<E: Error, Result: ~Copyable>(
     _ body: (_ elements: RawSpan) throws(E) -> Result
   ) throws(E) -> Result {
-    try body(RawSpan(_unsafeSpan: self))
+    try body(RawSpan(_elements: self))
   }
 }
 

--- a/Tests/FutureTests/ContiguousStorageTests.swift
+++ b/Tests/FutureTests/ContiguousStorageTests.swift
@@ -36,9 +36,10 @@ final class ContiguousStorageTests: XCTestCase {
   }
 
   @inline(never)
+  @lifetime(borrow array)
   private func skip(
     along array: borrowing Array<Int>
-  ) -> dependsOn(array) Skipper {
+  ) -> Skipper {
     Skipper(array.storage)
   }
 

--- a/Tests/FutureTests/ContiguousStorageTests.swift
+++ b/Tests/FutureTests/ContiguousStorageTests.swift
@@ -12,7 +12,7 @@ final class ContiguousStorageTests: XCTestCase {
     let span = a.storage
     XCTAssertEqual(span.count, capacity)
 
-    for i in span._indices {
+    for i in span.indices {
       XCTAssertEqual(span[i], a[i])
     }
 

--- a/Tests/FutureTests/RawSpanTests.swift
+++ b/Tests/FutureTests/RawSpanTests.swift
@@ -157,8 +157,8 @@ final class RawSpanTests: XCTestCase {
     }
 
     // Should we be able to derive a non-escapable value from a Span via unsafe pointers?
-    let copy = span.withUnsafeBytes { RawSpan(_unsafeBytes: $0) }
-    _ = copy
+//    let copy: RawSpan = span.withUnsafeBytes { RawSpan(_unsafeBytes: $0) }
+//    _ = copy
   }
 
   func testStrangeBorrow() {
@@ -200,6 +200,9 @@ final class RawSpanTests: XCTestCase {
         ),
         UInt8(capacity-2)
       )
+      let emptySpan = span._extracting(first: 0)
+      let emptierSpan = emptySpan._extracting(0..<0)
+      XCTAssertTrue(emptySpan.isIdentical(to: emptierSpan))
     }
 
     do {
@@ -231,16 +234,6 @@ final class RawSpanTests: XCTestCase {
       XCTAssertEqual(span._extracting(last: 1).byteCount, b.count)
       XCTAssertEqual(span._extracting(droppingFirst: 1).byteCount, b.count)
     }
-  }
-
-  func testBoundsChecking() {
-    let capacity = 4
-    let a = Array(0..<capacity)
-    let span = RawSpan(_unsafeSpan: a.storage)
-    for o in span.byteOffsets {
-      XCTAssertTrue(span.byteOffsets.contains(o))
-    }
-    XCTAssertFalse(span.byteOffsets.contains(span.byteCount))
   }
 
   func testByteOffsetsOf() {

--- a/Tests/FutureTests/RawSpanTests.swift
+++ b/Tests/FutureTests/RawSpanTests.swift
@@ -237,10 +237,10 @@ final class RawSpanTests: XCTestCase {
     let capacity = 4
     let a = Array(0..<capacity)
     let span = RawSpan(_unsafeSpan: a.storage)
-    for o in span._byteOffsets {
-      XCTAssertTrue(span.boundsContain(o))
+    for o in span.byteOffsets {
+      XCTAssertTrue(span.byteOffsets.contains(o))
     }
-    XCTAssertFalse(span.boundsContain(span.byteCount))
+    XCTAssertFalse(span.byteOffsets.contains(span.byteCount))
   }
 
   func testByteOffsetsOf() {
@@ -257,9 +257,9 @@ final class RawSpanTests: XCTestCase {
 
     var bounds: Range<Int>?
     bounds = span.byteOffsets(of: subSpan1)
-    XCTAssertEqual(bounds, span._byteOffsets.prefix(6))
+    XCTAssertEqual(bounds, span.byteOffsets.prefix(6))
     bounds = span.byteOffsets(of: subSpan2)
-    XCTAssertEqual(bounds, span._byteOffsets.suffix(6))
+    XCTAssertEqual(bounds, span.byteOffsets.suffix(6))
     bounds = subSpan2.byteOffsets(of: subSpan1)
     XCTAssertNil(bounds)
     bounds = subSpan1.byteOffsets(of: subSpan2)

--- a/Tests/FutureTests/RawSpanTests.swift
+++ b/Tests/FutureTests/RawSpanTests.swift
@@ -99,9 +99,8 @@ final class RawSpanTests: XCTestCase {
     a.withUnsafeBytes {
       let span = RawSpan(_unsafeBytes: $0)
 
-      var copy = span
-      copy._shrink(droppingFirst: 2)
-      let u0 = copy.unsafeLoadUnaligned(as: UInt64.self)
+      let suffix = span._extracting(droppingFirst: 2)
+      let u0 = suffix.unsafeLoadUnaligned(as: UInt64.self)
       XCTAssertEqual(u0 & 0xff, 2)
       XCTAssertEqual(u0.byteSwapped & 0xff, 9)
       let u1 = span.unsafeLoadUnaligned(fromByteOffset: 6, as: UInt64.self)
@@ -121,13 +120,13 @@ final class RawSpanTests: XCTestCase {
       let sub3 = span._extracting(...)
       let sub4 = span._extracting(unchecked: 2...)
       XCTAssertTrue(
-        sub1.unsafeView(as: UInt8.self)._elementsEqual(sub2.unsafeView(as: UInt8.self))
+        sub1._unsafeView(as: UInt8.self)._elementsEqual(sub2._unsafeView(as: UInt8.self))
       )
       XCTAssertTrue(
-        sub3.unsafeView(as: Int8.self)._elementsEqual(span.unsafeView(as: Int8.self))
+        sub3._unsafeView(as: Int8.self)._elementsEqual(span._unsafeView(as: Int8.self))
       )
       XCTAssertFalse(
-        sub4.unsafeView(as: Int8.self)._elementsEqual(sub3.unsafeView(as: Int8.self))
+        sub4._unsafeView(as: Int8.self)._elementsEqual(sub3._unsafeView(as: Int8.self))
       )
     }
   }
@@ -137,10 +136,8 @@ final class RawSpanTests: XCTestCase {
     let b = (0..<capacity).map(UInt8.init)
     b.withUnsafeBytes {
       let span = RawSpan(_unsafeBytes: $0)
-      var prefix = span
-      prefix._shrink(to: 0..<8)
-      var beyond = prefix
-      beyond._shrink(toUnchecked: 16..<24)
+      let prefix = span._extracting(0..<8)
+      let beyond = prefix._extracting(unchecked: 16..<24)
       XCTAssertEqual(beyond.byteCount, 8)
       XCTAssertEqual(beyond.unsafeLoad(as: UInt8.self), 16)
     }

--- a/Tests/FutureTests/RawSpanTests.swift
+++ b/Tests/FutureTests/RawSpanTests.swift
@@ -30,14 +30,14 @@ final class RawSpanTests: XCTestCase {
   func testInitWithSpanOfIntegers() {
     let capacity = 4
     let a = Array(0..<capacity)
-    let span = RawSpan(_unsafeSpan: a.storage)
+    let span = RawSpan(_elements: a.storage)
     XCTAssertEqual(span.byteCount, capacity*MemoryLayout<Int>.stride)
     XCTAssertFalse(span.isEmpty)
   }
 
   func testInitWithEmptySpanOfIntegers() {
     let a: [Int] = []
-    let span = RawSpan(_unsafeSpan: a.storage)
+    let span = RawSpan(_elements: a.storage)
     XCTAssertTrue(span.isEmpty)
   }
 
@@ -146,7 +146,7 @@ final class RawSpanTests: XCTestCase {
   func testUnsafeBytes() {
     let capacity = 4
     let array = Array(0..<capacity)
-    let span = RawSpan(_unsafeSpan: array.storage)
+    let span = RawSpan(_elements: array.storage)
     array.withUnsafeBytes {  b1 in
       span.withUnsafeBytes { b2 in
         XCTAssertTrue(b1.elementsEqual(b2))

--- a/Tests/FutureTests/SpanTests.swift
+++ b/Tests/FutureTests/SpanTests.swift
@@ -189,7 +189,7 @@ final class SpanTests: XCTestCase {
       let span = Span(_unsafeElements: $0)
       XCTAssertTrue(span._elementsEqual(span._extracting(0..<span.count)))
       XCTAssertTrue(span._elementsEqual(span._extracting(0...)))
-      XCTAssertTrue(span._elementsEqual(span._extracting(uncheckedBounds: ..<span.count)))
+      XCTAssertTrue(span._elementsEqual(span._extracting(unchecked: ..<span.count)))
       XCTAssertTrue(span._elementsEqual(span._extracting(...)))
 
       let emptySpan = span._extracting(0..<0)
@@ -204,7 +204,7 @@ final class SpanTests: XCTestCase {
       let v = Span(_unsafeElements: $0)
       XCTAssertTrue(v._elementsEqual(v._extracting(0..<v.count)))
       XCTAssertTrue(v._elementsEqual(v._extracting(0...)))
-      XCTAssertTrue(v._elementsEqual(v._extracting(uncheckedBounds: ..<v.count)))
+      XCTAssertTrue(v._elementsEqual(v._extracting(unchecked: ..<v.count)))
       XCTAssertTrue(v._elementsEqual(v._extracting(...)))
     }
   }
@@ -234,7 +234,7 @@ final class SpanTests: XCTestCase {
       let span = Span(_unsafeElements: $0)
       XCTAssertTrue(span._elementsEqual(span._extracting(0..<capacity)))
       XCTAssertTrue(span._elementsEqual(span._extracting(0...)))
-      XCTAssertTrue(span._elementsEqual(span._extracting(uncheckedBounds: ..<capacity)))
+      XCTAssertTrue(span._elementsEqual(span._extracting(unchecked: ..<capacity)))
     }
   }
 

--- a/Tests/FutureTests/SpanTests.swift
+++ b/Tests/FutureTests/SpanTests.swift
@@ -332,12 +332,6 @@ final class SpanTests: XCTestCase {
 
       let emptyBuffer = UnsafeBufferPointer(rebasing: ub[0..<0])
       XCTAssertEqual(emptyBuffer.baseAddress, ub.baseAddress)
-
-      let empty = Span(_unsafeElements: emptyBuffer)
-      XCTAssertEqual(empty.count, 0)
-      empty.withUnsafeBufferPointer {
-        XCTAssertNil($0.baseAddress)
-      }
     }
   }
 

--- a/Tests/FutureTests/SpanTests.swift
+++ b/Tests/FutureTests/SpanTests.swift
@@ -113,7 +113,7 @@ final class SpanTests: XCTestCase {
     let array = Array(0..<count)
     array.withUnsafeBufferPointer {
       let span = Span(_unsafeElements: $0)
-      let raw  = RawSpan(_unsafeSpan: span)
+      let raw  = RawSpan(_elements: span)
       XCTAssertEqual(raw.byteCount, span.count*MemoryLayout<Int>.stride)
     }
   }

--- a/Tests/FutureTests/SpanTests.swift
+++ b/Tests/FutureTests/SpanTests.swift
@@ -113,7 +113,7 @@ final class SpanTests: XCTestCase {
     let array = Array(0..<count)
     array.withUnsafeBufferPointer {
       let span = Span(_unsafeElements: $0)
-      let raw  = span._unsafeRawSpan
+      let raw  = RawSpan(_unsafeSpan: span)
       XCTAssertEqual(raw.byteCount, span.count*MemoryLayout<Int>.stride)
     }
   }
@@ -191,6 +191,9 @@ final class SpanTests: XCTestCase {
       XCTAssertTrue(span._elementsEqual(span._extracting(0...)))
       XCTAssertTrue(span._elementsEqual(span._extracting(uncheckedBounds: ..<span.count)))
       XCTAssertTrue(span._elementsEqual(span._extracting(...)))
+
+      let emptySpan = span._extracting(0..<0)
+      _ = emptySpan._extracting(0..<0)
     }
   }
 

--- a/Tests/FutureTests/SpanTests.swift
+++ b/Tests/FutureTests/SpanTests.swift
@@ -123,10 +123,10 @@ final class SpanTests: XCTestCase {
     let a = Array(0..<capacity)
     a.withUnsafeBufferPointer {
       let span = Span(_unsafeElements: $0)
-      XCTAssertEqual(span.count, span._indices.count)
+      XCTAssertEqual(span.count, span.indices.count)
 
       var i = 0
-      for j in span._indices {
+      for j in span.indices {
         XCTAssertEqual(i, j)
         i += 1
       }
@@ -399,9 +399,9 @@ final class SpanTests: XCTestCase {
 
     var bounds: Range<Int>?
     bounds = span.indices(of: subSpan1)
-    XCTAssertEqual(bounds, span._indices.prefix(6))
+    XCTAssertEqual(bounds, span.indices.prefix(6))
     bounds = span.indices(of: subSpan2)
-    XCTAssertEqual(bounds, span._indices.suffix(6))
+    XCTAssertEqual(bounds, span.indices.suffix(6))
     bounds = subSpan2.indices(of: subSpan1)
     XCTAssertNil(bounds)
     bounds = subSpan1.indices(of: subSpan2)

--- a/Tests/FutureTests/StdlibOutputSpanExtensionTests.swift
+++ b/Tests/FutureTests/StdlibOutputSpanExtensionTests.swift
@@ -14,7 +14,7 @@ import XCTest
 import Foundation
 import Future
 
-final class OutputBufferUsageTests: XCTestCase {
+final class StdlibOutputSpanExtensionTests: XCTestCase {
 
   func testArrayInitializationExample() {
     var array: [UInt8]

--- a/Tests/FutureTests/StdlibSpanExtensionTests.swift
+++ b/Tests/FutureTests/StdlibSpanExtensionTests.swift
@@ -21,7 +21,7 @@ final class StdlibSpanExtensionTests: XCTestCase {
   func testDataSpan() throws {
     let a = Data(0..<4)
     a.withSpan {
-      for i in $0._indices {
+      for i in $0.indices {
         XCTAssertEqual($0[i], UInt8(i))
       }
     }
@@ -35,7 +35,7 @@ final class StdlibSpanExtensionTests: XCTestCase {
   func testDataRawSpan() throws {
     let a = Data(0..<4)
     a.withBytes {
-      for i in $0._byteOffsets {
+      for i in $0.byteOffsets {
         XCTAssertEqual(
           $0.unsafeLoad(fromByteOffset: i, as: UInt8.self), UInt8(i)
         )
@@ -52,7 +52,7 @@ final class StdlibSpanExtensionTests: XCTestCase {
     let a = (0..<4).map(String.init(_:))
     do throws(ErrorForTesting) {
       a.withSpan {
-        for i in $0._indices {
+        for i in $0.indices {
           XCTAssertEqual($0[i], String(i))
         }
       }
@@ -84,7 +84,7 @@ final class StdlibSpanExtensionTests: XCTestCase {
   func testContiguousArraySpan() throws {
     let a = ContiguousArray((0..<4).map(String.init(_:)))
     a.withSpan {
-      for i in $0._indices {
+      for i in $0.indices {
         XCTAssertEqual($0[i], String(i))
       }
     }
@@ -114,8 +114,7 @@ final class StdlibSpanExtensionTests: XCTestCase {
     let a = (0..<7).map(String.init(_:)).prefix(upTo: 4)
     print(a.count)
     a.withSpan {
-      print($0._indices)
-      for i in $0._indices {
+      for i in $0.indices {
         print(i)
         let v = $0[i]
         _ = v
@@ -155,7 +154,7 @@ final class StdlibSpanExtensionTests: XCTestCase {
   func testCollectionOfOneRawSpan() throws {
     let a = CollectionOfOne(Int(UInt8.random(in: 0 ..< .max)))
     a.withBytes {
-      for i in $0._byteOffsets {
+      for i in $0.byteOffsets {
         let v = $0.unsafeLoad(fromByteOffset: i, as: UInt8.self)
         if v != 0 {
           XCTAssertEqual(Int(v), a.first)


### PR DESCRIPTION
Brings `Span` and `RawSpan` up to date with the standard library version, while preserving some functions that have been remove there.

The lifetime declaration syntax is updated to use the `@lifetime()` attributes rather than the `dependsOn()` annotations on return types.

Will now require a more recent snapshot, e.g. swift-DEVELOPMENT-SNAPSHOT-2024-11-16-a