### PR TITLE
Flesh out RigidArray even more; add complete test coverage

### DIFF
--- a/Sources/DequeModule/Deque.swift
+++ b/Sources/DequeModule/Deque.swift
@@ -9,7 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !COLLECTIONS_SINGLE_MODULE
 import Future
+#endif
 
 /// A collection implementing a double-ended queue. `Deque` (pronounced "deck")
 /// implements an ordered random-access collection that supports efficient

--- a/Sources/Future/Arrays/NewArray.swift
+++ b/Sources/Future/Arrays/NewArray.swift
@@ -95,7 +95,7 @@ extension NewArray {
     if _storage.isUnique() {
       _storage.value.reserveCapacity(n)
     } else {
-      _storage.replace { $0._copy(capacity: Swift.max($0.capacity, n)) }
+      _storage.replace { $0.copy(capacity: Swift.max($0.capacity, n)) }
     }
   }
 
@@ -113,7 +113,7 @@ extension NewArray {
 
   @inlinable
   internal mutating func _ensureUnique() {
-    _storage.ensureUnique { $0._copy() }
+    _storage.ensureUnique { $0.copy() }
   }
 
   @inlinable
@@ -127,8 +127,8 @@ extension NewArray {
     }
     let c = Swift.max(minimumCapacity, Self._grow(capacity))
     _storage.edit(
-      shared: { $0._copy(capacity: c) },
-      unique: { $0 = $0._move(capacity: c) }
+      shared: { $0.copy(capacity: c) },
+      unique: { $0.reserveCapacity(c) }
     )
   }
 

--- a/Sources/Future/Containers/RepeatingContainer.swift
+++ b/Sources/Future/Containers/RepeatingContainer.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if false // FIXME: Disabled until I have time to track down a flaky compiler crash
+
 #if false // FIXME: This is what we'd want
 import Builtin
 
@@ -108,4 +110,6 @@ extension RepeatingContainer: RandomAccessContainer where Element: ~Copyable {
     return _contents.span
   }
 }
+#endif
+
 #endif

--- a/Sources/Future/Span/UnsafeBufferPointer+Additions.swift
+++ b/Sources/Future/Span/UnsafeBufferPointer+Additions.swift
@@ -46,3 +46,72 @@ extension UnsafeMutableRawBufferPointer {
     unsafe (self.baseAddress == other.baseAddress) && (self.count == other.count)
   }
 }
+
+
+extension UnsafeMutableBufferPointer {
+  /// Initialize slots at the start of this buffer by copying data from `buffer`, then
+  /// shrink `self` to drop all initialized items from its front, leaving it addressing the
+  /// uninitialized remainder.
+  ///
+  /// If `Element` is not bitwise copyable, then the memory region addressed by `self` must be
+  /// entirely uninitialized, while `buffer` must be fully initialized.
+  ///
+  /// The count of `buffer` must not be greater than `self.count`.
+  @inlinable
+  internal mutating func _initializeAndDropPrefix(copying buffer: UnsafeBufferPointer<Element>) {
+    if buffer.isEmpty { return }
+    precondition(buffer.count <= self.count)
+    unsafe self.baseAddress.unsafelyUnwrapped.initialize(
+      from: buffer.baseAddress.unsafelyUnwrapped, count: buffer.count)
+    unsafe self = self.extracting(buffer.count...)
+  }
+
+  /// Initialize slots at the start of this buffer by copying data from `span`, then
+  /// shrink `self` to drop all initialized items from its front, leaving it addressing the
+  /// uninitialized remainder.
+  ///
+  /// If `Element` is not bitwise copyable, then the memory region addressed by `self` must be
+  /// entirely uninitialized.
+  ///
+  /// The count of `span` must not be greater than `self.count`.
+  @available(SwiftCompatibilitySpan 5.0, *)
+  @inlinable
+  internal mutating func _initializeAndDropPrefix(copying span: Span<Element>) {
+    unsafe span.withUnsafeBufferPointer { buffer in
+      unsafe self._initializeAndDropPrefix(copying: buffer)
+    }
+  }
+
+  /// Initialize all slots in this buffer by copying data from `items`, which must fit entirely
+  /// in this buffer.
+  ///
+  /// If `items` contains more elements than can fit into this buffer, then this function
+  /// will return an index other than `items.endIndex`. In that case, `self` may not be fully
+  /// populated.
+  ///
+  /// If `Element` is not bitwise copyable, then this function must be called on an
+  /// entirely uninitialized buffer.
+  ///
+  /// - Returns: A pair of values `(count, end)`, where `count` is the number of items that were
+  ///    successfully initialized, and `end` is the index into `items` after the last copied item.
+  @available(SwiftCompatibilitySpan 5.0, *)
+  @inlinable
+  internal func _initializePrefix<
+    C: Container<Element> & ~Copyable & ~Escapable
+  >(
+    copying items: borrowing C
+  ) -> (copied: Int, end: C.Index) {
+    var target = unsafe self
+    var i = items.startIndex
+    while true {
+      let start = i
+      let span = items.nextSpan(after: &i)
+      if span.isEmpty { break }
+      guard span.count <= target.count else {
+        return (self.count - target.count, start)
+      }
+      unsafe target._initializeAndDropPrefix(copying: span)
+    }
+    return (self.count - target.count, i)
+  }
+}

--- a/Tests/CollectionsTestSupportTests/StaccatoContainerTests.swift
+++ b/Tests/CollectionsTestSupportTests/StaccatoContainerTests.swift
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import _CollectionsTestSupport
+import Future
+
+class StaccatoContainerTests: CollectionTestCase {
+  func checkStriding<C: Container & ~Copyable & ~Escapable>(
+    _ container: borrowing C,
+    spanCounts: [Int],
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    let entry = context.push("checkStriding", file: file, line: line)
+    defer { context.pop(entry) }
+
+    var i = container.startIndex
+    var j = 0
+    var seen = 0
+    while true {
+      let span = container.nextSpan(after: &i)
+      if i == container.endIndex {
+        expectLessThanOrEqual(span.count, spanCounts[j])
+        expectEqual(span.count, container.count - seen)
+        break
+      }
+      expectEqual(span.count, spanCounts[j])
+      seen += span.count
+      j += 1
+      if j == spanCounts.count { j = 0 }
+    }
+  }
+
+  func test_Basic1() {
+    let items = StaccatoContainer(
+      contents: RigidArray(copying: 0 ..< 10),
+      spanCounts: [1])
+    checkContainer(items, expectedContents: 0 ..< 10)
+  }
+
+  func test_Basic2() {
+    let items = StaccatoContainer(
+      contents: RigidArray(copying: 0 ..< 10),
+      spanCounts: [3])
+    checkContainer(items, expectedContents: 0 ..< 10)
+  }
+
+  func test_Basic3() {
+    let items = StaccatoContainer(
+      contents: RigidArray(copying: 0 ..< 13),
+      spanCounts: [1, 2])
+    checkContainer(items, expectedContents: 0 ..< 13)
+  }
+
+  func test_SingleSpec() {
+    withEvery("c", in: [0, 10, 20]) { c in
+      withEvery("spanCount", in: 1 ... 20) { spanCount in
+        let items = StaccatoContainer(
+          contents: RigidArray(copying: 0 ..< c),
+          spanCounts: [spanCount])
+
+        checkStriding(items, spanCounts: [spanCount])
+        checkContainer(items, expectedContents: 0 ..< c)
+      }
+    }
+  }
+
+  func test_DoubleSpec() {
+    withEvery("c", in: [0, 10, 20]) { c in
+      withEvery("spanCount1", in: 1 ... 10) { spanCount1 in
+        withEvery("spanCount2", in: 1 ... 10) { spanCount2 in
+          let spanCounts = [spanCount1, spanCount2]
+          let items = StaccatoContainer(
+            contents: RigidArray(copying: 0 ..< c),
+            spanCounts: spanCounts)
+
+          checkStriding(items, spanCounts: spanCounts)
+          checkContainer(items, expectedContents: 0 ..< c)
+        }
+      }
+    }
+  }
+
+  func test_TripleSpec() {
+    withEvery("c", in: [0, 10, 20]) { c in
+      withEvery("spanCount1", in: 1 ... 5) { spanCount1 in
+        withEvery("spanCount2", in: 1 ... 5) { spanCount2 in
+          withEvery("spanCount3", in: 1 ... 5) { spanCount3 in
+            let spanCounts = [spanCount1, spanCount2, spanCount3]
+            let items = StaccatoContainer(
+              contents: RigidArray(copying: 0 ..< c),
+              spanCounts: spanCounts)
+
+            checkStriding(items, spanCounts: spanCounts)
+            checkContainer(items, expectedContents: 0 ..< c)
+          }
+        }
+      }
+    }
+  }
+}

--- a/Tests/FutureTests/RepeatingContainerTests.swift
+++ b/Tests/FutureTests/RepeatingContainerTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import _CollectionsTestSupport
 import Future
 
+#if false
 @available(SwiftStdlib 6.0, *)
 class RepeatingContainerTests: CollectionTestCase {
   func test_10() {
@@ -21,3 +22,4 @@ class RepeatingContainerTests: CollectionTestCase {
     }
   }
 }
+#endif

--- a/Tests/FutureTests/SpanTests/RawSpanTests.swift
+++ b/Tests/FutureTests/SpanTests/RawSpanTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-@testable import Future
+import Future
 
 @available(macOS 9999, *)
 final class RawSpanTests: XCTestCase {

--- a/Tests/_CollectionsTestSupport/ConformanceCheckers/CheckContainer.swift
+++ b/Tests/_CollectionsTestSupport/ConformanceCheckers/CheckContainer.swift
@@ -38,6 +38,7 @@ extension Container where Self: ~Copyable & ~Escapable {
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)
+@inlinable
 public func checkContainer<
   C: Container & ~Copyable & ~Escapable,
   Expected: Sequence<C.Element>
@@ -55,6 +56,7 @@ public func checkContainer<
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)
+@inlinable
 public func checkContainer<
   C: Container & ~Copyable & ~Escapable,
   Expected: Sequence<C.Element>
@@ -116,7 +118,7 @@ public func checkContainer<
     checkComparable(allIndices, oracle: { .comparing($0, $1) })
   }
 
-  withEveryRange("range", in: 0 ..< allIndices.count - 1) { range in
+  withEveryRange("range", in: 0 ..< expectedContents.count) { range in
     let i = range.lowerBound
     let j = range.upperBound
 
@@ -133,9 +135,7 @@ public func checkContainer<
   }
 
   // Check `formIndex(_,offsetBy:limitedBy:)`
-  let limits =
-  Set([0, allIndices.count - 1, allIndices.count / 2])
-    .sorted()
+  let limits = Set([0, allIndices.count - 1, allIndices.count / 2]).sorted()
   withEvery("limit", in: limits) { limit in
     withEvery("i", in: 0 ..< allIndices.count) { i in
       let max = allIndices.count - i + (limit >= i ? 2 : 0)
@@ -170,13 +170,13 @@ public func checkContainer<
       pos += span.count
       if span.isEmpty {
         expectEqual(origIndex, container.endIndex)
-        expectEqual(index, origIndex, "nextCount is not expected to move the end index")
+        expectEqual(index, origIndex, "nextSpan is not expected to move the end index")
         break
       }
       expectGreaterThan(
-        index, origIndex, "nextCount does not monotonically increase the index")
+        index, origIndex, "nextSpan does not monotonically increase the index")
       expectEqual(
-        index, allIndices[pos], "nextCount does not increase the index by the size of the span")
+        index, allIndices[pos], "nextSpan does not advance the index by the size of the returned span")
       r.append((origPos ..< pos, origIndex ..< index))
     }
     return r

--- a/Tests/_CollectionsTestSupport/MinimalTypes/StaccatoContainer.swift
+++ b/Tests/_CollectionsTestSupport/MinimalTypes/StaccatoContainer.swift
@@ -1,56 +1,60 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Collections open source project
 //
-// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
 import Future
 
-public struct TestContainer<Element: ~Copyable>: ~Copyable {
+/// A container type with user-defined contents and storage chunks. Useful for testing.
+public struct StaccatoContainer<Element: ~Copyable>: ~Copyable {
   internal let _contents: RigidArray<Element>
   internal let _spanCounts: [Int]
+  internal let _modulus: Int
 
   public init(contents: consuming RigidArray<Element>, spanCounts: [Int]) {
-    precondition(spanCounts.allSatisfy { $0 > 0 })
+    // FIXME: Make this take an arbitrary consumable container
+    precondition(!spanCounts.isEmpty && spanCounts.allSatisfy { $0 > 0 })
     self._contents = contents
     self._spanCounts = spanCounts
+    self._modulus = spanCounts.reduce(into: 0, { $0 += $1 })
   }
 }
 
-extension TestContainer where Element: ~Copyable {
-  public struct Index: Comparable {
-    internal var _offset: Int
+public struct _StaccatoContainerIndex: Comparable {
+  internal var _offset: Int
 
-    internal init(_offset: Int) {
-      self._offset = _offset
-    }
-
-    public static func == (left: Self, right: Self) -> Bool { left._offset == right._offset }
-    public static func < (left: Self, right: Self) -> Bool { left._offset < right._offset }
+  internal init(_offset: Int) {
+    self._offset = _offset
   }
+
+  public static func == (left: Self, right: Self) -> Bool { left._offset == right._offset }
+  public static func < (left: Self, right: Self) -> Bool { left._offset < right._offset }
+}
+
+extension StaccatoContainer where Element: ~Copyable {
+  public typealias Index = _StaccatoContainerIndex // rdar://150240032
 
   func _spanCoordinates(atOffset offset: Int) -> (spanIndex: Int, spanOffset: Int) {
     precondition(offset >= 0 && offset <= _contents.count)
-    let modulus = _spanCounts.reduce(into: 0, { $0 += $1 })
-    var remainder = offset % modulus
-    for i in 0 ..< _spanCounts.count {
+    var remainder = offset % _modulus
+    var i = 0
+    while i < _spanCounts.count {
       let c = _spanCounts[i]
-      if remainder < c {
-        return (i, remainder)
-      }
+      if remainder < c { break }
       remainder -= c
+      i += 1
     }
-    return (_spanCounts.count, 0)
+    return (i, remainder)
   }
 }
 
-extension TestContainer where Element: ~Copyable {
+extension StaccatoContainer where Element: ~Copyable {
   public var isEmpty: Bool { _contents.isEmpty }
   public var count: Int { _contents.count }
   public var startIndex: Index { Index(_offset: 0) }
@@ -77,7 +81,7 @@ extension TestContainer where Element: ~Copyable {
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)
-extension TestContainer: Container where Element: ~Copyable {
+extension StaccatoContainer: Container where Element: ~Copyable {
   public func formIndex(_ i: inout Index, offsetBy distance: inout Int, limitedBy limit: Index) {
     precondition(i >= startIndex && i <= endIndex)
     _contents.formIndex(&i._offset, offsetBy: &distance, limitedBy: limit._offset)
@@ -85,18 +89,19 @@ extension TestContainer: Container where Element: ~Copyable {
 
   @lifetime(borrow self)
   public func borrowElement(at index: Index) -> Future.Borrow<Element> {
-    precondition(index >= startIndex && index < endIndex)
+    precondition(index >= startIndex && index < endIndex, "Index out of bounds")
     return _contents.borrowElement(at: index._offset)
   }
 
   @lifetime(borrow self)
   public func nextSpan(after index: inout Index) -> Span<Element> {
     precondition(index >= startIndex && index <= endIndex)
-    let (spanIndex, spanOffset) = _spanCoordinates(atOffset: index._offset)
     let span = _contents.span
-    guard spanIndex < _spanCounts.count else { return span._extracting(last: 0) }
+    let (spanIndex, spanOffset) = _spanCoordinates(atOffset: index._offset)
     let c = _spanCounts[spanIndex] - spanOffset
-    index._offset += c
-    return span._extracting(index._offset ..< index._offset + c)
+    let startOffset = index._offset
+    let endOffset = Swift.min(startOffset + c, span.count)
+    index._offset = endOffset
+    return span._extracting(startOffset ..< endOffset)
   }
 }


### PR DESCRIPTION
- Add `StaccatoContainer` for testing operations that take input containers
- Update `Container` conformance validator
- Add `RigidArray` initializers that copy data from arbitrary collections, spans and containers.
- Add `RigidArray.replaceSubrange` overloads that take spans and containers.
- Rename `RigidArray.resize(to:)` to `RigidArray.setCapacity(_:)`.
- Make `RigidArray.copy()` and `RigidArray.copy(capacity:)` public API.

### Checklist`
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
