### PR TITLE
Align Heap._UnsafeHandle min/maxValue tie-breaking with Swift.min/max

### DIFF
--- a/Sources/HeapModule/Heap+UnsafeHandle.swift
+++ b/Sources/HeapModule/Heap+UnsafeHandle.swift
@@ -81,12 +81,17 @@ extension Heap._UnsafeHandle {
 
   @inlinable @inline(__always)
   internal func minValue(_ a: _HeapNode, _ b: _HeapNode) -> _HeapNode {
-    self[a] <= self[b] ? a : b
+    // The expression used here matches the implementation of the
+    // standard `Swift.min(_:_:)` function. This attempts to
+    // preserve any pre-existing order in case `T` has identity.
+    // `(min(x, y), max(x, y))` should return `(x, y)` in case `x == y`.
+    self[b] < self[a] ? b : a
   }
 
   @inlinable @inline(__always)
   internal func maxValue(_ a: _HeapNode, _ b: _HeapNode) -> _HeapNode {
-    self[a] > self[b] ? a : b
+    //  In case `a` and `b` match, we need to pick `b`. See `minValue(_:_:)`.
+    self[b] >= self[a] ? b : a
   }
 }
 

--- a/Sources/HeapModule/Heap+UnsafeHandle.swift
+++ b/Sources/HeapModule/Heap+UnsafeHandle.swift
@@ -81,12 +81,12 @@ extension Heap._UnsafeHandle {
 
   @inlinable @inline(__always)
   internal func minValue(_ a: _HeapNode, _ b: _HeapNode) -> _HeapNode {
-    self[a] < self[b] ? a : b
+    self[a] <= self[b] ? a : b
   }
 
   @inlinable @inline(__always)
   internal func maxValue(_ a: _HeapNode, _ b: _HeapNode) -> _HeapNode {
-    self[a] < self[b] ? b : a
+    self[a] > self[b] ? a : b
   }
 }
 

--- a/Sources/HeapModule/Heap.swift
+++ b/Sources/HeapModule/Heap.swift
@@ -212,7 +212,7 @@ extension Heap {
           handle.swapAt(.leftMax, with: &removed)
         }
       } else {
-        let maxNode = handle.maxValue(.rightMax, .leftMax)
+        let maxNode = handle.maxValue(.leftMax, .rightMax)
         handle.swapAt(maxNode, with: &removed)
         handle.trickleDownMax(maxNode)
       }

--- a/Tests/HeapTests/HeapTests.swift
+++ b/Tests/HeapTests/HeapTests.swift
@@ -587,4 +587,58 @@ final class HeapTests: CollectionTestCase {
       }
     }
   }
+
+  struct Distinguishable: Comparable, CustomStringConvertible {
+    var value: Int
+    var id: Int
+
+    static func ==(left: Self, right: Self) -> Bool {
+      left.value == right.value
+    }
+    static func <(left: Self, right: Self) -> Bool {
+      left.value < right.value
+    }
+    var description: String { "\(value)/\(id)" }
+  }
+
+  func test_tieBreaks_min() {
+    var heap: Heap = [
+      Distinguishable(value: 1, id: 1),
+      Distinguishable(value: 1, id: 2),
+      Distinguishable(value: 1, id: 3),
+      Distinguishable(value: 1, id: 4),
+      Distinguishable(value: 1, id: 5),
+    ]
+    while !heap.isEmpty {
+      let oldID = heap.min!.id
+      let newID = 10 * oldID
+      let old = heap.replaceMin(with: Distinguishable(value: 1, id: newID))
+      expectEqual(old.id, oldID)
+      expectEqual(heap.min?.id, 10 * oldID)
+      expectNotNil(heap.removeMin()) { min in
+        expectEqual(min.id, newID)
+      }
+    }
+  }
+
+  func test_tieBreaks_max() {
+    var heap: Heap = [
+      Distinguishable(value: 1, id: 1),
+      Distinguishable(value: 1, id: 2),
+      Distinguishable(value: 1, id: 3),
+      Distinguishable(value: 1, id: 4),
+      Distinguishable(value: 1, id: 5),
+    ]
+    while !heap.isEmpty {
+      let oldID = heap.max!.id
+      let newID = 10 * oldID
+      print(heap.unordered)
+      let old = heap.replaceMax(with: Distinguishable(value: 1, id: newID))
+      expectEqual(old.id, oldID)
+      expectEqual(heap.max?.id, 10 * oldID)
+      expectNotNil(heap.removeMax()) { max in
+        expectEqual(max.id, newID)
+      }
+    }
+  }
 }


### PR DESCRIPTION
Heap._UnsafeHandle has minValue and maxValue. Original functionality was `minValue`, `if a == b, return b`. For `maxValue`, `if a == b, return a`. In both cases, this is the opposite tiebreaker choice from `Swift.min` and `Swift.max`.

`Heap.replaceMax` used `Heap._UnsafeHandle.maxValue` while `Heap.max` used `Swift.max`, and due to different tiebreaker choices, led to inconsistency as seen in #439 .

Therefore I go ahead and update `Heap._UnsafeHandle.maxValue/minValue` to be consistent with `Swift.max/min`.

Fixes #439 


### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
