### PR TITLE
ManagedBuffer.capacity is unavailable on OpenBSD.

### DIFF
--- a/Sources/HashTreeCollections/HashNode/_HashNode+Storage.swift
+++ b/Sources/HashTreeCollections/HashNode/_HashNode+Storage.swift
@@ -77,10 +77,15 @@ extension _HashNode.Storage {
       bytes += itemAlignment - childAlignment
     }
 
+    let mincap = (bytes &+ childStride &- 1) / childStride
     let object = _HashNode.Storage.create(
-      minimumCapacity: (bytes &+ childStride &- 1) / childStride
+      minimumCapacity: mincap
     ) { buffer in
+#if os(OpenBSD)
+      _HashNodeHeader(byteCapacity: mincap * childStride)
+#else
       _HashNodeHeader(byteCapacity: buffer.capacity * childStride)
+#endif
     }
 
     object.withUnsafeMutablePointers { header, elements in

--- a/Sources/HashTreeCollections/HashNode/_HashTreeStatistics.swift
+++ b/Sources/HashTreeCollections/HashNode/_HashTreeStatistics.swift
@@ -115,12 +115,14 @@ extension _HashNode {
 
       let objectHeaderSize = 2 * MemoryLayout<Int>.stride
 
+#if !os(OpenBSD)
       // Note: for simplicity, we assume that there is no padding between
       // the object header and the storage header.
       let start = _getUnsafePointerToStoredProperties(self.raw.storage)
       let capacity = self.raw.storage.capacity
       let end = $0._memory + capacity * MemoryLayout<_RawHashNode>.stride
       stats.grossBytes += objectHeaderSize + (end - start)
+#endif
 
       for child in $0.children {
         child.gatherStatistics(level.descend(), &stats)

--- a/Sources/HashTreeCollections/HashNode/_HashTreeStatistics.swift
+++ b/Sources/HashTreeCollections/HashNode/_HashTreeStatistics.swift
@@ -115,14 +115,11 @@ extension _HashNode {
 
       let objectHeaderSize = 2 * MemoryLayout<Int>.stride
 
-#if !os(OpenBSD)
       // Note: for simplicity, we assume that there is no padding between
       // the object header and the storage header.
       let start = _getUnsafePointerToStoredProperties(self.raw.storage)
-      let capacity = self.raw.storage.capacity
-      let end = $0._memory + capacity * MemoryLayout<_RawHashNode>.stride
+      let end = $0._memory + $0.byteCapacity
       stats.grossBytes += objectHeaderSize + (end - start)
-#endif
 
       for child in $0.children {
         child.gatherStatistics(level.descend(), &stats)


### PR DESCRIPTION
ManagedBuffer.capacity depends on malloc introspection (e.g., `malloc_size`), which is not available on this platform -- and is thus marked as such.

Here, _HashNode.Storage is a ManagedBuffer. Thankfully, the uses of .capacity are fairly limited: one for statistic purposes, which we just completely omit on the platform, and the other, setting a minimum capacity in the header by the buffer's .capacity; the alternative being setting that minimum capacity directly.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate). __n/a: no new code paths, just refactoring__
- [x] I've added benchmarks covering new functionality (if appropriate). __n/a: no new functionality__
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions. __having difficulty running tests myself, will use CI if possible__
- [x] I've updated the documentation if necessary. __no documentation changes necessary__
