### PR TITLE
Build and run tests for Wasm in `pull_request.yml`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,8 @@ jobs:
       macos_exclude_xcode_versions: '[{"xcode_version": "16.0"}, {"xcode_version": "16.1"}]'
       enable_macos_checks: true
       enable_wasm_sdk_build: true
+      wasm_sdk_build_command: |
+        swift build --build-tests && wasmkit run --dir .build --dir / .build/release/swift-collectionsPackageTests.xctest
 
   embedded-swift:
     name: Build with Embedded Swift


### PR DESCRIPTION
We only build the package for Wasm but don't test it. Unfortunately, test for Wasm are not directly supported by `swift test` yet, but we can run `wasmkit` manually to work around this.
 
### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [N/A] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [N/A] I've updated the documentation if necessary.
