### PR TITLE
[1.2] Update GitHub metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -10,12 +10,12 @@ labels: bug
     Before you submit your issue, please replace each paragraph
     below with the relevant details for your bug, and complete
     the steps in the checklist by placing an 'x' in each box:
-    
+
     - [x] I've completed this task
     - [ ] This task isn't completed
 -->
 
-Replace this paragraph with a short description of the incorrect behavior. 
+Replace this paragraph with a short description of the incorrect behavior.
 (If this is a regression, please note the last version of the package that exhibited the correct behavior in addition to your current version.)
 
 ### Information

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
     Before you submit your request, please replace the paragraph
     below with the relevant details, and complete the steps in the
     checklist by placing an 'x' in each box:
-    
+
     - [x] I've completed this task
     - [ ] This task isn't completed
 -->
@@ -15,8 +15,8 @@
 Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.
 
 ### Checklist
-- [ ] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
-- [ ] My contributions are licensed under the [Swift license](/LICENSE.txt).
+- [ ] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
+- [ ] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
 - [ ] I've followed the coding style of the rest of the project.
 - [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
 - [ ] I've added benchmarks covering new functionality (if appropriate).

--- a/.github/PULL_REQUEST_TEMPLATE/NEW.md
+++ b/.github/PULL_REQUEST_TEMPLATE/NEW.md
@@ -4,13 +4,13 @@
     Before you submit your request, please replace each paragraph
     below with the relevant details, and complete the steps in the
     checklist by placing an 'x' in each box:
-    
+
     - [x] I've completed this task
     - [ ] This task isn't completed
 -->
 
 ### Description
-Replace this paragraph with a description of your changes and rationale. 
+Replace this paragraph with a description of your changes and rationale.
 Provide links to an existing issue or external references/discussions, if appropriate.
 
 ### Detailed Design
@@ -23,7 +23,7 @@ public struct Example: Collection {
 ```
 
 ### Documentation
-How has the new feature been documented? 
+How has the new feature been documented?
 Have the relevant portions of the guides in the Documentation folder been updated in addition to symbol-level documentation?
 
 ### Testing
@@ -36,7 +36,7 @@ How did you verify the new feature performs as expected?
 What is the impact of this change on existing users of this package? Does it deprecate or remove any existing API?
 
 ### Checklist
-- [ ] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
+- [ ] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
 - [ ] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
 - [ ] I've followed the coding style of the rest of the project.
 - [ ] I've added tests covering all new code paths my change adds to the project (to the extent possible).

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,6 +11,20 @@ jobs:
     with:
       linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}]'
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}]'
+      enable_macos_checks: true
+      enable_wasm_sdk_build: true
+
+  embedded-swift:
+    name: Build with Embedded Swift
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      enable_linux_checks: false
+      enable_macos_checks: false
+      enable_windows_checks: false
+      enable_wasm_sdk_build: false
+      enable_embedded_wasm_sdk_build: true
+      swift_flags: --target Collections
+
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main


### PR DESCRIPTION
- Update pull request and issue templates
- Add workflow configuration

Like #535, the initial version of this simply copies the workflow from `main`. This is not going to work, but I'm curious to see which jobs will actually fail.
