### PR TITLE
fix comment for OrderedSet.appending(contentsOf:)

### DIFF
--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial SetAlgebra union.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial SetAlgebra union.swift
@@ -87,7 +87,7 @@ extension OrderedSet {
   ///
   ///     let a: OrderedSet = [1, 2, 3, 4]
   ///     let b: OrderedSet = [0, 2, 4, 6]
-  ///     a.union(b) // [1, 2, 3, 4, 0, 6]
+  ///     a.appending(contentsOf: b) // [1, 2, 3, 4, 0, 6]
   ///
   /// This is functionally equivalent to `self.union(elements)`, but it's
   /// more explicit about how the new members are ordered in the new set.


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Collections!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

I thought the example code for `OrderedSet.appending(contentsOf:)` should be `a.appending(contentsOf: b)` instead of `a.union(b)`. Please close this PR if this is intended.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
