### PR TITLE
1.1: Use full module triple for Swift modules

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -40,13 +40,12 @@ if(COLLECTIONS_SINGLE_MODULE)
           LIBRARY DESTINATION lib/swift_static/${swift_os}
           RUNTIME DESTINATION bin)
     endif()
-    get_swift_host_arch(swift_arch)
     install(FILES $<TARGET_PROPERTY:${COLLECTIONS_MODULE_NAME},Swift_MODULE_DIRECTORY>/${COLLECTIONS_MODULE_NAME}.swiftdoc
       DESTINATION lib/${swift}/${swift_os}/${COLLECTIONS_MODULE_NAME}.swiftmodule
-      RENAME ${swift_arch}.swiftdoc)
+      RENAME ${SwiftCollections_MODULE_TRIPLE}.swiftdoc)
     install(FILES $<TARGET_PROPERTY:${COLLECTIONS_MODULE_NAME},Swift_MODULE_DIRECTORY>/${COLLECTIONS_MODULE_NAME}.swiftmodule
       DESTINATION lib/${swift}/${swift_os}/${COLLECTIONS_MODULE_NAME}.swiftmodule
-      RENAME ${swift_arch}.swiftmodule)
+      RENAME ${SwiftCollections_MODULE_TRIPLE}.swiftmodule)
   else()
     _install_target(${COLLECTIONS_MODULE_NAME})
   endif()


### PR DESCRIPTION
Install swiftmodules using the full module triple. This replaces the CMake logic that attempts to compute the appropriate architecture using values passed into CMake with a query to ask the compiler what the appropriate module triple is for the given input target triple. This is more robust mechanism and will future-proof this part of the code against any new platforms and architectures to anything that the Swift compiler building the project can support.

This is currently needed for the x86_64 FreeBSD bringup effort, where the `amd64` architecture should be spelled `x86_64` in the swiftmodule triple for the Swift compiler to find it. A surgical approach adding another condition for amd64 FreeBSD would have less risk, but would also require a new tag for every new platform that the `get_swift_host_arch` didn't compute correctly or hadn't considered. The approach in the commit will work for all new platforms. Bugs in this approach will come from issues in the compiler when targeting the new platform and can be fixed in the compiler without changes to Swift-Collections.