### PR TITLE
[BigString] Bring back Index._isUTF16TrailingSurrogate

### DIFF
--- a/Sources/RopeModule/BigString/Basics/BigString+Index.swift
+++ b/Sources/RopeModule/BigString/Basics/BigString+Index.swift
@@ -106,6 +106,10 @@ extension BigString.Index {
     _flags = 0
   }
 
+  public var _isUTF16TrailingSurrogate: Bool {
+    _orderingValue & 1 != 0
+  }
+
   internal func _knownScalarAligned() -> Self {
     var copy = self
     copy._chunkIndex = _chunkIndex.scalarAligned


### PR DESCRIPTION
This was removed as part of https://github.com/apple/swift-collections/pull/488, but it seems Foundation was using this API. Until we change Foundation to remove calling this function (or to call whatever new thing we have), bring this back in the meantime.