### PR TITLE
Add Heap.removeAll(where:)

### DIFF
--- a/Sources/HeapModule/Heap.swift
+++ b/Sources/HeapModule/Heap.swift
@@ -280,13 +280,15 @@ extension Heap {
   public mutating func removeAll(
     where shouldBeRemoved: (Element) throws -> Bool
   ) rethrows {
-    defer { _checkInvariants() }
-    try _storage.removeAll(where: shouldBeRemoved)
-    if _storage.count > 1 {
-      _update { handle in
-        handle.heapify()
+    defer {
+      if _storage.count > 1 {
+        _update { handle in
+          handle.heapify()
+        }
       }
+      _checkInvariants()
     }
+    try _storage.removeAll(where: shouldBeRemoved)
   }
 
   /// Replaces the maximum value in the heap with the given replacement,

--- a/Sources/HeapModule/Heap.swift
+++ b/Sources/HeapModule/Heap.swift
@@ -268,6 +268,26 @@ extension Heap {
     _checkInvariants()
     return removed
   }
+    
+  /// Removes all the elements that satisfy the given predicate.
+  ///
+  /// - Parameter shouldBeRemoved: A closure that takes an element of the
+  ///   heap as its argument and returns a Boolean value indicating
+  ///   whether the element should be removed from the heap.
+  ///
+  /// - Complexity: O(*n*), where *n* is the number of items in the heap.
+  @inlinable
+  public mutating func removeAll(
+    where shouldBeRemoved: (Element) throws -> Bool
+  ) rethrows {
+    defer { _checkInvariants() }
+    try _storage.removeAll(where: shouldBeRemoved)
+    if _storage.count > 1 {
+      _update { handle in
+        handle.heapify()
+      }
+    }
+  }
 
   /// Replaces the maximum value in the heap with the given replacement,
   /// then updates heap contents to reflect the change.

--- a/Tests/HeapTests/HeapTests.swift
+++ b/Tests/HeapTests/HeapTests.swift
@@ -641,4 +641,42 @@ final class HeapTests: CollectionTestCase {
       }
     }
   }
+
+  func test_removeAll_noneRemoved() {
+    withEvery("count", in: 0 ..< 20) { count in
+      withEvery("seed", in: 0 ..< 100) { seed in
+        var rng = RepeatableRandomNumberGenerator(seed: seed)
+        let input = (0 ..< count).shuffled(using: &rng)
+        var heap = Heap(input)
+        heap.removeAll { _ in false }
+        let expected = Array(0 ..< count)
+        expectEqualElements(heap.itemsInAscendingOrder(), expected)
+      }
+    }
+  }
+    
+  func test_removeAll_allRemoved() {
+    withEvery("count", in: 0 ..< 20) { count in
+      withEvery("seed", in: 0 ..< 100) { seed in
+        var rng = RepeatableRandomNumberGenerator(seed: seed)
+        let input = (0 ..< count).shuffled(using: &rng)
+        var heap = Heap(input)
+        heap.removeAll { _ in true }
+        expectTrue(heap.isEmpty)
+      }
+    }
+  }
+    
+  func test_removeAll_removeEvenNumbers() {
+    withEvery("count", in: 0 ..< 20) { count in
+      withEvery("seed", in: 0 ..< 100) { seed in
+        var rng = RepeatableRandomNumberGenerator(seed: seed)
+        let input = (0 ..< count).shuffled(using: &rng)
+        var heap = Heap(input)
+        heap.removeAll { $0 % 2 == 0 }
+        let expected = Array(stride(from: 1, to: count, by: 2))
+        expectEqualElements(heap.itemsInAscendingOrder(), expected)
+      }
+    }
+  }
 }


### PR DESCRIPTION

This PR introduces a new method `Heap.removeAll(where:)` that allows users to remove all elements satisfying a given predicate from the heap in O(n) time. This is done by filtering the buffer and re-heapifying.

Closes #255 

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
