### PR TITLE
Add the missing COLLECTIONS_SINGLE_MODULE when import InternalCollectionsUtils

### DIFF
--- a/Sources/BitCollections/BitArray/BitArray+BitwiseOperations.swift
+++ b/Sources/BitCollections/BitArray/BitArray+BitwiseOperations.swift
@@ -9,7 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !COLLECTIONS_SINGLE_MODULE
 import InternalCollectionsUtilities
+#endif
 
 #if false
 // FIXME: Bitwise operators disabled for now. I have two concerns:

--- a/Sources/BitCollections/BitArray/BitArray+Codable.swift
+++ b/Sources/BitCollections/BitArray/BitArray+Codable.swift
@@ -9,7 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !COLLECTIONS_SINGLE_MODULE
 import InternalCollectionsUtilities
+#endif
 
 #if !$Embedded
 extension BitArray: Codable {

--- a/Sources/BitCollections/BitArray/BitArray+Initializers.swift
+++ b/Sources/BitCollections/BitArray/BitArray+Initializers.swift
@@ -9,7 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !COLLECTIONS_SINGLE_MODULE
 import InternalCollectionsUtilities
+#endif
 
 extension BitArray {
   /// Initialize a bit array from a bit set.

--- a/Sources/BitCollections/BitArray/BitArray+RandomBits.swift
+++ b/Sources/BitCollections/BitArray/BitArray+RandomBits.swift
@@ -9,7 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !COLLECTIONS_SINGLE_MODULE
 import InternalCollectionsUtilities
+#endif
 
 extension BitArray {
   /// Create and return a new bit array consisting of `count` random bits,

--- a/Sources/BitCollections/BitArray/BitArray+Testing.swift
+++ b/Sources/BitCollections/BitArray/BitArray+Testing.swift
@@ -9,7 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !COLLECTIONS_SINGLE_MODULE
 import InternalCollectionsUtilities
+#endif
 
 extension BitArray {
   @_spi(Testing)

--- a/Sources/BitCollections/BitSet/BitSet+BidirectionalCollection.swift
+++ b/Sources/BitCollections/BitSet/BitSet+BidirectionalCollection.swift
@@ -9,7 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !COLLECTIONS_SINGLE_MODULE
 import InternalCollectionsUtilities
+#endif
 
 extension BitSet: Sequence {
   /// The type representing the bit set's elements.

--- a/Sources/BitCollections/BitSet/BitSet+Random.swift
+++ b/Sources/BitCollections/BitSet/BitSet+Random.swift
@@ -9,7 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !COLLECTIONS_SINGLE_MODULE
 import InternalCollectionsUtilities
+#endif
 
 extension BitSet {
   public static func random(upTo limit: Int) -> BitSet {

--- a/Sources/BitCollections/BitSet/BitSet+SetAlgebra basics.swift
+++ b/Sources/BitCollections/BitSet/BitSet+SetAlgebra basics.swift
@@ -9,7 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !COLLECTIONS_SINGLE_MODULE
 import InternalCollectionsUtilities
+#endif
 
 extension BitSet {
   /// Returns a Boolean value that indicates whether the given element exists


### PR DESCRIPTION
Some classes lack of  macros (`COLLECTIONS_SINGLE_MODULE`) judgment when `import InternalCollectionsUtilities`, then add it like everywhere else.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
