### PR TITLE
[SortedSet] Fix subtreeCount inconsistency after remove at index

### DIFF
--- a/Sources/SortedCollections/BTree/_Node.UnsafeHandle+Deletion.swift
+++ b/Sources/SortedCollections/BTree/_Node.UnsafeHandle+Deletion.swift
@@ -106,9 +106,14 @@ extension _Node.UnsafeHandle {
         startIndex + self[childAt: childSlot].read { $0.subtreeCount }
       
       if offset < endIndex {
-        return self[childAt: childSlot].update {
+        let element = self[childAt: childSlot].update {
           $0.remove(at: offset - startIndex)
         }
+        
+        // Reduce the subtree count.
+        self.subtreeCount -= 1
+        
+        return element
       } else if offset == endIndex {
         let predecessor = self[childAt: childSlot].update {
           $0.popLastElement()

--- a/Tests/SortedCollectionsTests/SortedSet/SortedSet Tests.swift
+++ b/Tests/SortedCollectionsTests/SortedSet/SortedSet Tests.swift
@@ -79,6 +79,22 @@ class SortedSetTests: CollectionTestCase {
       }
     }
   }
+  
+  func test_removeAtIndex() {
+    withEvery("count", in: 0 ..< 40) { count in
+      withEvery("index", in: 0..<count) { index in
+        var sorted = SortedSet(0 ..< count)
+        let removed = sorted.remove(at: sorted.index(sorted.startIndex, offsetBy: index))
+        
+        var comparisonKeys = Array(0 ..< count)
+        comparisonKeys.remove(at: index)
+        
+        expectEqual(removed, index)
+        expectEqual(sorted.count, count - 1)
+        expectEqualElements(sorted, comparisonKeys)
+      }
+    }
+  }
 
   func test_CustomStringConvertible() {
     let a: SortedSet<Int> = []


### PR DESCRIPTION
This PR fixes an issue where calling `remove(at:)` on a `SortedSet` would correctly remove the element but fail to update the set’s `count`, leading to inconsistency between the actual contents and the reported size of the set.

The root cause was a missing update to the internal B-Tree node’s `subtreeCount` when removing an element from a node's child node. This PR ensures the internal node properly decrements its `subtreeCount` after removal, keeping the tree metadata consistent.

Resolves #441

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
