### PR TITLE
RigidArray: Add moving/consuming variants of range-replacement operations

### DIFF
--- a/Sources/Future/Span/UnsafeBufferPointer+Additions.swift
+++ b/Sources/Future/Span/UnsafeBufferPointer+Additions.swift
@@ -48,6 +48,19 @@ extension UnsafeMutableRawBufferPointer {
 }
 
 
+extension UnsafeMutableBufferPointer where Element: ~Copyable {
+  @inlinable
+  internal func _moveInitializePrefix(
+    from source: UnsafeMutableBufferPointer<Element>
+  ) -> Int {
+    if source.isEmpty { return 0 }
+    precondition(source.count <= self.count)
+    unsafe self.baseAddress.unsafelyUnwrapped.moveInitialize(
+      from: source.baseAddress.unsafelyUnwrapped, count: source.count)
+    return source.count
+  }
+}
+
 extension UnsafeMutableBufferPointer {
   /// Initialize slots at the start of this buffer by copying data from `source`.
   ///
@@ -58,12 +71,21 @@ extension UnsafeMutableBufferPointer {
   ///
   /// - Returns: The index after the last item that was initialized in this buffer.
   @inlinable
-  internal func _initializePrefix(copying source: UnsafeBufferPointer<Element>) -> Int {
+  internal func _initializePrefix(
+    copying source: UnsafeBufferPointer<Element>
+  ) -> Int {
     if source.isEmpty { return 0 }
     precondition(source.count <= self.count)
     unsafe self.baseAddress.unsafelyUnwrapped.initialize(
       from: source.baseAddress.unsafelyUnwrapped, count: source.count)
     return source.count
+  }
+
+  @inlinable
+  internal func _initializePrefix(
+    copying source: UnsafeMutableBufferPointer<Element>
+  ) -> Int {
+    unsafe _initializePrefix(copying: UnsafeBufferPointer(source))
   }
 
   /// Initialize slots at the start of this buffer by copying data from `source`.


### PR DESCRIPTION
It looks like we need _at least four_ variants of each operation that transfers bulk data from one place to another, depending on what happens to the source container:

1. When the elements are copyable, we can borrow the source container and copy items out of it. (I'm using a `copying` label for this, as in `append(copying:)`)
2. We can move elements from the source into the target by _mutating_  the source container to empty it out. (I call this `append(moving:)` for now.)
3. We can move elements from the source into the target by entirely _consuming_ the source container. (`append(consuming:)`)
4. We have the classic RangeReplacementCollection operations (like `append(contentsOf:)`) that are declared to _take ownership_ of the source container (like the consuming case above), but they generally _copy_ items out of it without physically consuming anything (like the copying case above). These fundamentally rely on consuming/borrowing being a mostly irrelevant distinction for copyable entities; they cannot be replaced with any of the other three above without breaking source compatibility. (For example, they can be used to append a collection to itself -- a useful operation that none of the other flavors can directly support.)

We may need to add even more flavors. Given that noncopyable containers may not generally be sliceable, we might actually end up adding variants that explicitly operate on specific ranges in the source container.

- Take a range of items from a container and append them to the end _of the same container_ by copying them. (`append(copyingRange:)`?)
- Take a range of items from one container and append them to the end of another. (`append(copyingRange:in:)?`
- Move a range of items in a container to the end of the same. (`append(movingRange:)`?)
- Remove a range of items from one container and append them to the end of another. (`append(movingRange:in:)`?)

The case when the source and the target containers are the same is particularly interesting, as it is a very useful class of operation that we've never been able to _satisfyingly_ incorporate into classic (copyable) Swift. (`array.append(contentsOf: array)` technically works, but it implicitly forces a copy-on-write copy of the array storage, and that catches people off by surprise -- it's not a satisfying solution.) In the ownership model, the Law of Exclusivity requires forbids a borrow of `self` to be passed to a mutating method of the same entity -- so that case has to be supported by dedicated variants.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
