### PR TITLE
Fix CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ if(NOT SWIFT_SYSTEM_NAME)
   endif()
 endif()
 
-include(PlatformInfo)
-
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 set(CMAKE_Swift_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
 

--- a/cmake/modules/PlatformInfo.cmake
+++ b/cmake/modules/PlatformInfo.cmake
@@ -8,7 +8,7 @@ See https://swift.org/LICENSE.txt for license information
 #]]
 
 set(target_info_cmd "${CMAKE_Swift_COMPILER}" -print-target-info)
-if(CMAKE_Swfit_COMPILER_TARGET)
+if(CMAKE_Swift_COMPILER_TARGET)
   list(APPEND target_info_cmd -target ${CMAKE_Swift_COMPILER_TARGET})
 endif()
 execute_process(COMMAND ${target_info_cmd} OUTPUT_VARIABLE target_info_json)


### PR DESCRIPTION
Fixing two issues in the CMake build:
 - There was a typo in the CMake `PlatformInfo.cmake` misspelling `CMAKE_Swift_COMPILER_TARGET`
 - It looks like there was a merge conflict where the resolution ended up including the PlatformInfo module twice. Deleting one of them.