### PR TITLE
[SortedCollections] Fix B-tree root reduction during element removal causing data loss

### DIFF
--- a/Sources/SortedCollections/BTree/_BTree+UnsafeCursor.swift
+++ b/Sources/SortedCollections/BTree/_BTree+UnsafeCursor.swift
@@ -351,8 +351,12 @@ extension _BTree {
         }
         
         if depth == 0 && newNode.read({ $0.elementCount == 0 && !$0.isLeaf }) {
-          // If the root has no elements, we won't
-          newNode.update(isUnique: true) { $0.drop() }
+          // If the root has no elements, we drop it and promote the child.
+          node = newNode.update(isUnique: true) { handle in
+            let newRoot = handle.moveChild(atSlot: 0)
+            handle.drop()
+            return newRoot
+          }
         } else {
           node = newNode
         }

--- a/Tests/SortedCollectionsTests/SortedDictionary/SortedDictionary Tests.swift
+++ b/Tests/SortedCollectionsTests/SortedDictionary/SortedDictionary Tests.swift
@@ -13,8 +13,6 @@
 import _CollectionsTestSupport
 @_spi(Testing) @testable import SortedCollections
 
-#if false // Temporarily disabled until the failures can be investigated
-
 final class SortedDictionaryTests: CollectionTestCase {
   func test_empty() {
     let d = SortedDictionary<Int, String>()
@@ -284,5 +282,4 @@ final class SortedDictionaryTests: CollectionTestCase {
   }
 }
 
-#endif
 #endif


### PR DESCRIPTION
When removing elements from a B-tree, the root node could become empty while still having children. The previous code incorrectly just called `drop()` which deallocated all children, causing massive data loss during removal operations.

This fix implements proper root reduction by moving the single remaining child out of the empty root, then safely dropping the now-empty parent node and promoting the extracted child to become the new root.

This fixes `test_modifySubscriptRemoval` in `SortedDictionaryTests`, so we re-enable SortedDictionary tests which now all pass.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
