### PR TITLE
Make OrderedSet.firstIndex ~4% faster by reducing ARC traffic

### DIFF
--- a/Sources/OrderedCollections/HashTable/_HashTable.swift
+++ b/Sources/OrderedCollections/HashTable/_HashTable.swift
@@ -177,6 +177,7 @@ extension _HashTable {
   ///    the closure call. The closure must not escape it outside the call.
   @inlinable
   @inline(__always)
+  @_effects(releasenone)
   internal func read<R>(_ body: (_UnsafeHashTable) throws -> R) rethrows -> R {
     try _storage.withUnsafeMutablePointers { header, elements in
       let handle = _UnsafeHashTable(header: header, buckets: elements, readonly: true)


### PR DESCRIPTION
`OrderedSet.firstIndex(of:)` runs into some retain/release overhead that make up ~4% of its runtime.
Adding `@_effects(releasenone)` get's rid of this. 

I have personally never used `@_effects(releasenone)` before but I have seen it used throughout this project. If I understand its behavior correctly it should be safe to use it here but I'm not certain. 

Tested with
- Apple Swift version 6.1 (swiftlang-6.1.0.1.51 clang-1600.3.2.3)
- DEVELOPMENT-SNAPSHOT-2025-02-06-a (6.2.20250206101)
### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
