### PR TITLE
[OrderedSet] Add `OrderedSet.appending(contentsOf:)`

### DIFF
--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial SetAlgebra union.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial SetAlgebra union.swift
@@ -81,5 +81,28 @@ extension OrderedSet {
     result.formUnion(other)
     return result
   }
+
+  /// Returns a new set with the contents of a sequence appended to the end of the set, excluding
+  /// elements that are already members.
+  ///
+  ///     let a: OrderedSet = [1, 2, 3, 4]
+  ///     let b: OrderedSet = [0, 2, 4, 6]
+  ///     a.union(b) // [1, 2, 3, 4, 0, 6]
+  ///
+  /// This is functionally equivalent to `self.union(elements)`, but it's
+  /// more explicit about how the new members are ordered in the new set.
+  ///
+  /// - Parameter elements: A finite sequence of elements to append.
+  ///
+  /// - Complexity: Expected to be O(`self.count` + `elements.count`) on average,
+  ///    if `Element` implements high-quality hashing.
+  @inlinable
+  public __consuming func appending(
+    contentsOf elements: __owned some Sequence<Element>
+  ) -> Self {
+    var result = self
+    result.append(contentsOf: elements)
+    return result
+  }
 }
 

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -961,6 +961,20 @@ class OrderedSetTests: CollectionTestCase {
     }
   }
 
+  func test_appending_Self() {
+    withSampleRanges { r1, r2 in
+      let expected = Set(r1).union(r2).sorted()
+
+      let u1 = OrderedSet(r1)
+      let u2 = OrderedSet(r2)
+      let actual1 = u1.appending(contentsOf: u2)
+      expectEqualElements(actual1, expected)
+
+      let actual2 = actual1.appending(contentsOf: u2).appending(contentsOf: u1)
+      expectEqualElements(actual2, expected)
+    }
+  }
+
   func test_formUnion_Self() {
     withSampleRanges { r1, r2 in
       let expected = Set(r1).union(r2).sorted()


### PR DESCRIPTION
### Description
This PR adds a new public function on `appending(contentsOf:)` to `OrderedSet`. It is functionally equivalent to `union(_:)`  but is more explicit about ordering. I find myself looking for this, rather than `union` because a mutating `append(contentsOf:)` already exists. 

A counter argument to this addition would be to minimize duplicative APIs as much as possible to reduce API surface area. However, there's already precedent for "alternative" functions, given `append(contentsOf:)` and `formUnion(_:)` coexist. And in this case I believe it adds sufficient value to justify the addition.

It's second nature to look for an "append" on ordered collections in Swift. Arrays are ubiquitous and an `append(contentsOf:)` exists. However, unlike Array, OrderedSet does not support the `+` operator, so adding this as an alternative to `union(_:)` seems to fill a gap.

### Detailed Design
The implementation is simple, copying the instance to a mutable value then calling `append(contentsOf:)` and returning the result. This is the same pattern to how `union(_:)` works.

### Documentation
Symbol-level documentation has been added but I don't think it's necessary to update any guides, since this isn't adding any new functionality.

### Testing
A new `test_appending_Self` has been added

### Performance
Not profiled.

### Source Impact
What is the impact of this change on existing users of this package? Does it deprecate or remove any existing API?

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (to the extent possible).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexpected benchmark regressions.
- [x] I've updated the documentation (if appropriate).
