### PR TITLE
Fix CMake build for `release/1.2`

### DIFF
--- a/cmake/modules/PlatformInfo.cmake
+++ b/cmake/modules/PlatformInfo.cmake
@@ -8,7 +8,7 @@ See https://swift.org/LICENSE.txt for license information
 #]]
 
 set(target_info_cmd "${CMAKE_Swift_COMPILER}" -print-target-info)
-if(CMAKE_Swfit_COMPILER_TARGET)
+if(CMAKE_Swift_COMPILER_TARGET)
   list(APPEND target_info_cmd -target ${CMAKE_Swift_COMPILER_TARGET})
 endif()
 execute_process(COMMAND ${target_info_cmd} OUTPUT_VARIABLE target_info_json)


### PR DESCRIPTION
This PR cherry picks https://github.com/apple/swift-collections/pull/482/commits, which fixes a typo in the CMake build that is blocking https://github.com/swiftlang/swift/pull/83310.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
