### PR TITLE
[cmake] Install libraries in standard directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ if(COLLECTIONS_FOUNDATION_TOOLCHAIN_MODULE)
 endif()
 
 include(CTest)
+include(GNUInstallDirs)
 include(SwiftSupport)
 
 add_subdirectory(Sources)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -40,13 +40,12 @@ if(COLLECTIONS_SINGLE_MODULE)
           LIBRARY DESTINATION lib/swift_static/${swift_os}
           RUNTIME DESTINATION bin)
     endif()
-    get_swift_host_arch(swift_arch)
     install(FILES $<TARGET_PROPERTY:${COLLECTIONS_MODULE_NAME},Swift_MODULE_DIRECTORY>/${COLLECTIONS_MODULE_NAME}.swiftdoc
-      DESTINATION lib/${swift}/${swift_os}/${COLLECTIONS_MODULE_NAME}.swiftdoc
-      RENAME ${swift_arch}.swiftdoc)
+      DESTINATION lib/${swift}/${swift_os}/${COLLECTIONS_MODULE_NAME}.swiftmodule
+      RENAME ${Swift_MODULE_TRIPLE}.swiftdoc)
     install(FILES $<TARGET_PROPERTY:${COLLECTIONS_MODULE_NAME},Swift_MODULE_DIRECTORY>/${COLLECTIONS_MODULE_NAME}.swiftmodule
       DESTINATION lib/${swift}/${swift_os}/${COLLECTIONS_MODULE_NAME}.swiftmodule
-      RENAME ${swift_arch}.swiftmodule)
+      RENAME ${Swift_MODULE_TRIPLE}.swiftmodule)
   else()
     _install_target(${COLLECTIONS_MODULE_NAME})
   endif()

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -68,6 +68,28 @@ function(get_swift_host_os result_var_name)
   set(${result_var_name} ${SWIFT_SYSTEM_NAME} PARENT_SCOPE)
 endfunction()
 
+if(NOT Swift_MODULE_TRIPLE)
+  # Attempt to get the module triple from the Swift compiler.
+  set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
+  if(CMAKE_Swift_COMPILER_TARGET)
+    list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
+  endif()
+  execute_process(COMMAND ${module_triple_command}
+    OUTPUT_VARIABLE target_info_json)
+  string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
+
+  # Exit now if we failed to infer the triple.
+  if(NOT module_triple)
+    message(FATAL_ERROR
+      "Failed to get module triple from Swift compiler. "
+      "Compiler output: ${target_info_json}")
+  endif()
+
+  # Cache the module triple for future use.
+  set(Swift_MODULE_TRIPLE "${module_triple}" CACHE STRING "swift module triple used for installed swiftmodule and swiftinterface files")
+  mark_as_advanced(Swift_MODULE_TRIPLE)
+endif()
+
 function(_install_target module)
   get_swift_host_os(swift_os)
   get_target_property(type ${module} TYPE)
@@ -78,24 +100,20 @@ function(_install_target module)
     set(swift swift)
   endif()
 
-  install(TARGETS ${module}
-    ARCHIVE DESTINATION lib/${swift}/${swift_os}
-    LIBRARY DESTINATION lib/${swift}/${swift_os}
-    RUNTIME DESTINATION bin)
+  install(TARGETS ${module})
   if(type STREQUAL EXECUTABLE)
     return()
   endif()
 
-  get_swift_host_arch(swift_arch)
   get_target_property(module_name ${module} Swift_MODULE_NAME)
   if(NOT module_name)
     set(module_name ${module})
   endif()
 
   install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
-    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
-    RENAME ${swift_arch}.swiftdoc)
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${Swift_MODULE_TRIPLE}.swiftdoc)
   install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
-    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
-    RENAME ${swift_arch}.swiftmodule)
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${Swift_MODULE_TRIPLE}.swiftmodule)
 endfunction()


### PR DESCRIPTION
Previously, libs were installed under `lib/swift/${os}`. They should be installed in the default library directory for the relevant target system.
In addition, swiftmodules were installed in the older layout format. This changes to use the standard modern layout format for swiftmodules.

### Checklist
- [*] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [*] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [*] I've followed the coding style of the rest of the project.
- [*] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [*] I've added benchmarks covering new functionality (if appropriate).
- [*] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [*] I've updated the documentation if necessary.
