### PR TITLE
[RopeModule] Fix warnings

### DIFF
--- a/Sources/RopeModule/BigString/Chunk/BigString+Chunk.swift
+++ b/Sources/RopeModule/BigString/Chunk/BigString+Chunk.swift
@@ -106,11 +106,11 @@ extension BigString._Chunk {
   @_lifetime(borrow self)
   func utf8Span(from i: Index, to j: Index? = nil) -> UTF8Span {
     guard j == nil else {
-      let span = span._extracting(i.utf8Offset..<j!.utf8Offset)
+      let span = span.extracting(i.utf8Offset..<j!.utf8Offset)
       return _overrideLifetime(UTF8Span(unchecked: span), borrowing: self)
     }
 
-    let span = span._extracting(i.utf8Offset...)
+    let span = span.extracting(i.utf8Offset...)
     return _overrideLifetime(UTF8Span(unchecked: span), borrowing: self)
   }
 }


### PR DESCRIPTION
`Span.extracting` has become public API now.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
