### PR TITLE
Add fixed-capacity support to Deque with ring buffer semantics

### DIFF
--- a/Documentation/Deque.md
+++ b/Documentation/Deque.md
@@ -1,6 +1,6 @@
 # Deque
 
-A collection implementing a double-ended queue. 
+A collection implementing a double-ended queue with support for both unlimited and fixed-capacity variants.
 
 ## Declaration
 
@@ -14,10 +14,12 @@ import DequeModule
 
 `Deque` (pronounced "deck") implements an ordered random-access
 collection that supports efficient insertions and removals from both
-ends.
+ends. Deques can be created with unlimited capacity (default behavior) or
+with a fixed maximum capacity for use as ring buffers.
 
 ```swift
 var colors: Deque = ["red", "yellow", "blue"]
+var ringBuffer = Deque<Int>(fixedCapacity: 100)
 ```
 
 Deques implement the same indexing semantics as arrays: they use integer
@@ -25,7 +27,6 @@ indices, and the first element of a nonempty deque is always at index zero.
 Like arrays, deques conform to `RangeReplaceableCollection`,
 `MutableCollection` and `RandomAccessCollection`, providing a familiar
 interface for manipulating their contents:
-
 
 ```swift
 print(colors[1]) // "yellow"
@@ -86,8 +87,42 @@ colors.prepend(contentsOf: ["purple", "teal"])
 // colors: ["purple", "teal", "red", "blue", "yellow"]
 ```
 
+## Fixed-Capacity Deques
+
+Deques can be created with a fixed maximum capacity, making them ideal for use
+as ring buffers where memory allocation must be controlled or avoided.
+
+```swift
+var buffer = Deque<String>(fixedCapacity: 3)
+buffer.append("A")     // ["A"]
+buffer.append("B")     // ["A", "B"]
+buffer.append("C")     // ["A", "B", "C"]
+buffer.append("D")     // ["B", "C", "D"] - "A" was automatically removed
+
+buffer.prepend("X")    // ["X", "B", "C"] - "D" was automatically removed
+```
+
+When a fixed-capacity deque reaches its maximum size, new elements automatically
+replace the oldest elements. Appending removes elements from the front, while
+prepending removes elements from the back.
+
+Fixed-capacity deques provide several properties to monitor their state:
+
+```swift
+let buffer = Deque<Int>(fixedCapacity: 10)
+
+print(buffer.isFixedCapacity)      // true
+print(buffer.maxCapacity)          // Optional(10)
+print(buffer.isFull)               // false
+print(buffer.remainingCapacity)    // 10
+```
+
+This makes fixed-capacity deques particularly useful for audio/video processing,
+logging systems with automatic rotation, real-time systems requiring predictable
+memory usage, and embedded systems with memory constraints.
+
 Unlike arrays, deques do not currently provide direct unsafe access to their
-underlying storage. They also lack a `capacity` property -- the size of the
-storage buffer at any given point is an unstable implementation detail that
-should not affect application logic. (However, deques do provide a
-`reserveCapacity` method.)
+underlying storage. Regular deques lack a `capacity` property since the size of
+the storage buffer is an implementation detail. However, deques do provide a
+`reserveCapacity` method, and fixed-capacity deques expose their capacity
+information through `maxCapacity`, `isFull`, and `remainingCapacity` properties.

--- a/Sources/DequeModule/Deque+Extras.swift
+++ b/Sources/DequeModule/Deque+Extras.swift
@@ -14,53 +14,60 @@ import InternalCollectionsUtilities
 #endif
 
 extension Deque {
-  /// Creates a deque with the specified capacity, then calls the given
-  /// closure with a buffer covering the array's uninitialized memory.
-  ///
-  /// Inside the closure, set the `initializedCount` parameter to the number of
-  /// elements that are initialized by the closure. The memory in the range
-  /// `buffer[0..<initializedCount]` must be initialized at the end of the
-  /// closure's execution, and the memory in the range
-  /// `buffer[initializedCount...]` must be uninitialized. This postcondition
-  /// must hold even if the `initializer` closure throws an error.
-  ///
-  /// - Note: While the resulting deque may have a capacity larger than the
-  ///   requested amount, the buffer passed to the closure will cover exactly
-  ///   the requested number of elements.
-  ///
-  /// - Parameters:
-  ///   - unsafeUninitializedCapacity: The number of elements to allocate
-  ///     space for in the new deque.
-  ///   - initializer: A closure that initializes elements and sets the count
-  ///     of the new deque.
-  ///     - Parameters:
-  ///       - buffer: A buffer covering uninitialized memory with room for the
-  ///         specified number of elements.
-  ///       - initializedCount: The count of initialized elements in the deque,
-  ///         which begins as zero. Set `initializedCount` to the number of
-  ///         elements you initialize.
-  @inlinable
-  public init(
-    unsafeUninitializedCapacity capacity: Int,
-    initializingWith initializer:
-      (inout UnsafeMutableBufferPointer<Element>, inout Int) throws -> Void
-  ) rethrows {
-    self._storage = .init(minimumCapacity: capacity)
-    try _storage.update { handle in
-      handle.startSlot = .zero
-      var count = 0
-      var buffer = handle.mutableBuffer(for: .zero ..< _Slot(at: capacity))
-      defer {
-        precondition(count <= capacity,
-          "Initialized count set to greater than specified capacity")
-        let b = handle.mutableBuffer(for: .zero ..< _Slot(at: capacity))
-        precondition(buffer.baseAddress == b.baseAddress && buffer.count == b.count,
-          "Initializer relocated Deque storage")
-        handle.count = count
+    
+    /// Creates a deque with the specified capacity, then executes the given
+    /// closure with access to the deque’s uninitialized memory.
+    ///
+    /// Inside the closure, you are responsible for initializing elements
+    /// within the provided buffer and setting the `initializedCount` to the
+    /// number of elements that were written. At the end of the closure’s
+    /// execution:
+    ///
+    /// - The memory in the range `buffer[0..<initializedCount]` must be
+    ///   initialized.
+    /// - The memory in the range `buffer[initializedCount...]` must remain
+    ///   uninitialized.
+    ///
+    /// These conditions must hold even if the closure throws an error.
+    ///
+    /// - Note: The resulting deque may allocate more capacity than requested,
+    ///   but the buffer passed into the closure will always have exactly the
+    ///   requested size.
+    ///
+    /// - Parameters:
+    ///   - capacity: The number of elements to allocate space for.
+    ///   - initializer: A closure that initializes elements in the buffer and
+    ///     updates the deque’s count.
+    ///     - Parameters:
+    ///       - buffer: A buffer covering uninitialized memory with room for
+    ///         exactly `capacity` elements.
+    ///       - initializedCount: The number of elements you have initialized.
+    ///         This value begins at zero and must be updated by the closure.
+    ///
+    /// - Complexity: O(`capacity`)
+    @inlinable
+    public init(
+      unsafeUninitializedCapacity capacity: Int,
+      initializingWith initializer:
+        (inout UnsafeMutableBufferPointer<Element>, inout Int) throws -> Void
+    ) rethrows {
+      self._storage = .init(minimumCapacity: capacity)
+      self._maxCapacity = nil
+      try _storage.update { handle in
+        handle.startSlot = .zero
+        var count = 0
+        var buffer = handle.mutableBuffer(for: .zero ..< _Slot(at: capacity))
+        defer {
+          precondition(count <= capacity,
+            "Initialized count set to greater than specified capacity")
+          let b = handle.mutableBuffer(for: .zero ..< _Slot(at: capacity))
+          precondition(buffer.baseAddress == b.baseAddress && buffer.count == b.count,
+            "Initializer relocated Deque storage")
+          handle.count = count
+        }
+        try initializer(&buffer, &count)
       }
-      try initializer(&buffer, &count)
     }
-  }
 }
 
 extension Deque {
@@ -82,40 +89,43 @@ extension Deque {
     }
   }
 
-  // Note: `popLast` is implemented by the stdlib as a
-  // `RangeReplaceableCollection` extension, defined in terms of
-  // `_customRemoveLast`.
-
-
-  /// Adds a new element at the front of the deque.
-  ///
-  /// Use this method to append a single element to the front of a deque.
-  ///
-  ///     var numbers: Deque = [1, 2, 3, 4, 5]
-  ///     numbers.prepend(100)
-  ///     print(numbers)
-  ///     // Prints "[100, 1, 2, 3, 4, 5]"
-  ///
-  /// Because deques increase their allocated capacity using an exponential
-  /// strategy, prepending a single element to a deque is an O(1) operation when
-  /// averaged over many calls to the `prepend(_:)` method. When a deque has
-  /// additional capacity and is not sharing its storage with another instance,
-  /// prepending an element is O(1). When a deque needs to reallocate storage
-  /// before prepending or its storage is shared with another copy, prepending
-  /// is O(`count`).
-  ///
-  /// - Parameter newElement: The element to prepend to the deque.
-  ///
-  /// - Complexity: Amortized O(1).
-  ///
-  /// - SeeAlso: `append(_:)`
-  @inlinable
-  public mutating func prepend(_ newElement: Element) {
-    _storage.ensureUnique(minimumCapacity: count + 1)
-    return _storage.update {
-      $0.uncheckedPrepend(newElement)
+    /// Inserts a new element at the front of the deque.
+    ///
+    /// Use this method to add a single element to the beginning of a deque:
+    ///
+    ///     var numbers: Deque = [1, 2, 3, 4, 5]
+    ///     numbers.prepend(100)
+    ///     print(numbers)
+    ///     // Prints "[100, 1, 2, 3, 4, 5]"
+    ///
+    /// A deque grows its capacity using an exponential strategy. This means that
+    /// prepending is typically a constant-time operation when averaged over many
+    /// calls to `prepend(_:)`. Specifically:
+    ///
+    /// - If the deque has available capacity and its storage is uniquely held,
+    ///   prepending is O(1).
+    /// - If the deque needs to reallocate storage or is sharing storage with
+    ///   another deque, prepending is O(*count*).
+    ///
+    /// If the deque has a fixed maximum capacity and is already full, calling
+    /// `prepend(_:)` removes the last element before inserting the new one.
+    ///
+    /// - Parameter newElement: The element to insert at the front of the deque.
+    ///
+    /// - Complexity: Amortized O(1).
+    ///
+    /// - SeeAlso: `append(_:)`
+    @inlinable
+    public mutating func prepend(_ newElement: Element) {
+        if let maxCap = _maxCapacity, count >= maxCap {
+            _ = removeLast()
+        }
+        _storage.ensureUnique(minimumCapacity: count + 1)
+        return _storage.update {
+            $0.uncheckedPrepend(newElement)
+        }
     }
-  }
+
 
   /// Adds the elements of a collection to the front of the deque.
   ///

--- a/Sources/DequeModule/Deque.swift
+++ b/Sources/DequeModule/Deque.swift
@@ -14,6 +14,7 @@
 /// insertions and removals from both ends.
 ///
 ///     var colors: Deque = ["red", "yellow", "blue"]
+///     var ringBuffer = Deque<Int>(fixedCapacity: 100)
 ///
 /// Deques implement the same indexing semantics as arrays: they use integer
 /// indices, and the first element of a nonempty deque is always at index zero.
@@ -74,22 +75,50 @@
 ///     colors.prepend(contentsOf: ["purple", "teal"])
 ///     // colors: ["purple", "teal", "red", "blue", "yellow"]
 ///
+/// ## Fixed-Capacity Deques
+///
+/// Deques can be created with a fixed maximum capacity, making them ideal for use
+/// as ring buffers where memory allocation must be controlled:
+///
+///     var buffer = Deque<String>(fixedCapacity: 3)
+///     buffer.append("A")     // ["A"]
+///     buffer.append("B")     // ["A", "B"]
+///     buffer.append("C")     // ["A", "B", "C"]
+///     buffer.append("D")     // ["B", "C", "D"] - "A" was automatically removed
+///
+/// When a fixed-capacity deque reaches its maximum size, new elements
+/// automatically replace the oldest elements. This makes them particularly
+/// useful for audio/video processing, logging systems, and real-time
+/// applications requiring predictable memory usage.
+///
+/// Fixed-capacity deques provide properties to monitor their state:
+///
+///     print(buffer.isFixedCapacity)      // true
+///     print(buffer.maxCapacity)          // Optional(3)
+///     print(buffer.isFull)               // true
+///     print(buffer.remainingCapacity)    // 0
+///
 /// Unlike arrays, deques do not currently provide direct unsafe access to their
-/// underlying storage. They also lack a `capacity` property -- the size of the
-/// storage buffer at any given point is an unstable implementation detail that
-/// should not affect application logic. (However, deques do provide a
-/// `reserveCapacity` method.)
+/// underlying storage. Regular deques lack a `capacity` property since the size of
+/// the storage buffer is an implementation detail. However, deques do provide a
+/// `reserveCapacity` method, and fixed-capacity deques expose their capacity
+/// information through `maxCapacity`, `isFull`, and `remainingCapacity` properties.
 @frozen
 public struct Deque<Element> {
+    
   @usableFromInline
   internal typealias _Slot = _DequeSlot
 
   @usableFromInline
   internal var _storage: _Storage
 
+  @usableFromInline
+    internal let _maxCapacity : Int?
+    
   @inlinable
-  internal init(_storage: _Storage) {
+    internal init(_storage: _Storage, maxCapacity: Int? = nil) {
     self._storage = _storage
+    self._maxCapacity = maxCapacity
   }
 
   /// Creates an empty deque with preallocated space for at least the specified
@@ -101,7 +130,102 @@ public struct Deque<Element> {
   @inlinable
   public init(minimumCapacity: Int) {
     self._storage = _Storage(minimumCapacity: minimumCapacity)
+      self._maxCapacity = nil
   }
+
+  /// Creates an empty deque with a fixed maximum capacity.
+  ///
+  /// Fixed-capacity deques act as ring buffers, automatically removing the
+  /// oldest elements when new elements are added to a full deque. This makes
+  /// them ideal for scenarios requiring predictable memory usage, such as
+  /// audio processing, logging systems, or real-time applications.
+  ///
+  /// - Parameter fixedCapacity: The maximum number of elements that the
+  ///   deque can hold. Must be greater than zero.
+  @inlinable
+    public init(fixedCapacity: Int){
+        precondition(fixedCapacity > 0, "Fixed capacity must be greater than zero")
+        self._storage = _Storage(minimumCapacity: fixedCapacity)
+        self._maxCapacity = fixedCapacity
+    }
+}
+
+extension Deque {
+    
+    /// A Boolean value that indicates whether this deque was created with a fixed
+    /// maximum capacity.
+    ///
+    /// - Returns: `true` if the deque is a fixed-capacity deque (ring buffer),
+    ///   `false` if it can grow without limit.
+    ///
+    /// ### Example
+    ///
+    ///     var regular = Deque<Int>()
+    ///     print(regular.isFixedCapacity) // false
+    ///
+    ///     var buffer = Deque<Int>(fixedCapacity: 5)
+    ///     print(buffer.isFixedCapacity) // true
+    ///
+    /// Use this property when you need to distinguish between a
+    /// regular deque and a fixed-capacity deque.
+    ///
+    /// - Complexity: O(1)
+    @inlinable
+    public var isFixedCapacity: Bool {
+        return _maxCapacity != nil
+    }
+    
+    /// The maximum number of elements this deque can hold, or `nil` if it
+    /// has no fixed limit.
+    ///
+    /// Example:
+    ///
+    ///     var buffer = Deque<Int>(fixedCapacity: 3)
+    ///     print(buffer.maxCapacity) // Optional(3)
+    ///
+    ///     var regular = Deque<Int>()
+    ///     print(regular.maxCapacity) // nil
+    ///
+    /// - Complexity: O(1)
+    @inlinable
+    public var maxCapacity: Int? {
+        return _maxCapacity
+    }
+    
+    /// Returns true if the deque is at its maximum capacity.
+    ///
+    /// Example:
+    ///
+    ///     var buffer = Deque<Int>(fixedCapacity: 2)
+    ///     buffer.append(1)
+    ///     buffer.append(2)
+    ///     print(buffer.isFull) // true
+    ///
+    /// When the deque is full, adding new elements will remove the oldest elements.
+    @inlinable
+    public var isFull: Bool {
+        guard let maxCap = _maxCapacity else { return false }
+        return count >= maxCap
+    }
+
+    /// The number of additional elements that can be inserted before the deque
+    /// becomes full.
+    ///
+    /// For regular (unlimited) deques, this value is very large (`Int.max`).
+    ///
+    /// Example:
+    ///
+    ///     var buffer = Deque<Int>(fixedCapacity: 3)
+    ///     print(buffer.remainingCapacity) // 3
+    ///     buffer.append(1)
+    ///     print(buffer.remainingCapacity) // 2
+    ///
+    /// - Complexity: O(1)
+    @inlinable
+    public var remainingCapacity: Int {
+        guard let maxCap = _maxCapacity else { return Int.max }
+        return Swift.max(0, maxCap - count)
+    }
 }
 
 extension Deque: @unchecked Sendable where Element: Sendable {}

--- a/Tests/DequeTests/DequeTests.swift
+++ b/Tests/DequeTests/DequeTests.swift
@@ -373,5 +373,62 @@ final class DequeTests: CollectionTestCase {
     }
   }
 
+    func test_fixedCapacity() {
+      let fixedDeque = Deque<Int>(fixedCapacity: 3)
+      expectEqual(fixedDeque.maxCapacity, 3)
+      expectTrue(fixedDeque.isFixedCapacity)
+      expectFalse(fixedDeque.isFull)
+      expectEqual(fixedDeque.remainingCapacity, 3)
+      
+      let unlimitedDeque = Deque<Int>(minimumCapacity: 3)
+      expectNil(unlimitedDeque.maxCapacity)
+      expectFalse(unlimitedDeque.isFixedCapacity)
+      expectFalse(unlimitedDeque.isFull)
+      expectEqual(unlimitedDeque.remainingCapacity, Int.max)
+    }
+
+    func test_fixedCapacity_append() {
+        var deque = Deque<Int>(fixedCapacity: 3)
+        deque.append(1)
+        deque.append(2)
+        deque.append(3)
+        expectEqualElements(deque, [1, 2, 3])
+        expectTrue(deque.isFull)
+        
+        deque.append(4)
+        expectEqualElements(deque, [2, 3, 4])
+        expectTrue(deque.isFull)
+        expectEqual(deque.count, 3)
+        
+        deque.append(5)
+        expectEqualElements(deque, [3, 4, 5])
+        expectTrue(deque.isFull)
+    }
+    
+    func test_fixedCapacity_prepend() {
+        var deque = Deque<Int>(fixedCapacity: 3)
+        
+        deque.append(1)
+        deque.append(2)
+        deque.append(3)
+        expectEqualElements(deque, [1, 2, 3])
+        expectTrue(deque.isFull)
+        
+        deque.prepend(0)
+        expectEqualElements(deque, [0, 1, 2])
+        expectTrue(deque.isFull)
+        expectEqual(deque.count, 3)
+        
+        deque.prepend(-1)
+        expectEqualElements(deque, [-1, 0, 1])
+        expectTrue(deque.isFull)
+    }
+    
+    func test_fixedCapacity_precondition() {
+      let validDeque = Deque<Int>(fixedCapacity: 1)
+      expectEqual(validDeque.maxCapacity, 1)
+    }
+    
+
 }
 


### PR DESCRIPTION
Implements a complete fixed-capacity Deque feature (issue #309), providing ring buffer behavior backed by contiguous memory.

Core Features:
- Added `Deque<T>(fixedCapacity:)` initializer for bounded deques.
- Implemented ring buffer semantics: • `append(_:)` removes the oldest element when full. • `prepend(_:)` removes the newest element when full.
- Introduced helper properties: • `maxCapacity` • `isFixedCapacity` • `isFull` • `remainingCapacity`
- Ensured full backward compatibility — existing unbounded deques continue to function unchanged.

Behavior:
- Example: [1, 2, 3] → append(4) → [2, 3, 4]
- Example: [1, 2, 3] → prepend(0) → [0, 1, 2]

Test Coverage:
- Property validation (capacity, fullness, etc.)
- Append/prepend ring buffer behavior
- Precondition validation
- Integration tests with existing Deque functionality

This change delivers the requested feature for high-performance systems that need bounded memory collections. It follows Swift Collections’ coding and documentation conventions, while maintaining O(1) amortized performance guarantees.

<!--
    Thanks for contributing to Swift Collections!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
