### PR TITLE
[actions] exclude Xcode 26 beta 6

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
     with:
       linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}]'
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}]'
-      macos_exclude_xcode_versions: '[{"xcode_version": "16.0"}, {"xcode_version": "16.1"}]'
+      macos_exclude_xcode_versions: '[{"xcode_version": "16.0"}, {"xcode_version": "16.1"}, {"xcode_version": "26.b6"}]'
       enable_macos_checks: true
       enable_wasm_sdk_build: true
 


### PR DESCRIPTION
Xcode 26b6's macOS SDK doesn't support backdeployment of `Span` and friends, guaranteeing compilation failures in the modules that use them.
This is fixed in Xcode 26 17A321, released on September 9th.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
