### PR TITLE
[Rope] Resolve deprecation warnings on `String.Index._description`

### DIFF
--- a/Tests/RopeModuleTests/TestBigString.swift
+++ b/Tests/RopeModuleTests/TestBigString.swift
@@ -171,7 +171,7 @@ class TestBigString: CollectionTestCase {
       guard i1 < flat.endIndex, i2 < big.endIndex else { continue }
       let c1 = flat[i1]
       let c2 = big[i2]
-      expectEqual(c1, c2, "i: \(i), i1: \(i1._description), i2: \(i2)", file: file, line: line)
+      expectEqual(c1, c2, "i: \(i), i1: \(i1), i2: \(i2)", file: file, line: line)
     }
 
     for i in 0 ..< c {
@@ -179,7 +179,7 @@ class TestBigString: CollectionTestCase {
       let i2 = indices2[i]
       let d1 = flat.utf8.distance(from: flat.startIndex, to: i1)
       let d2 = big.utf8.distance(from: big.startIndex, to: i2)
-      expectEqual(d2, d1, "i: \(i), i1: \(i1._description), i2: \(i2)", file: file, line: line)
+      expectEqual(d2, d1, "i: \(i), i1: \(i1), i2: \(i2)", file: file, line: line)
     }
     return (indices1, indices2)
   }
@@ -221,7 +221,7 @@ class TestBigString: CollectionTestCase {
       guard i1 < flat.endIndex, i2 < big.endIndex else { continue }
       let c1 = flat.unicodeScalars[i1]
       let c2 = big.unicodeScalars[i2]
-      expectEqual(c1, c2, "i: \(i), i1: \(i1._description), i2: \(i2)", file: file, line: line)
+      expectEqual(c1, c2, "i: \(i), i1: \(i1), i2: \(i2)", file: file, line: line)
     }
 
     for i in 0 ..< c {
@@ -229,7 +229,7 @@ class TestBigString: CollectionTestCase {
       let i2 = indices2[i]
       let d1 = flat.utf8.distance(from: flat.startIndex, to: i1)
       let d2 = big.utf8.distance(from: big.startIndex, to: i2)
-      expectEqual(d2, d1, "i: \(i), i1: \(i1._description), i2: \(i2)", file: file, line: line)
+      expectEqual(d2, d1, "i: \(i), i1: \(i1), i2: \(i2)", file: file, line: line)
     }
     return (indices1, indices2)
   }
@@ -271,7 +271,7 @@ class TestBigString: CollectionTestCase {
       guard i1 < flat.endIndex, i2 < big.endIndex else { continue }
       let c1 = flat.utf8[i1]
       let c2 = big.utf8[i2]
-      expectEqual(c1, c2, "i: \(i), i1: \(i1._description), i2: \(i2)", file: file, line: line)
+      expectEqual(c1, c2, "i: \(i), i1: \(i1), i2: \(i2)", file: file, line: line)
     }
 
     for i in 0 ..< c {
@@ -279,7 +279,7 @@ class TestBigString: CollectionTestCase {
       let i2 = indices2[i]
       let d1 = flat.utf8.distance(from: flat.startIndex, to: i1)
       let d2 = big.utf8.distance(from: big.startIndex, to: i2)
-      expectEqual(d2, d1, "i: \(i), i1: \(i1._description), i2: \(i2)", file: file, line: line)
+      expectEqual(d2, d1, "i: \(i), i1: \(i1), i2: \(i2)", file: file, line: line)
     }
     return (indices1, indices2)
   }
@@ -321,7 +321,7 @@ class TestBigString: CollectionTestCase {
       guard i1 < flat.endIndex, i2 < big.endIndex else { continue }
       let c1 = flat.utf16[i1]
       let c2 = big.utf16[i2]
-      expectEqual(c1, c2, "i: \(i), i1: \(i1._description), i2: \(i2)", file: file, line: line)
+      expectEqual(c1, c2, "i: \(i), i1: \(i1), i2: \(i2)", file: file, line: line)
     }
 
     for i in 0 ..< c {
@@ -329,7 +329,7 @@ class TestBigString: CollectionTestCase {
       let i2 = indices2[i]
       let d1 = flat.utf16.distance(from: flat.startIndex, to: i1)
       let d2 = big.utf16.distance(from: big.startIndex, to: i2)
-      expectEqual(d2, d1, "i: \(i), i1: \(i1._description), i2: \(i2)", file: file, line: line)
+      expectEqual(d2, d1, "i: \(i), i1: \(i1), i2: \(i2)", file: file, line: line)
     }
     return (indices1, indices2)
   }


### PR DESCRIPTION
On recent enough stdlibs, we can now just print the index directly to get the same effect.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
