### PR TITLE
Update containers

### DIFF
--- a/Sources/DequeModule/Deque+Container.swift
+++ b/Sources/DequeModule/Deque+Container.swift
@@ -21,7 +21,14 @@ extension Deque: RandomAccessContainer {
 
   @available(SwiftCompatibilitySpan 5.0, *)
   @lifetime(borrow self)
-  public func nextSpan(after index: inout Int, maximumCount: Int) -> Span<Element> {
-    _storage.value.nextSpan(after: &index, maximumCount: maximumCount)
+  public func nextSpan(after index: inout Int) -> Span<Element> {
+    _storage.value.nextSpan(after: &index)
   }
+
+  @available(SwiftCompatibilitySpan 5.0, *)
+  @lifetime(borrow self)
+  public func previousSpan(before index: inout Int) -> Span<Element> {
+    _storage.value.previousSpan(before: &index)
+  }
+
 }

--- a/Sources/DequeModule/DynamicDeque.swift
+++ b/Sources/DequeModule/DynamicDeque.swift
@@ -35,8 +35,14 @@ extension DynamicDeque: @unchecked Sendable where Element: Sendable & ~Copyable 
 extension DynamicDeque: RandomAccessContainer where Element: ~Copyable {
   @available(SwiftCompatibilitySpan 5.0, *)
   @lifetime(borrow self)
-  public func nextSpan(after index: inout Int, maximumCount: Int) -> Span<Element> {
-    _storage.nextSpan(after: &index, maximumCount: maximumCount)
+  public func nextSpan(after index: inout Int) -> Span<Element> {
+    _storage.nextSpan(after: &index)
+  }
+
+  @available(SwiftCompatibilitySpan 5.0, *)
+  @lifetime(borrow self)
+  public func previousSpan(before index: inout Int) -> Span<Element> {
+    _storage.previousSpan(before: &index)
   }
 }
 

--- a/Sources/DequeModule/RigidDeque.swift
+++ b/Sources/DequeModule/RigidDeque.swift
@@ -82,17 +82,24 @@ extension RigidDeque where Element: ~Copyable {
 extension RigidDeque: RandomAccessContainer, MutableContainer where Element: ~Copyable {
   @inlinable
   @lifetime(borrow self)
-  public func nextSpan(after index: inout Int, maximumCount: Int) -> Span<Element> {
-    let slots = _handle.slotRange(following: &index, maximumCount: maximumCount)
+  public func nextSpan(after index: inout Int) -> Span<Element> {
+    let slots = _handle.slotRange(following: &index)
+    return _span(over: slots)
+  }
+
+  @inlinable
+  @lifetime(borrow self)
+  public func previousSpan(before index: inout Int) -> Span<Element> {
+    let slots = _handle.slotRange(preceding: &index)
     return _span(over: slots)
   }
 
   @inlinable
   @lifetime(&self)
   public mutating func nextMutableSpan(
-    after index: inout Int, maximumCount: Int
+    after index: inout Int
   ) -> MutableSpan<Element> {
-    let slots = _handle.slotRange(following: &index, maximumCount: maximumCount)
+    let slots = _handle.slotRange(following: &index)
     return _mutableSpan(over: slots)
   }
 }

--- a/Sources/Future/Arrays/DynamicArray.swift
+++ b/Sources/Future/Arrays/DynamicArray.swift
@@ -63,8 +63,13 @@ extension DynamicArray where Element: ~Copyable {
 @available(SwiftCompatibilitySpan 5.0, *)
 extension DynamicArray: RandomAccessContainer where Element: ~Copyable {
   @lifetime(borrow self)
-  public func nextSpan(after index: inout Int, maximumCount: Int) -> Span<Element> {
-    _storage.nextSpan(after: &index, maximumCount: maximumCount)
+  public func nextSpan(after index: inout Int) -> Span<Element> {
+    _storage.nextSpan(after: &index)
+  }
+
+  @lifetime(borrow self)
+  public func previousSpan(before index: inout Int) -> Span<Element> {
+    _storage.previousSpan(before: &index)
   }
 }
 
@@ -101,10 +106,8 @@ extension DynamicArray: MutableContainer where Element: ~Copyable {
 
   @available(SwiftCompatibilitySpan 5.0, *)
   @lifetime(&self)
-  public mutating func nextMutableSpan(
-    after index: inout Int, maximumCount: Int
-  ) -> MutableSpan<Element> {
-    _storage.nextMutableSpan(after: &index, maximumCount: maximumCount)
+  public mutating func nextMutableSpan(after index: inout Int) -> MutableSpan<Element> {
+    _storage.nextMutableSpan(after: &index)
   }
 }
 

--- a/Sources/Future/Arrays/NewArray.swift
+++ b/Sources/Future/Arrays/NewArray.swift
@@ -65,10 +65,15 @@ extension NewArray: RandomAccessContainer, MutableContainer {
   public func borrowElement(at index: Int) -> Borrow<Element> {
     _storage.value.borrowElement(at: index)
   }
-  
+
   @lifetime(borrow self)
-  public func nextSpan(after index: inout Int, maximumCount: Int) -> Span<Element> {
-    _storage.value.nextSpan(after: &index, maximumCount: maximumCount)
+  public func nextSpan(after index: inout Int) -> Span<Element> {
+    _storage.value.nextSpan(after: &index)
+  }
+
+  @lifetime(borrow self)
+  public func previousSpan(before index: inout Int) -> Span<Element> {
+    return _storage.value.previousSpan(before: &index)
   }
 
   @lifetime(&self)
@@ -78,11 +83,9 @@ extension NewArray: RandomAccessContainer, MutableContainer {
   }
 
   @lifetime(&self)
-  public mutating func nextMutableSpan(
-    after index: inout Int, maximumCount: Int
-  ) -> MutableSpan<Element> {
+  public mutating func nextMutableSpan(after index: inout Int) -> MutableSpan<Element> {
     _ensureUnique()
-    return _storage.value.nextMutableSpan(after: &index, maximumCount: maximumCount)
+    return _storage.value.nextMutableSpan(after: &index)
   }
 }
 

--- a/Sources/Future/Containers/BidirectionalContainer.swift
+++ b/Sources/Future/Containers/BidirectionalContainer.swift
@@ -20,8 +20,9 @@ public protocol BidirectionalContainer<Element>: Container, ~Copyable, ~Escapabl
 
 @available(SwiftCompatibilitySpan 5.0, *)
 extension BidirectionalContainer where Self: ~Copyable & ~Escapable {
+  @inlinable
   @lifetime(borrow self)
-  func previousSpan(before index: inout Index, maximumCount: Int) -> Span<Element> {
+  public func previousSpan(before index: inout Index, maximumCount: Int) -> Span<Element> {
     var span = previousSpan(before: &index)
     if span.count > maximumCount {
       // Index remains within the same span, so offseting it is expected to be quick

--- a/Sources/Future/Containers/BidirectionalContainer.swift
+++ b/Sources/Future/Containers/BidirectionalContainer.swift
@@ -13,4 +13,21 @@
 public protocol BidirectionalContainer<Element>: Container, ~Copyable, ~Escapable {
   func index(before i: Index) -> Index
   func formIndex(before i: inout Index)
+
+  @lifetime(borrow self)
+  func previousSpan(before index: inout Index) -> Span<Element>
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+extension BidirectionalContainer where Self: ~Copyable & ~Escapable {
+  @lifetime(borrow self)
+  func previousSpan(before index: inout Index, maximumCount: Int) -> Span<Element> {
+    var span = previousSpan(before: &index)
+    if span.count > maximumCount {
+      // Index remains within the same span, so offseting it is expected to be quick
+      index = self.index(index, offsetBy: span.count - maximumCount)
+      span = span._extracting(last: maximumCount)
+    }
+    return span
+  }
 }

--- a/Sources/Future/Containers/Container.swift
+++ b/Sources/Future/Containers/Container.swift
@@ -30,19 +30,48 @@ public protocol Container<Element>: ~Copyable, ~Escapable {
     limitedBy limit: Index
   )
 
+  // FIXME: Do we want these as standard requirements?
+  func index(alignedDown index: Index) -> Index
+  func index(alignedUp index: Index) -> Index
+
   #if compiler(>=9999) // FIXME: We can't do this yet
   subscript(index: Index) -> Element { borrow }
   #else
-  @lifetime(copy self)
+  @lifetime(borrow self)
   func borrowElement(at index: Index) -> Borrow<Element>
   #endif
 
-  @lifetime(copy self)
-  func nextSpan(after index: inout Index, maximumCount: Int) -> Span<Element>
+  // See if index rounding results need to get returned somewhere
+  // maximumCount: see if it has any real reason to exist yet
+  @lifetime(borrow self)
+  func nextSpan(after index: inout Index) -> Span<Element>
+
+  // Try a version where nextSpan takes an index range
+
+  // See if it makes sense to have a ~Escapable ValidatedIndex type, as a sort of non-self-driving iterator substitute
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)
 extension Container where Self: ~Copyable & ~Escapable {
+  @inlinable
+  public func index(alignedDown index: Index) -> Index { index }
+
+  @inlinable
+  public func index(alignedUp index: Index) -> Index { index }
+
+  @inlinable
+  @lifetime(borrow self)
+  public func nextSpan(after index: inout Index, maximumCount: Int) -> Span<Element> {
+    let original = index
+    var span = nextSpan(after: &index)
+    if span.count > maximumCount {
+      span = span._extracting(first: maximumCount)
+      // Index remains within the same span, so offseting it is expected to be quick
+      index = self.index(original, offsetBy: maximumCount)
+    }
+    return span
+  }
+
   @inlinable
   public subscript(index: Index) -> Element {
     @lifetime(copy self)
@@ -52,3 +81,41 @@ extension Container where Self: ~Copyable & ~Escapable {
   }
 }
 
+
+#if false // DEMO
+@available(SwiftCompatibilitySpan 5.0, *)
+extension Container where Self: ~Copyable & ~Escapable {
+  // This is just to demo the bulk iteration model
+  func forEachSpan<E: Error>(_ body: (Span<Element>) throws(E) -> Void) throws(E) {
+    var it = self.startIndex
+    while true {
+      let span = self.nextSpan(after: &it)
+      if span.isEmpty { break }
+      try body(span)
+    }
+  }
+
+  // This is just to demo the bulk iteration model
+  func forEach<E: Error>(_ body: (borrowing Element) throws(E) -> Void) throws(E) {
+    var it = self.startIndex
+    while true {
+      let span = self.nextSpan(after: &it)
+      if span.isEmpty { break }
+      var i = 0
+      while i < span.count {
+        unsafe try body(span[unchecked: i])
+        i &+= 1
+      }
+    }
+  }
+
+  borrowing func borrowingMap<E: Error, U>(
+    _ transform: (borrowing Element) throws(E) -> U
+  ) throws(E) -> [U] {
+    var result: [U] = []
+    result.reserveCapacity(count)
+    try self.forEach { value throws(E) in result.append(try transform(value)) }
+    return result
+  }
+}
+#endif

--- a/Sources/Future/Containers/Container.swift
+++ b/Sources/Future/Containers/Container.swift
@@ -42,7 +42,6 @@ public protocol Container<Element>: ~Copyable, ~Escapable {
   #endif
 
   // See if index rounding results need to get returned somewhere
-  // maximumCount: see if it has any real reason to exist yet
   @lifetime(borrow self)
   func nextSpan(after index: inout Index) -> Span<Element>
 

--- a/Sources/Future/Containers/ContiguousContainer.swift
+++ b/Sources/Future/Containers/ContiguousContainer.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @available(SwiftCompatibilitySpan 5.0, *)
-public protocol ContiguousContainer<Element>: ~Copyable, ~Escapable {
+public protocol ContiguousContainer<Element>: /*RandomAccessContainer*/ ~Copyable, ~Escapable {
   associatedtype Element: ~Copyable/* & ~Escapable*/
 
   var span: Span<Element> { @lifetime(copy self) get }

--- a/Sources/Future/Containers/MutableContainer.swift
+++ b/Sources/Future/Containers/MutableContainer.swift
@@ -19,11 +19,29 @@ public protocol MutableContainer<Element>: Container, ~Copyable, ~Escapable {
 #endif
 
   @lifetime(&self)
-  mutating func nextMutableSpan(after index: inout Index, maximumCount: Int) -> MutableSpan<Element>
+  mutating func nextMutableSpan(after index: inout Index) -> MutableSpan<Element>
+
+  // FIXME: What about previousMutableSpan?
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)
 extension MutableContainer where Self: ~Copyable & ~Escapable {
+  #if false // Hm...
+  @lifetime(&self)
+  mutating func nextMutableSpan(
+    after index: inout Index, maximumCount: Int
+  ) -> MutableSpan<Element> {
+    let original = index
+    var span = self.nextMutableSpan(after: &index)
+    if span.count > maximumCount {
+      span = span.extracting(first: maximumCount)
+      // Index remains within the same span, so offseting it is expected to be quick
+      index = self.index(original, offsetBy: maximumCount)
+    }
+    return span
+  }
+  #endif
+
   @inlinable
   public subscript(index: Index) -> Element {
     @lifetime(borrow self)

--- a/Sources/Future/Span/Span+Container.swift
+++ b/Sources/Future/Span/Span+Container.swift
@@ -25,11 +25,17 @@ extension Span: RandomAccessContainer where Element: ~Copyable {
   }
 
   @lifetime(copy self)
-  public func nextSpan(after index: inout Index, maximumCount: Int) -> Span<Element> {
-    precondition(index >= 0 && index <= count, "Invalid index")
-    let end = index + Swift.min(count - index, maximumCount)
-    defer { index = end }
-    return _extracting(unsafe Range(uncheckedBounds: (index, end)))
+  public func nextSpan(after index: inout Index) -> Span<Element> {
+    precondition(index >= 0 && index <= count, "Index out of bounds")
+    defer { index = count }
+    return _extracting(unsafe Range(uncheckedBounds: (index, count)))
+  }
+
+  @lifetime(copy self)
+  public func previousSpan(before index: inout Int) -> Span<Element> {
+    precondition(index >= 0 && index <= count, "Index out of bounds")
+    defer { index = 0 }
+    return _extracting(unsafe Range(uncheckedBounds: (0, index)))
   }
 }
 

--- a/Sources/Future/Tools/Shared.swift
+++ b/Sources/Future/Tools/Shared.swift
@@ -145,9 +145,16 @@ extension Shared where Storage: ~Copyable {
 }
 
 extension Shared where Storage: ~Copyable {
-  @available(SwiftStdlib 6.0, *) // for ===
   @inlinable
   public func isIdentical(to other: Self) -> Bool {
-    unsafe self._box === other._box
+    if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
+      return unsafe self._box === other._box
+    } else {
+      // To call the standard `===`, we need to do `_SharedBox` -> AnyObject conversions
+      // that are only supported in the Swift 6+ runtime.
+      let a = unsafe Builtin.bridgeToRawPointer(self._box)
+      let b = unsafe Builtin.bridgeToRawPointer(other._box)
+      return Bool(Builtin.cmp_eq_RawPointer(a, b))
+    }
   }
 }

--- a/Tests/FutureTests/DynamicArrayTests.swift
+++ b/Tests/FutureTests/DynamicArrayTests.swift
@@ -146,14 +146,14 @@ class DynamicArrayTests: CollectionTestCase {
 
     var index = 0
     do {
-      let span = array.nextSpan(after: &index, maximumCount: Int.max)
+      let span = array.nextSpan(after: &index)
       expectEqual(span.count, c)
       for i in 0 ..< span.count {
         expectEqual(span[i].value, 100 + i)
       }
     }
     do {
-      let span2 = array.nextSpan(after: &index, maximumCount: Int.max)
+      let span2 = array.nextSpan(after: &index)
       expectEqual(span2.count, 0)
     }
   }
@@ -181,5 +181,12 @@ class DynamicArrayTests: CollectionTestCase {
       expectEqual(array.nextSpan(after: &index, maximumCount: Int.max).count, 0)
       expectEqual(index, i)
     }
+  }
+
+  func iterationDemo() {
+    let c = 100_000
+    let stride = 7
+    let array = DynamicArray<Counted>(count: c) { Counted($0) }
+
   }
 }


### PR DESCRIPTION
- Adjust lifetime semantics for `nextSpan`
- Remove `maximumCount` argument from `nextSpan` -- replace it with a default algorithm
- Add `previousSpan` to `BidirectionalContainer`