### PR TITLE
[CI] Drop Xcode 26 testing for now

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
     with:
       linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}]'
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}]'
-      macos_exclude_xcode_versions: '[{"xcode_version": "16.0"}, {"xcode_version": "16.1"}, {"xcode_version": "26.b6"}]'
+      macos_exclude_xcode_versions: '[{"xcode_version": "16.0"}, {"xcode_version": "16.1"}, {"xcode_version": "26.0"}]'
       enable_macos_checks: true
       enable_wasm_sdk_build: true
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,8 @@ jobs:
       linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}]'
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}]'
       macos_exclude_xcode_versions: '[{"xcode_version": "16.2"}, {"xcode_version": "26.0"}]'
-      enable_macos_checks: false
+      macos_xcode_versions: "[\"16.2\", \"16.3\", \"26.0\"]"
+      enable_macos_checks: true
       enable_wasm_sdk_build: true
 
   embedded-swift:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
     with:
       linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}]'
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}]'
-      macos_exclude_xcode_versions: '[{"xcode_version": "16.0"}, {"xcode_version": "16.1"}, {"xcode_version": "26.0"}]'
+      macos_exclude_xcode_versions: '[{"xcode_version": "16.2"}, {"xcode_version": "26.0"}]'
       enable_macos_checks: true
       enable_wasm_sdk_build: true
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
       linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}]'
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}]'
       macos_exclude_xcode_versions: '[{"xcode_version": "16.2"}, {"xcode_version": "26.0"}]'
-      enable_macos_checks: true
+      enable_macos_checks: false
       enable_wasm_sdk_build: true
 
   embedded-swift:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,8 +11,7 @@ jobs:
     with:
       linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}]'
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}]'
-      macos_exclude_xcode_versions: '[{"xcode_version": "16.2"}, {"xcode_version": "26.0"}]'
-      macos_xcode_versions: "[\"16.2\", \"16.3\", \"26.0\"]"
+      macos_exclude_xcode_versions: '[{"xcode_version": "26.0"}]'
       enable_macos_checks: true
       enable_wasm_sdk_build: true
 


### PR DESCRIPTION
Test runner appears not to be able to load libswiftCompatibilitySpan.dylib.

I see nothing I can do to fix this on my end.

rdar://161459068
