### PR TITLE
Fix API documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ The package currently provides the following implementations:
 
 - [`TreeSet`][TreeSet] and [`TreeDictionary`][TreeDictionary], persistent hashed collections implementing Compressed Hash-Array Mapped Prefix Trees (CHAMP). These work similar to the standard `Set` and `Dictionary`, but they excel at use cases that mutate shared copies, offering dramatic memory savings and radical time improvements.  
 
-[BitSet]: https://swiftpackageindex.com/apple/swift-collections/1.1.0/documentation/bitcollections/bitset
-[BitArray]: https://swiftpackageindex.com/apple/swift-collections/1.1.0/documentation/bitcollections/bitarray
-[Deque]: https://swiftpackageindex.com/apple/swift-collections/1.1.0/documentation/dequemodule/deque
-[Heap]: https://swiftpackageindex.com/apple/swift-collections/1.1.0/documentation/heapmodule/heap
-[OrderedSet]: https://swiftpackageindex.com/apple/swift-collections/1.1.0/documentation/orderedcollections/orderedset
-[OrderedDictionary]: https://swiftpackageindex.com/apple/swift-collections/1.1.0/documentation/orderedcollections/ordereddictionary
-[TreeSet]: https://swiftpackageindex.com/apple/swift-collections/1.1.0/documentation/hashtreecollections/treeset
-[TreeDictionary]: https://swiftpackageindex.com/apple/swift-collections/1.1.0/documentation/hashtreecollections/treedictionary
+[BitSet]: https://swiftpackageindex.com/apple/swift-collections/documentation/bitcollections/bitset
+[BitArray]: https://swiftpackageindex.com/apple/swift-collections/documentation/bitcollections/bitarray
+[Deque]: https://swiftpackageindex.com/apple/swift-collections/documentation/dequemodule/deque
+[Heap]: https://swiftpackageindex.com/apple/swift-collections/documentation/heapmodule/heap
+[OrderedSet]: https://swiftpackageindex.com/apple/swift-collections/documentation/orderedcollections/orderedset
+[OrderedDictionary]: https://swiftpackageindex.com/apple/swift-collections/documentation/orderedcollections/ordereddictionary
+[TreeSet]: https://swiftpackageindex.com/apple/swift-collections/documentation/hashtreecollections/treeset
+[TreeDictionary]: https://swiftpackageindex.com/apple/swift-collections/documentation/hashtreecollections/treedictionary
 
 Swift Collections uses the same modularization approach as [**Swift Numerics**](https://github.com/apple/swift-numerics): it provides a standalone module for each thematic group of data structures it implements. For instance, if you only need a double-ended queue type, you can pull in only that by importing `DequeModule`. `OrderedSet` and `OrderedDictionary` share much of the same underlying implementation, so they are provided by a single module, called `OrderedCollections`. However, there is also a top-level `Collections` module that gives you every collection type with a single import statement:
 


### PR DESCRIPTION
As of today the latest public release is 1.2.0 so API docs links in README.md are outdated, they still point to 1.1.0.
To avoid the maintenance cost of keeping URLs up to date this PR removes library version from URLs, making them always point to the latest stable release instead.

Another alternative would be to point URLs to the main branch ([example](https://swiftpackageindex.com/apple/swift-collections/main/documentation/bitcollections/bitset)), however for most of developers this README.md is the main entry point when installing the library and they would except to see docs for the latest stable release.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [ ] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
