### PR TITLE
[Docs] Fix landing page of collections documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 The package currently provides the following implementations:
 
+- [`RigidArray`][RigidArray], a fixed capacity and no implicit resizing dynamic non-copyable array capable of storing non-copyable elements.
+
+- [`UniqueArray`][UniqueArray], an implicitly resizable dynamic non-copyable array capable of storing non-copyable elements.
+
 - [`BitSet`][BitSet] and [`BitArray`][BitArray], dynamic bit collections.
 
 - [`Deque<Element>`][Deque], a double-ended queue backed by a ring buffer. Deques are range-replaceable, mutable, random-access collections.
@@ -22,6 +26,8 @@ The package currently provides the following implementations:
 
 - [`TreeSet`][TreeSet] and [`TreeDictionary`][TreeDictionary], persistent hashed collections implementing Compressed Hash-Array Mapped Prefix Trees (CHAMP). These work similar to the standard `Set` and `Dictionary`, but they excel at use cases that mutate shared copies, offering dramatic memory savings and radical time improvements.  
 
+[RigidArray]: https://swiftpackageindex.com/apple/swift-collections/documentation/basiccontainers/rigidarray
+[UniqueArray]: https://swiftpackageindex.com/apple/swift-collections/documentation/basiccontainers/uniquearray
 [BitSet]: https://swiftpackageindex.com/apple/swift-collections/documentation/bitcollections/bitset
 [BitArray]: https://swiftpackageindex.com/apple/swift-collections/documentation/bitcollections/bitarray
 [Deque]: https://swiftpackageindex.com/apple/swift-collections/documentation/dequemodule/deque

--- a/Sources/Collections/Collections.docc/Collections.md
+++ b/Sources/Collections/Collections.docc/Collections.md
@@ -11,28 +11,11 @@
 - [`Swift Collections` on GitHub](https://github.com/apple/swift-collections/)
 - [`Swift Collections` on the Swift Forums](https://forums.swift.org/c/related-projects/collections/72)
 
+### Modules
 
-## Topics
-
-### Bit Collections
-
-- ``BitSet``
-- ``BitArray``
-
-### Deque Module
-
-- ``Deque``
-
-### Heap Module
-
-- ``Heap``
-
-### Ordered Collections
-
-- ``OrderedSet``
-- ``OrderedDictionary``
-
-### Persistent Hashed Collections
-
-- ``TreeSet``
-- ``TreeDictionary``
+- [Basic Containers](./basiccontainers) - [`RigidArray`](./basiccontainers/rigidarray), a fixed capacity and no implicit resizing dynamic non-copyable array capable of storing non-copyable elements. [`UniqueArray`](./basiccontainers/uniquearray), an implicitly resizable dynamic non-copyable array capable of storing non-copyable elements.
+- [Bit Collections](./bitcollections) - [`BitSet`](./bitcollections/bitset) and [`BitArray`](./bitcollections/bitarray), dynamic bit collections.
+- [Deque Module](./dequemodule) - [`Deque<Element>`](./dequemodule/deque), a double-ended queue backed by a ring buffer. Deques are range-replaceable, mutable, random-access collections.
+- [Heap Module](./heapmodule) - [`Heap`](./heapmodule/heap), a min-max heap backed by an array, suitable for use as a priority queue.
+- [Ordered Collections](./orderedcollections) - [`OrderedSet<Element>`](./orderedcollections/orderedset), a variant of the standard `Set` where the order of items is well-defined and items can be arbitrarily reordered. Uses a `ContiguousArray` as its backing store, augmented by a separate hash table of bit packed offsets into it. [`OrderedDictionary<Key, Value>`](./orderedcollections/ordereddictionary), an ordered variant of the standard `Dictionary`, providing similar benefits.
+- [Hash Tree Collections](./hashtreecollections) - [`TreeSet`](./hashtreecollections/treeset) and [`TreeDictionary`](./hashtreecollections/treedictionary), persistent hashed collections implementing Compressed Hash-Array Mapped Prefix Trees (CHAMP). These work similar to the standard `Set` and `Dictionary`, but they excel at use cases that mutate shared copies, offering dramatic memory savings and radical time improvements.


### PR DESCRIPTION
Docc doesn't really like reexported modules, so the `Collections` default target couldn't access any of the other symbols from its documentation. Provide relative links to those instead and add some blurbs about the new `RigidArray` and `UniqueArray`.