### PR TITLE
Add checks for Wasm compatibility to `pull_request.yml`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,6 +13,16 @@ jobs:
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}]'
       macos_exclude_xcode_versions: '[{"xcode_version": "16.0"}, {"xcode_version": "16.1"}]'
       enable_macos_checks: true
+
+  test-wasm:
+    name: Test Wasm
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      enable_wasm_sdk_build: true
+      enable_linux_checks: false
+      enable_macos_checks: false
+      enable_windows_checks: false
+
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main


### PR DESCRIPTION
This library currently has no PR testing for Wasm, even though it's a dependency of other libraries that declare Wasm support. To prevent possible future regressions, let's add Wasm checks to the CI workflows.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [N/A] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [N/A] I've updated the documentation if necessary.
