### PR TITLE
Fix OrderedSet example usage

### DIFF
--- a/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
@@ -39,8 +39,8 @@ import InternalCollectionsUtilities
 /// *in the same order*. This matches the concept of equality of an `Array`, and
 /// it is different from the unordered `Set`.
 ///
-///     let a: OrderedSet = [1, 2, 3, 4]
-///     let b: OrderedSet = [4, 3, 2, 1]
+///     var a: OrderedSet = [1, 2, 3, 4]
+///     var b: OrderedSet = [4, 3, 2, 1]
 ///     a == b // false
 ///     b.sort() // `b` now has value [1, 2, 3, 4]
 ///     a == b // true

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet.swift
@@ -39,7 +39,7 @@ import InternalCollectionsUtilities
 /// *in the same order*. This matches the concept of equality of an `Array`, and
 /// it is different from the unordered `Set`.
 ///
-///     var a: OrderedSet = [1, 2, 3, 4]
+///     let a: OrderedSet = [1, 2, 3, 4]
 ///     var b: OrderedSet = [4, 3, 2, 1]
 ///     a == b // false
 ///     b.sort() // `b` now has value [1, 2, 3, 4]
@@ -90,7 +90,7 @@ import InternalCollectionsUtilities
 /// it implements the same concept of equality as the standard `Set`, ignoring
 /// element ordering.
 ///
-///     var a: OrderedSet = [0, 1, 2, 3]
+///     let a: OrderedSet = [0, 1, 2, 3]
 ///     let b: OrderedSet = [3, 2, 1, 0]
 ///     a == b // false
 ///     a.unordered == b.unordered // true
@@ -174,7 +174,7 @@ import InternalCollectionsUtilities
 ///
 ///     func pickyFunction(_ items: Array<Int>)
 ///
-///     var set: OrderedSet = [0, 1, 2, 3]
+///     let set: OrderedSet = [0, 1, 2, 3]
 ///     pickyFunction(set) // error
 ///     pickyFunction(set.elements) // OK
 ///


### PR DESCRIPTION
Code presented as an example usage of `OrderedSet` doesn't compile since mutating `sort` function is called on immutable `let`.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [ ] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
