### PR TITLE
Add support for older builds of the 6.2 compiler

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Collections open source project
@@ -56,8 +56,6 @@ let availabilityMacros: KeyValuePairs<String, String> = [
   "SwiftStdlib 6.0": "macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0",
   "SwiftStdlib 6.1": "macOS 15.4, iOS 18.4, watchOS 11.4, tvOS 18.4, visionOS 2.4",
   "SwiftStdlib 6.2": "macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999",
-  "SwiftCompatibilitySpan 5.0": "macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.1",
-  "SwiftCompatibilitySpan 6.2": "macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0",
 ]
 
 let extraSettings: [SwiftSetting] = [

--- a/Sources/DequeModule/Deque+Container.swift
+++ b/Sources/DequeModule/Deque+Container.swift
@@ -20,13 +20,13 @@ extension Deque: RandomAccessContainer {
     _storage.value.borrowElement(at: index)
   }
 
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @lifetime(borrow self)
   public func nextSpan(after index: inout Int) -> Span<Element> {
     _storage.value.nextSpan(after: &index)
   }
 
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @lifetime(borrow self)
   public func previousSpan(before index: inout Int) -> Span<Element> {
     _storage.value.previousSpan(before: &index)

--- a/Sources/DequeModule/DynamicDeque.swift
+++ b/Sources/DequeModule/DynamicDeque.swift
@@ -33,13 +33,13 @@ public struct DynamicDeque<Element: ~Copyable>: ~Copyable {
 extension DynamicDeque: @unchecked Sendable where Element: Sendable & ~Copyable {}
 
 extension DynamicDeque: RandomAccessContainer where Element: ~Copyable {
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @lifetime(borrow self)
   public func nextSpan(after index: inout Int) -> Span<Element> {
     _storage.nextSpan(after: &index)
   }
 
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @lifetime(borrow self)
   public func previousSpan(before index: inout Int) -> Span<Element> {
     _storage.previousSpan(before: &index)

--- a/Sources/DequeModule/RigidDeque.swift
+++ b/Sources/DequeModule/RigidDeque.swift
@@ -61,7 +61,7 @@ extension RigidDeque where Element: ~Copyable {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension RigidDeque where Element: ~Copyable {
   @inlinable
   @lifetime(borrow self)
@@ -78,7 +78,7 @@ extension RigidDeque where Element: ~Copyable {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension RigidDeque: RandomAccessContainer, MutableContainer where Element: ~Copyable {
   @inlinable
   @lifetime(borrow self)

--- a/Sources/Future/Arrays/DynamicArray.swift
+++ b/Sources/Future/Arrays/DynamicArray.swift
@@ -74,7 +74,7 @@ extension DynamicArray /*where Element: Copyable*/ {
     self.append(copying: contents)
   }
 
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   @inline(__always)
   public init<C: Container<Element> & ~Copyable & ~Escapable>(
@@ -84,7 +84,7 @@ extension DynamicArray /*where Element: Copyable*/ {
     self.init(consuming: RigidArray(capacity: capacity, copying: contents))
   }
 
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   @inline(__always)
   public init<C: Container<Element> & Sequence<Element>>(
@@ -110,7 +110,7 @@ extension DynamicArray where Element: ~Copyable {
 //MARK: - Span creation
 
 extension DynamicArray where Element: ~Copyable {
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   public var span: Span<Element> {
     @lifetime(borrow self)
     @inlinable
@@ -118,8 +118,9 @@ extension DynamicArray where Element: ~Copyable {
       _storage.span
     }
   }
-  
-  @available(SwiftCompatibilitySpan 5.0, *)
+
+#if compiler(>=6.2) && $InoutLifetimeDependence
+  @available(SwiftStdlib 6.2, *)
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
     @inlinable
@@ -127,6 +128,16 @@ extension DynamicArray where Element: ~Copyable {
       _storage.mutableSpan
     }
   }
+#else
+  @available(SwiftStdlib 6.2, *)
+  public var mutableSpan: MutableSpan<Element> {
+    @lifetime(borrow self)
+    @inlinable
+    mutating get {
+      _storage.mutableSpan
+    }
+  }
+#endif
 }
 
 //MARK: RandomAccessContainer conformance
@@ -162,7 +173,7 @@ extension DynamicArray where Element: ~Copyable {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension DynamicArray: RandomAccessContainer where Element: ~Copyable {
   @inlinable
   @lifetime(borrow self)
@@ -181,21 +192,28 @@ extension DynamicArray: RandomAccessContainer where Element: ~Copyable {
 
 extension DynamicArray where Element: ~Copyable {
   @inlinable
+#if compiler(>=6.2) && $InoutLifetimeDependence
   @lifetime(&self)
+#else
+  @lifetime(borrow self)
+#endif
   public mutating func mutateElement(at index: Int) -> Inout<Element> {
     _storage.mutateElement(at: index)
   }
 
   @inlinable
-  @lifetime(&self)
   public mutating func swapAt(_ i: Int, _ j: Int) {
     _storage.swapAt(i, j)
   }
 }
 
 extension DynamicArray: MutableContainer where Element: ~Copyable {
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
+#if compiler(>=6.2) && $InoutLifetimeDependence
   @lifetime(&self)
+#else
+  @lifetime(borrow self)
+#endif
   public mutating func nextMutableSpan(after index: inout Int) -> MutableSpan<Element> {
     _storage.nextMutableSpan(after: &index)
   }
@@ -348,7 +366,7 @@ extension DynamicArray where Element: ~Copyable {
   ///   whether the element should be removed from the array.
   ///
   /// - Complexity: O(`count`)
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public mutating func removeAll<E: Error>(
     where shouldBeRemoved: (borrowing Element) throws(E) -> Bool
@@ -440,7 +458,7 @@ extension DynamicArray {
   ///
   /// - Complexity: O(`newElements.count`) when amortized over many
   ///     invocations on the same array.
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public mutating func append(copying newElements: Span<Element>) {
     _ensureFreeCapacity(newElements.count)
@@ -475,7 +493,7 @@ extension DynamicArray {
     }
   }
 
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   public mutating func _appendContainer<
     C: Container<Element> & ~Copyable & ~Escapable
   >(
@@ -499,7 +517,7 @@ extension DynamicArray {
   ///
   /// - Complexity: O(`newElements.count`), when amortized over many invocations
   ///    over the same array.
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public mutating func append<
     C: Container<Element> & ~Copyable & ~Escapable
@@ -519,7 +537,7 @@ extension DynamicArray {
   ///
   /// - Complexity: O(`newElements.count`), when amortized over many invocations
   ///    over the same array.
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public mutating func append<
     C: Container<Element> & Sequence<Element>
@@ -636,7 +654,7 @@ extension DynamicArray {
   ///
   /// - Complexity: O(*n* + *m*), where *n* is count of this array and
   ///     *m* is the count of `newElements`.
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @inlinable
   public mutating func insert(
     copying newElements: Span<Element>, at index: Int
@@ -677,7 +695,7 @@ extension DynamicArray {
       at: index, copying: newElements, newCount: newCount)
   }
 
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @inlinable
   internal mutating func _insertContainer<
     C: Container<Element> & ~Copyable & ~Escapable
@@ -711,7 +729,7 @@ extension DynamicArray {
   ///
   /// - Complexity: O(*n* + *m*), where *n* is count of this array and
   ///    *m* is the count of `newElements`.
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   @inline(__always)
   public mutating func insert<
@@ -742,7 +760,7 @@ extension DynamicArray {
   ///
   /// - Complexity: O(*n* + *m*), where *n* is count of this array and
   ///    *m* is the count of `newElements`.
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   @inline(__always)
   public mutating func insert<
@@ -850,7 +868,7 @@ extension DynamicArray {
   ///
   /// - Complexity: O(*n* + *m*), where *n* is count of this array and
   ///   *m* is the count of `newElements`.
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @inlinable
   public mutating func replaceSubrange(
     _ subrange: Range<Int>,
@@ -898,7 +916,7 @@ extension DynamicArray {
       subrange, copyingCollection: newElements, newCount: c)
   }
 
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @inlinable
   public mutating func _replaceSubrange<
     C: Container<Element> & ~Copyable & ~Escapable
@@ -937,7 +955,7 @@ extension DynamicArray {
   ///
   /// - Complexity: O(*n* + *m*), where *n* is count of this array and
   ///   *m* is the count of `newElements`.
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @inlinable
   @inline(__always)
   public mutating func replaceSubrange<
@@ -973,7 +991,7 @@ extension DynamicArray {
   ///
   /// - Complexity: O(*n* + *m*), where *n* is count of this array and
   ///   *m* is the count of `newElements`.
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @inlinable
   @inline(__always)
   public mutating func replaceSubrange<

--- a/Sources/Future/Arrays/NewArray.swift
+++ b/Sources/Future/Arrays/NewArray.swift
@@ -59,7 +59,7 @@ extension NewArray: RandomAccessCollection, MutableCollection {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension NewArray: RandomAccessContainer, MutableContainer {
   @lifetime(borrow self)
   public func borrowElement(at index: Int) -> Borrow<Element> {
@@ -76,13 +76,21 @@ extension NewArray: RandomAccessContainer, MutableContainer {
     return _storage.value.previousSpan(before: &index)
   }
 
+#if compiler(>=6.2) && $InoutLifetimeDependence
   @lifetime(&self)
+#else
+  @lifetime(borrow self)
+#endif
   public mutating func mutateElement(at index: Int) -> Inout<Element> {
     _ensureUnique()
     return _storage.value.mutateElement(at: index)
   }
 
+#if compiler(>=6.2) && $InoutLifetimeDependence
   @lifetime(&self)
+#else
+  @lifetime(borrow self)
+#endif
   public mutating func nextMutableSpan(after index: inout Int) -> MutableSpan<Element> {
     _ensureUnique()
     return _storage.value.nextMutableSpan(after: &index)
@@ -172,7 +180,7 @@ extension NewArray {
     self._storage.value.append(newElement)
   }
 
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @inlinable
   public mutating func insert(_ item: consuming Element, at index: Int) {
     precondition(index >= 0 && index <= count)
@@ -211,7 +219,7 @@ extension NewArray {
   }
 
 
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @inlinable
   public mutating func removeLast() -> Element {
     precondition(count > 0, "Cannot remove last element from empty array")

--- a/Sources/Future/Containers/BidirectionalContainer.swift
+++ b/Sources/Future/Containers/BidirectionalContainer.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 public protocol BidirectionalContainer<Element>: Container, ~Copyable, ~Escapable {
   func index(before i: Index) -> Index
   func formIndex(before i: inout Index)
@@ -18,7 +18,7 @@ public protocol BidirectionalContainer<Element>: Container, ~Copyable, ~Escapabl
   func previousSpan(before index: inout Index) -> Span<Element>
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension BidirectionalContainer where Self: ~Copyable & ~Escapable {
   @inlinable
   @lifetime(borrow self)

--- a/Sources/Future/Containers/Container.swift
+++ b/Sources/Future/Containers/Container.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 public protocol Container<Element>: ~Copyable, ~Escapable {
   associatedtype Element: ~Copyable/* & ~Escapable*/
   associatedtype Index: Comparable
@@ -30,7 +30,7 @@ public protocol Container<Element>: ~Copyable, ~Escapable {
     limitedBy limit: Index
   )
 
-  #if compiler(>=9999) // FIXME: We can't do this yet
+  #if compiler(>=9999) // FIXME: Needs borrow accessors
   subscript(index: Index) -> Element { borrow }
   #else
   @lifetime(borrow self)
@@ -83,7 +83,7 @@ public protocol Container<Element>: ~Copyable, ~Escapable {
   func _customLastIndexOfEquatableElement(_ element: borrowing Element) -> Index??
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: ~Copyable & ~Escapable {
   @inlinable
   public func _defaultIndex(_ i: Index, advancedBy distance: Int) -> Index {
@@ -171,7 +171,7 @@ extension Container where Self: ~Copyable & ~Escapable {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: ~Copyable & ~Escapable {
   @inlinable
   public var isEmpty: Bool {
@@ -215,13 +215,13 @@ extension Container where Self: ~Copyable & ~Escapable {
   public func _customLastIndexOfEquatableElement(_ element: borrowing Element) -> Index?? { nil }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: Sequence {
   @inlinable
   public var underestimatedCount: Int { count }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: Collection {
   // Resolve ambiguities between default implementations between Collection
   // and Container.
@@ -256,7 +256,7 @@ extension Container where Self: Collection {
   public func _customLastIndexOfEquatableElement(_ element: borrowing Element) -> Index?? { nil }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: ~Copyable & ~Escapable {
   @inlinable
   public subscript(index: Index) -> Element {
@@ -269,7 +269,7 @@ extension Container where Self: ~Copyable & ~Escapable {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: ~Copyable & ~Escapable {
   @inlinable
   @lifetime(borrow self)
@@ -287,7 +287,7 @@ extension Container where Self: ~Copyable & ~Escapable {
 
 
 #if false // DEMO
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: ~Copyable & ~Escapable {
   // This is just to demo the bulk iteration model
   func forEachSpan<E: Error>(_ body: (Span<Element>) throws(E) -> Void) throws(E) {

--- a/Sources/Future/Containers/ContainerAlgorithms.swift
+++ b/Sources/Future/Containers/ContainerAlgorithms.swift
@@ -11,7 +11,7 @@
 
 //MARK: - firstIndex(where:)
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: ~Copyable & ~Escapable {
   @inlinable
   internal func _containerFirstIndex<E: Error>(
@@ -55,7 +55,7 @@ extension Container where Self: ~Copyable & ~Escapable {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: Collection {
   /// Returns the first index that addresses an element of the container that
   /// satisfies the given predicate.
@@ -83,7 +83,7 @@ extension Container where Self: Collection {
 
 //MARK: - firstIndex(of:)
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Element: Equatable {
   @inlinable
   internal func _containerFirstIndex(of element: Element) -> Index? {
@@ -110,7 +110,7 @@ extension Container where Element: Equatable {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: Collection, Element: Equatable {
   /// Returns the first index where the specified value appears in the container.
   ///
@@ -131,7 +131,7 @@ extension Container where Self: Collection, Element: Equatable {
 
 //MARK: - lastIndex(where:)
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension BidirectionalContainer where Self: ~Copyable & ~Escapable {
   @inlinable
   internal func _containerLastIndex<E: Error>(
@@ -175,7 +175,7 @@ extension BidirectionalContainer where Self: ~Copyable & ~Escapable {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension BidirectionalContainer where Self: BidirectionalCollection {
   /// Returns the first index that addresses an element of the container that
   /// satisfies the given predicate.
@@ -203,7 +203,7 @@ extension BidirectionalContainer where Self: BidirectionalCollection {
 
 //MARK: - lastIndex(of:)
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension BidirectionalContainer where Element: Equatable {
   @inlinable
   internal func _containerLastIndex(of element: Element) -> Index? {
@@ -230,7 +230,7 @@ extension BidirectionalContainer where Element: Equatable {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension BidirectionalContainer where Self: BidirectionalCollection, Element: Equatable {
   /// Returns the first index where the specified value appears in the container.
   ///
@@ -251,7 +251,7 @@ extension BidirectionalContainer where Self: BidirectionalCollection, Element: E
 
 //MARK: - elementsEqual(_:,by:)
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: ~Copyable & ~Escapable {
   @inlinable
   internal func _spanwiseZip<Other: Container & ~Copyable & ~Escapable, State: ~Copyable, E: Error>(
@@ -345,7 +345,7 @@ extension Container where Self: ~Copyable & ~Escapable {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: Sequence {
   /// Returns a Boolean value indicating whether this container and another
   /// container contain equivalent elements in the same order, using the given
@@ -379,7 +379,7 @@ extension Container where Self: Sequence {
 //MARK: - elementsEqual(_:)
 
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: ~Copyable & ~Escapable, Element: Equatable {
   /// Returns a Boolean value indicating whether this container and another
   /// container contain the same elements in the same order.
@@ -398,7 +398,7 @@ extension Container where Self: ~Copyable & ~Escapable, Element: Equatable {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: Sequence, Element: Equatable {
   /// Returns a Boolean value indicating whether this container and another
   /// container contain the same elements in the same order.

--- a/Sources/Future/Containers/ContiguousContainer.swift
+++ b/Sources/Future/Containers/ContiguousContainer.swift
@@ -48,8 +48,10 @@ where Self: ~Copyable & ~Escapable, Index == Int {
 @available(SwiftStdlib 6.2, *)
 extension Array: ContiguousContainer {}
 
+#if compiler(>=6.2) && $InoutLifetimeDependence // FIXME: Crashes older 6.2 compilers.
 @available(SwiftStdlib 6.2, *)
 extension ContiguousArray: ContiguousContainer {}
+#endif
 
 @available(SwiftStdlib 6.2, *)
 extension CollectionOfOne: ContiguousContainer {}

--- a/Sources/Future/Containers/MutableContainer.swift
+++ b/Sources/Future/Containers/MutableContainer.swift
@@ -9,17 +9,26 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 public protocol MutableContainer<Element>: Container, ~Copyable, ~Escapable {
-#if compiler(>=9999) // FIXME: We can't do this yet
+#if compiler(>=9999) // FIXME: Needs borrow accessors
   subscript(index: Index) -> Element { borrow mutate }
 #else
+
+#if compiler(>=6.2) && $InoutLifetimeDependence
   @lifetime(&self)
+#else
+  @lifetime(borrow self)
+#endif
   @lifetime(self: copy self)
   mutating func mutateElement(at index: Index) -> Inout<Element>
 #endif
 
+#if compiler(>=6.2) && $InoutLifetimeDependence
   @lifetime(&self)
+#else
+  @lifetime(borrow self)
+#endif
   @lifetime(self: copy self)
   mutating func nextMutableSpan(after index: inout Index) -> MutableSpan<Element>
 
@@ -29,39 +38,86 @@ public protocol MutableContainer<Element>: Container, ~Copyable, ~Escapable {
   mutating func swapAt(_ i: Index, _ j: Index)
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension MutableContainer where Self: ~Copyable & ~Escapable {
-  #if false // Hm...
+#if false  // FIXME: This has flagrant exclusivity violations.
+#if compiler(>=6.2) && $InoutLifetimeDependence
   @lifetime(&self)
-  mutating func nextMutableSpan(
+#else
+  @lifetime(borrow self)
+#endif
+  public mutating func nextMutableSpan(
     after index: inout Index, maximumCount: Int
   ) -> MutableSpan<Element> {
-    let original = index
-    var span = self.nextMutableSpan(after: &index)
-    if span.count > maximumCount {
-      span = span.extracting(first: maximumCount)
-      // Index remains within the same span, so offseting it is expected to be quick
-      index = self.index(original, offsetBy: maximumCount)
+    let start = index
+    do {
+      let span = self.nextMutableSpan(after: &index)
+      guard span.count > maximumCount else { return span }
     }
-    return span
+    // Index remains within the same span, so offseting it is expected to be quick
+    let end = self.index(start, offsetBy: maximumCount)
+    index = start
+    var span = self.nextMutableSpan(after: &index)
+    let extract = span.extracting(first: maximumCount) // FIXME: Oops
+    index = end
+    return extract
   }
-  #endif
+#endif
 
+  @lifetime(self: copy self)
+  public mutating func withNextMutableSpan<
+    E: Error, R: ~Copyable
+  >(
+    after index: inout Index, maximumCount: Int,
+    body: (inout MutableSpan<Element>) throws(E) -> R
+  ) throws(E) -> R {
+    // FIXME: We don't want this to be closure-based, but MutableSpan cannot be sliced "in place".
+    let start = index
+    do {
+      var span = self.nextMutableSpan(after: &index)
+      if span.count <= maximumCount {
+        return try body(&span)
+      }
+    }
+    // Try again, but figure out what our target index is first.
+    // Index remains within the same span, so offseting it is expected to be quick
+    index = self.index(start, offsetBy: maximumCount)
+    var i = start
+    var span = self.nextMutableSpan(after: &i)
+    var extract = span.extracting(first: maximumCount)
+    return try body(&extract)
+  }
+
+#if compiler(>=6.2) && $InoutLifetimeDependence
   @inlinable
   public subscript(index: Index) -> Element {
     @lifetime(borrow self)
     unsafeAddress {
       unsafe borrowElement(at: index)._pointer
     }
-    
+
     @lifetime(&self)
     unsafeMutableAddress {
       unsafe mutateElement(at: index)._pointer
     }
   }
+#else
+  @inlinable
+  public subscript(index: Index) -> Element {
+    @lifetime(borrow self)
+    unsafeAddress {
+      unsafe borrowElement(at: index)._pointer
+    }
+
+    @lifetime(borrow self)
+    unsafeMutableAddress {
+      unsafe mutateElement(at: index)._pointer
+    }
+  }
+#endif
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension MutableContainer where Self: ~Copyable & ~Escapable {
   /// Moves all elements satisfying `isSuffixElement` into a suffix of the
   /// container, returning the start position of the resulting suffix.

--- a/Sources/Future/Containers/MutableContainer.swift
+++ b/Sources/Future/Containers/MutableContainer.swift
@@ -64,6 +64,7 @@ extension MutableContainer where Self: ~Copyable & ~Escapable {
   }
 #endif
 
+#if compiler(>=6.2) && $InoutLifetimeDependence // FIXME: Crashes older 6.2 compilers.
   @lifetime(self: copy self)
   public mutating func withNextMutableSpan<
     E: Error, R: ~Copyable
@@ -87,6 +88,7 @@ extension MutableContainer where Self: ~Copyable & ~Escapable {
     var extract = span.extracting(first: maximumCount)
     return try body(&extract)
   }
+#endif
 
 #if compiler(>=6.2) && $InoutLifetimeDependence
   @inlinable

--- a/Sources/Future/Containers/RandomAccessContainer.swift
+++ b/Sources/Future/Containers/RandomAccessContainer.swift
@@ -9,11 +9,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 public protocol RandomAccessContainer<Element>
 : BidirectionalContainer, ~Copyable, ~Escapable {}
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension RandomAccessContainer
 where Self: ~Copyable & ~Escapable, Index: Strideable, Index.Stride == Int
 {
@@ -83,7 +83,7 @@ where Self: ~Copyable & ~Escapable, Index: Strideable, Index.Stride == Int
 
 // Disambiguate parallel extensions on RandomAccessContainer and RandomAccessCollection
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension RandomAccessCollection
 where
   Self: RandomAccessContainer,

--- a/Sources/Future/Containers/RepeatingContainer.swift
+++ b/Sources/Future/Containers/RepeatingContainer.swift
@@ -53,7 +53,7 @@ extension RepeatingContainer where Element: ~Copyable {
 }
 
 #if false // FIXME: This is what we'd want
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension RepeatingContainer: RandomAccessContainer where Element: ~Copyable {
   @lifetime(borrow self)
   public func borrowElement(at index: Int) -> Borrow<Element> {
@@ -85,7 +85,7 @@ extension RepeatingContainer: RandomAccessContainer where Element: ~Copyable {
   }
 }
 #else
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension RepeatingContainer: RandomAccessContainer where Element: ~Copyable {
   @lifetime(borrow self)
   public func borrowElement(at index: Int) -> Borrow<Element> {

--- a/Sources/Future/Span/LifetimeOverride.swift
+++ b/Sources/Future/Span/LifetimeOverride.swift
@@ -53,7 +53,11 @@ public func _overrideLifetime<
 @_unsafeNonescapableResult
 @_alwaysEmitIntoClient
 @_transparent
+#if compiler(>=6.2) && $InoutLifetimeDependence
 @lifetime(&source)
+#else
+@lifetime(borrow source)
+#endif
 public func _overrideLifetime<
   T: ~Copyable & ~Escapable,
   U: ~Copyable & ~Escapable

--- a/Sources/Future/Span/SpanExtensions.swift
+++ b/Sources/Future/Span/SpanExtensions.swift
@@ -13,7 +13,7 @@
 @usableFromInline
 internal let immortalThing: [Void] = []
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Span where Element: ~Copyable {
   public static var empty: Span {
     @lifetime(immortal)
@@ -32,7 +32,7 @@ extension Span where Element: ~Copyable {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Span where Element: Equatable {
   /// Returns a Boolean value indicating whether this and another span
   /// contain equal elements in the same order.

--- a/Sources/Future/Span/UnsafeBufferPointer+Additions.swift
+++ b/Sources/Future/Span/UnsafeBufferPointer+Additions.swift
@@ -96,7 +96,7 @@ extension UnsafeMutableBufferPointer {
   /// The `source` span must fit entirely in `self`.
   ///
   /// - Returns: The index after the last item that was initialized in this buffer.
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @inlinable
   internal func _initializePrefix(copying source: Span<Element>) -> Int {
     unsafe source.withUnsafeBufferPointer { unsafe self._initializePrefix(copying: $0) }
@@ -114,7 +114,7 @@ extension UnsafeMutableBufferPointer {
   ///
   /// - Returns: A pair of values `(count, end)`, where `count` is the number of items that were
   ///    successfully initialized, and `end` is the index into `items` after the last copied item.
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @inlinable
   internal func _initializePrefix<
     C: Container<Element> & ~Copyable & ~Escapable
@@ -157,7 +157,7 @@ extension UnsafeMutableBufferPointer {
   /// entirely uninitialized.
   ///
   /// The count of `span` must not be greater than `self.count`.
-  @available(SwiftCompatibilitySpan 5.0, *)
+  @available(SwiftStdlib 6.2, *)
   @inlinable
   internal mutating func _initializeAndDropPrefix(copying span: Span<Element>) {
     unsafe span.withUnsafeBufferPointer { buffer in

--- a/Sources/Future/Tools/Inout.swift
+++ b/Sources/Future/Tools/Inout.swift
@@ -41,10 +41,14 @@ public struct Inout<T: ~Copyable>: ~Copyable, ~Escapable {
   ///                            instance of type 'T'.
   /// - Parameter owner: The owning instance that this 'Inout' instance's
   ///                    lifetime is based on.
-  @lifetime(&owner)
   @unsafe
   @_alwaysEmitIntoClient
   @_transparent
+#if compiler(>=6.2) && $InoutLifetimeDependence
+  @lifetime(&owner)
+#else
+  @lifetime(borrow owner)
+#endif
   public init<Owner: ~Copyable & ~Escapable>(
     unsafeAddress: UnsafeMutablePointer<T>,
     mutating owner: inout Owner

--- a/Tests/CollectionsTestSupportTests/MinimalTypeConformances.swift
+++ b/Tests/CollectionsTestSupportTests/MinimalTypeConformances.swift
@@ -47,7 +47,7 @@ final class MinimalTypeTests: CollectionTestCase {
 
   #if false // FIXME: Track down compiler crash
   func testTestContainer() {
-    guard #available(SwiftCompatibilitySpan 5.0, *) else { return }
+    guard #available(SwiftStdlib 6.2, *) else { return }
     let a = TestContainer(
       contents: RigidArray(count: 100, initializedWith: { $0 }),
       spanCounts: [3, 1, 7])

--- a/Tests/CollectionsTestSupportTests/StaccatoContainerTests.swift
+++ b/Tests/CollectionsTestSupportTests/StaccatoContainerTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import _CollectionsTestSupport
 import Future
 
+@available(SwiftStdlib 6.2, *)
 class StaccatoContainerTests: CollectionTestCase {
   func checkStriding<C: Container & ~Copyable & ~Escapable>(
     _ container: borrowing C,

--- a/Tests/FutureTests/ArrayTests/DynamicArrayTests.swift
+++ b/Tests/FutureTests/ArrayTests/DynamicArrayTests.swift
@@ -14,6 +14,7 @@ import _CollectionsTestSupport
 import Future
 import Synchronization
 
+@available(SwiftStdlib 6.2, *)
 class DynamicArrayTests: CollectionTestCase {
   func test_validate_Container() {
     withSomeArrayLayouts("layout", ofCapacities: [0, 10, 100]) { layout in

--- a/Tests/FutureTests/ArrayTests/RigidArrayTests.swift
+++ b/Tests/FutureTests/ArrayTests/RigidArrayTests.swift
@@ -13,7 +13,7 @@ import XCTest
 import _CollectionsTestSupport
 import Future
 
-@available(SwiftStdlib 6.0, *)
+@available(SwiftStdlib 6.2, *)
 class RigidArrayTests: CollectionTestCase {
   func test_validate_Container() {
     withSomeArrayLayouts("layout", ofCapacities: [0, 10, 100]) { layout in

--- a/Tests/FutureTests/ContiguousStorageTests.swift
+++ b/Tests/FutureTests/ContiguousStorageTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 import Future
 
+@available(SwiftStdlib 6.2, *)
 final class ContiguousStorageTests: XCTestCase {
 
   @available(SwiftStdlib 6.2, *)

--- a/Tests/_CollectionsTestSupport/AssertionContexts/Assertions+Containers.swift
+++ b/Tests/_CollectionsTestSupport/AssertionContexts/Assertions+Containers.swift
@@ -12,7 +12,7 @@
 
 import Future
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 public func expectContainersWithEquivalentElements<
   C1: Container & ~Copyable & ~Escapable,
   C2: Container & ~Copyable & ~Escapable
@@ -32,7 +32,7 @@ public func expectContainersWithEquivalentElements<
 }
 
 /// Check if `left` and `right` contain equal elements in the same order.
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 public func expectContainersWithEqualElements<
   Element: Equatable,
   C1: Container<Element> & ~Copyable & ~Escapable,
@@ -52,7 +52,7 @@ public func expectContainersWithEqualElements<
 }
 
 /// Check if `left` and `right` contain equal elements in the same order.
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 public func expectContainerContents<
   Element: Equatable,
   C1: Container<Element> & ~Copyable & ~Escapable,
@@ -92,7 +92,7 @@ public func expectContainerContents<
 }
 
 /// Check if `left` and `right` contain equal elements in the same order.
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 public func expectContainerContents<
   C1: Container & ~Copyable & ~Escapable,
   C2: Collection,

--- a/Tests/_CollectionsTestSupport/ConformanceCheckers/CheckContainer.swift
+++ b/Tests/_CollectionsTestSupport/ConformanceCheckers/CheckContainer.swift
@@ -12,7 +12,7 @@
 import XCTest
 import Future
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension Container where Self: ~Copyable & ~Escapable {
   @inlinable
   internal func _indicesByIndexAfter() -> [Index] {
@@ -37,7 +37,7 @@ extension Container where Self: ~Copyable & ~Escapable {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 @inlinable
 public func checkContainer<
   C: Container & ~Copyable & ~Escapable,
@@ -55,7 +55,7 @@ public func checkContainer<
     file: file, line: line)
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 @inlinable
 public func checkContainer<
   C: Container & ~Copyable & ~Escapable,

--- a/Tests/_CollectionsTestSupport/MinimalTypes/StaccatoContainer.swift
+++ b/Tests/_CollectionsTestSupport/MinimalTypes/StaccatoContainer.swift
@@ -80,7 +80,7 @@ extension StaccatoContainer where Element: ~Copyable {
   }
 }
 
-@available(SwiftCompatibilitySpan 5.0, *)
+@available(SwiftStdlib 6.2, *)
 extension StaccatoContainer: Container where Element: ~Copyable {
   public func formIndex(_ i: inout Index, offsetBy distance: inout Int, limitedBy limit: Index) {
     precondition(i >= startIndex && i <= endIndex)


### PR DESCRIPTION
Rip out all traces of SwiftCompatibilitySpan availability; it isn't actually functional in 6.2.

Older compiler builds seem to struggle with slightly more complex mutating dependencies and Container protocol requirements that have defaults on RandomAccessContainer.

The tests are still passing, which is a good sign.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
