### PR TITLE
Install swiftmodules with full module triple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,6 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 See https://swift.org/LICENSE.txt for license information
 #]]
 
-if(POLICY CMP0091)
-  cmake_policy(SET CMP0091 NEW)
-endif()
-
 cmake_minimum_required(VERSION 3.16)
 project(SwiftCollections
   LANGUAGES C Swift)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ project(SwiftCollections
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
+include(PlatformInfo)
+
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 set(CMAKE_Swift_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
 

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -40,13 +40,12 @@ if(COLLECTIONS_SINGLE_MODULE)
           LIBRARY DESTINATION lib/swift_static/${swift_os}
           RUNTIME DESTINATION bin)
     endif()
-    get_swift_host_arch(swift_arch)
     install(FILES $<TARGET_PROPERTY:${COLLECTIONS_MODULE_NAME},Swift_MODULE_DIRECTORY>/${COLLECTIONS_MODULE_NAME}.swiftdoc
       DESTINATION lib/${swift}/${swift_os}/${COLLECTIONS_MODULE_NAME}.swiftmodule
-      RENAME ${swift_arch}.swiftdoc)
+      RENAME ${SwiftCollections_MODULE_TRIPLE}.swiftdoc)
     install(FILES $<TARGET_PROPERTY:${COLLECTIONS_MODULE_NAME},Swift_MODULE_DIRECTORY>/${COLLECTIONS_MODULE_NAME}.swiftmodule
       DESTINATION lib/${swift}/${swift_os}/${COLLECTIONS_MODULE_NAME}.swiftmodule
-      RENAME ${swift_arch}.swiftmodule)
+      RENAME ${SwiftCollections_MODULE_TRIPLE}.swiftmodule)
   else()
     _install_target(${COLLECTIONS_MODULE_NAME})
   endif()

--- a/cmake/modules/PlatformInfo.cmake
+++ b/cmake/modules/PlatformInfo.cmake
@@ -1,0 +1,24 @@
+#[[
+This source file is part of the Swift Collections Open Source Project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+set(target_info_cmd "${CMAKE_Swift_COMPILER}" -print-target-info)
+if(CMAKE_Swfit_COMPILER_TARGET)
+  list(APPEND target_info_cmd -target ${CMAKE_Swift_COMPILER_TARGET})
+endif()
+execute_process(COMMAND ${target_info_cmd} OUTPUT_VARIABLE target_info_json)
+message(CONFIGURE_LOG "Swift target info: ${target_info_cmd}\n"
+"${target_info_json}")
+
+if(NOT SwiftCollections_MODULE_TRIPLE)
+  string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
+  set(SwiftCollections_MODULE_TRIPLE "${module_triple}" CACHE STRING "Triple used for installed swift{doc,module, interface} files")
+  mark_as_advanced(SwiftCollections_MODULE_TRIPLE)
+
+  message(CONFIGURE_LOG "Swift module triple: ${module_triple}")
+endif()

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -7,53 +7,6 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 See https://swift.org/LICENSE.txt for license information
 #]]
 
-# Returns the architecture name in a variable
-#
-# Usage:
-#   get_swift_host_arch(result_var_name)
-#
-# Sets ${result_var_name} with the converted architecture name derived from
-# CMAKE_SYSTEM_PROCESSOR.
-function(get_swift_host_arch result_var_name)
-  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
-    set("${result_var_name}" "x86_64" PARENT_SCOPE)
-  elseif ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "AArch64|aarch64|arm64|ARM64")
-    if(CMAKE_SYSTEM_NAME MATCHES Darwin)
-      set("${result_var_name}" "arm64" PARENT_SCOPE)
-    else()
-      set("${result_var_name}" "aarch64" PARENT_SCOPE)
-    endif()
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64")
-    set("${result_var_name}" "powerpc64" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
-    set("${result_var_name}" "powerpc64le" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
-    set("${result_var_name}" "s390x" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv6l")
-    set("${result_var_name}" "armv6" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l")
-    set("${result_var_name}" "armv7" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a")
-    set("${result_var_name}" "armv7" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "amd64")
-    set("${result_var_name}" "amd64" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64")
-    set("${result_var_name}" "x86_64" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "IA64")
-    set("${result_var_name}" "itanium" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86")
-    set("${result_var_name}" "i686" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
-    set("${result_var_name}" "i686" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "wasm32")
-    set("${result_var_name}" "wasm32" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "wasm64")
-    set("${result_var_name}" "wasm64" PARENT_SCOPE)
-  else()
-    message(FATAL_ERROR "Unrecognized architecture on host system: ${CMAKE_SYSTEM_PROCESSOR}")
-  endif()
-endfunction()
-
 # Returns the os name in a variable
 #
 # Usage:
@@ -89,7 +42,6 @@ function(_install_target module)
     return()
   endif()
 
-  get_swift_host_arch(swift_arch)
   get_target_property(module_name ${module} Swift_MODULE_NAME)
   if(NOT module_name)
     set(module_name ${module})
@@ -97,8 +49,9 @@ function(_install_target module)
 
   install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
     DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
-    RENAME ${swift_arch}.swiftdoc)
+    RENAME ${SwiftCollections_MODULE_TRIPLE}.swiftdoc)
+
   install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
     DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
-    RENAME ${swift_arch}.swiftmodule)
+    RENAME ${SwiftCollections_MODULE_TRIPLE}.swiftmodule)
 endfunction()


### PR DESCRIPTION
This cleans up how the CMake build of Swift-Collections installs swiftmodules to use the swift module triple expected by the compiler for a given target triple instead of trying to recreate the correct architecture name in CMake. The existing computation is incorrect for modules building for x86_64 FreeBSD machines, causing swift-foundation to fail to build. Letting the compiler specify what it expects the module triple to be for a given target triple will be more robust.

resolves: https://github.com/swiftlang/swift-foundation/issues/1230