### PR TITLE
Fix links in GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -10,12 +10,12 @@ labels: bug
     Before you submit your issue, please replace each paragraph
     below with the relevant details for your bug, and complete
     the steps in the checklist by placing an 'x' in each box:
-    
+
     - [x] I've completed this task
     - [ ] This task isn't completed
 -->
 
-Replace this paragraph with a short description of the incorrect behavior. 
+Replace this paragraph with a short description of the incorrect behavior.
 (If this is a regression, please note the last version of the package that exhibited the correct behavior in addition to your current version.)
 
 ### Information

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
     Before you submit your request, please replace the paragraph
     below with the relevant details, and complete the steps in the
     checklist by placing an 'x' in each box:
-    
+
     - [x] I've completed this task
     - [ ] This task isn't completed
 -->
@@ -15,8 +15,8 @@
 Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.
 
 ### Checklist
-- [ ] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
-- [ ] My contributions are licensed under the [Swift license](/LICENSE.txt).
+- [ ] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
+- [ ] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
 - [ ] I've followed the coding style of the rest of the project.
 - [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
 - [ ] I've added benchmarks covering new functionality (if appropriate).

--- a/.github/PULL_REQUEST_TEMPLATE/NEW.md
+++ b/.github/PULL_REQUEST_TEMPLATE/NEW.md
@@ -4,13 +4,13 @@
     Before you submit your request, please replace each paragraph
     below with the relevant details, and complete the steps in the
     checklist by placing an 'x' in each box:
-    
+
     - [x] I've completed this task
     - [ ] This task isn't completed
 -->
 
 ### Description
-Replace this paragraph with a description of your changes and rationale. 
+Replace this paragraph with a description of your changes and rationale.
 Provide links to an existing issue or external references/discussions, if appropriate.
 
 ### Detailed Design
@@ -23,7 +23,7 @@ public struct Example: Collection {
 ```
 
 ### Documentation
-How has the new feature been documented? 
+How has the new feature been documented?
 Have the relevant portions of the guides in the Documentation folder been updated in addition to symbol-level documentation?
 
 ### Testing
@@ -36,7 +36,7 @@ How did you verify the new feature performs as expected?
 What is the impact of this change on existing users of this package? Does it deprecate or remove any existing API?
 
 ### Checklist
-- [ ] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
+- [ ] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
 - [ ] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
 - [ ] I've followed the coding style of the rest of the project.
 - [ ] I've added tests covering all new code paths my change adds to the project (to the extent possible).


### PR DESCRIPTION
The PR template's links to the Swift license and contribution guidelines have been broken for ages -- fix them.

### Checklist
- [ ] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [ ] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [ ] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
