### PR TITLE
Include notes about index mutation in `span(after/before:)` (+ other doc fixes)

### DIFF
--- a/Sources/BasicContainers/RigidArray/RigidArray+Container.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Container.swift
@@ -20,12 +20,12 @@ import ContainersPreview
 @available(SwiftStdlib 5.0, *)
 extension RigidArray: BorrowingSequence where Element: ~Copyable {
   public typealias BorrowingIterator = Span<Element>.BorrowingIterator
-  
+
   @inlinable
   public var estimatedCount: EstimatedCount {
     .exactly(count)
   }
-  
+
   @_alwaysEmitIntoClient
   @inline(__always)
   public func makeBorrowingIterator() -> BorrowingIterator {
@@ -63,7 +63,7 @@ extension RigidArray where Element: ~Copyable {
   /// start.
   ///
   /// Valid indices consist of the position of every element and a "past the
-  /// end” position that’s not valid for use as a subscript argument.
+  /// end" position that's not valid for use as a subscript argument.
   public typealias Index = Int
 
   /// The position of the first element in a nonempty array. This is always zero.
@@ -73,7 +73,7 @@ extension RigidArray where Element: ~Copyable {
   @inline(__always)
   public var startIndex: Int { 0 }
 
-  /// The array’s "past the end” position—that is, the position one greater than
+  /// The array's "past the end" position—that is, the position one greater than
   /// the last valid subscript argument. This is always equal to the array's
   /// count.
   ///
@@ -88,7 +88,7 @@ extension RigidArray where Element: ~Copyable {
   @inlinable
   @inline(__always)
   public var indices: Range<Int> { unsafe Range(uncheckedBounds: (0, count)) }
-  
+
   @_alwaysEmitIntoClient
   @_transparent
   package func _checkItemIndex(_ index: Int) {
@@ -96,7 +96,7 @@ extension RigidArray where Element: ~Copyable {
       UInt(bitPattern: index) < UInt(bitPattern: _count),
       "Index out of bounds")
   }
-  
+
   @_alwaysEmitIntoClient
   @_transparent
   package func _checkValidIndex(_ index: Int) {
@@ -104,7 +104,7 @@ extension RigidArray where Element: ~Copyable {
       UInt(bitPattern: index) <= UInt(bitPattern: _count),
       "Index out of bounds")
   }
-  
+
   @_alwaysEmitIntoClient
   @_transparent
   package func _checkValidBounds(_ subrange: Range<Int>) {
@@ -185,7 +185,7 @@ extension RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @inline(__always)
   public func index(after index: Int) -> Int { index + 1 }
-  
+
   /// Returns the position immediately before the given index.
   ///
   /// - Note: To improve performance, this method does not validate that the
@@ -251,7 +251,7 @@ extension RigidArray where Element: ~Copyable {
   public func index(_ index: Int, offsetBy n: Int) -> Int {
     index + n
   }
-  
+
   /// Returns the distance between two indices.
   ///
   /// - Note: To improve performance, this method does not validate that the
@@ -269,7 +269,7 @@ extension RigidArray where Element: ~Copyable {
   public func distance(from start: Index, to end: Index) -> Int {
     end - start
   }
-  
+
   /// Offsets the given index by the specified distance, but no further than
   /// the given limiting index.
   ///
@@ -390,4 +390,3 @@ extension RigidArray where Element: ~Copyable {
 }
 
 #endif
-

--- a/Sources/BasicContainers/RigidArray/RigidArray+Insertions.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Insertions.swift
@@ -318,7 +318,7 @@ extension RigidArray {
   /// array at the specified position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// specified index. If you pass the array's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the array.
   ///
   /// All existing elements at or following the specified position are moved to
@@ -348,7 +348,7 @@ extension RigidArray {
   /// array at the specified position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// specified index. If you pass the array's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the array.
   ///
   /// All existing elements at or following the specified position are moved to
@@ -376,7 +376,7 @@ extension RigidArray {
   /// Copies the elements of a span into this array at the specified position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// specified index. If you pass the array's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the array.
   ///
   /// All existing elements at or following the specified position are moved to
@@ -454,7 +454,7 @@ extension RigidArray {
   /// position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// specified index. If you pass the array's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the array.
   ///
   /// All existing elements at or following the specified position are moved to
@@ -485,7 +485,7 @@ extension RigidArray {
   /// position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// specified index. If you pass the array's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the array.
   ///
   /// All existing elements at or following the specified position are moved
@@ -514,7 +514,7 @@ extension RigidArray {
   /// position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// specified index. If you pass the array's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the array.
   ///
   /// All existing elements at or following the specified position are moved to

--- a/Sources/BasicContainers/RigidArray/RigidArray.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray.swift
@@ -91,7 +91,7 @@ public struct RigidArray<Element: ~Copyable>: ~Copyable {
     unsafe _storage.extracting(0 ..< _count).deinitialize()
     unsafe _storage.deallocate()
   }
-  
+
   @_alwaysEmitIntoClient
   package init(_storage: UnsafeMutableBufferPointer<Element>, count: Int) {
     self._storage = _storage
@@ -125,6 +125,7 @@ extension RigidArray where Element: ~Copyable {
   }
 
   /// A Boolean value indicating whether this rigid array is fully populated.
+  ///
   /// If this property returns true, then the array's storage is at capacity,
   /// and it cannot accommodate any additional elements.
   ///
@@ -196,6 +197,7 @@ extension RigidArray where Element: ~Copyable {
 extension RigidArray where Element: ~Copyable {
   /// Arbitrarily edit the storage underlying this array by invoking a
   /// user-supplied closure with a mutable `OutputSpan` view over it.
+  ///
   /// This method calls its function argument at most once, allowing it to
   /// arbitrarily modify the contents of the output span it is given.
   /// The argument is free to add, remove or reorder any items; however,
@@ -256,10 +258,14 @@ extension RigidArray where Element: ~Copyable {
 @available(SwiftStdlib 5.0, *)
 extension RigidArray where Element: ~Copyable {
   /// Return a borrowing span over the maximal storage chunk following the
-  /// specified position in the array. The span provides direct read-only access
-  /// to all array elements in the range `index ..< count`.
+  /// specified position in the array.
+  ///
+  /// The returned span provides direct read-only access to all array elements
+  /// in the range `index ..< count`.
   ///
   /// - Parameter index: A valid index in the array, including the end index.
+  ///   When `span(after:)` returns, `index` is equal to the array's
+  ///   `endIndex`.
   ///
   /// - Complexity: O(1)
   @inlinable
@@ -269,10 +275,14 @@ extension RigidArray where Element: ~Copyable {
   }
 
   /// Return a borrowing span over the maximal storage chunk preceding the
-  /// specified position in the array. The span provides direct read-only access
-  /// to all array elements in the range `0 ..< index`.
+  /// specified position in the array.
+  ///
+  /// The returned span provides direct read-only access to all array elements
+  /// in the range `0 ..< index`.
   ///
   /// - Parameter index: A valid index in the array, including the end index.
+  ///   When `span(before:)` returns, `index` is equal to the array's
+  ///   `startIndex`.
   ///
   /// - Complexity: O(1)
   @inlinable
@@ -285,10 +295,14 @@ extension RigidArray where Element: ~Copyable {
 @available(SwiftStdlib 5.0, *)
 extension RigidArray where Element: ~Copyable {
   /// Return a mutable span over the maximal storage chunk following the
-  /// specified position in the array. The span provides direct mutating access
-  /// to all array elements in the range `index ..< count`.
+  /// specified position in the array.
+  ///
+  /// The returned span provides direct mutating access to all array elements
+  /// in the range `index ..< count`.
   ///
   /// - Parameter index: A valid index in the array, including the end index.
+  ///   When `mutableSpan(after:)` returns, `index` is equal to the array's
+  ///   `endIndex`.
   ///
   /// - Complexity: O(1)
   @_lifetime(&self)
@@ -299,10 +313,14 @@ extension RigidArray where Element: ~Copyable {
   }
 
   /// Return a mutable span over the maximal storage chunk preceding the specified
-  /// position in the array. The span provides direct mutating access to all
-  /// array elements in the range `0 ..< index`.
+  /// position in the array.
+  ///
+  /// The returned span provides direct mutating access to all array elements
+  /// in the range `0 ..< index`.
   ///
   /// - Parameter index: A valid index in the array, including the end index.
+  ///   When `mutableSpan(before:)` returns, `index` is equal to the array's
+  ///   `startIndex`.
   ///
   /// - Complexity: O(1)
   @_lifetime(&self)
@@ -367,7 +385,7 @@ extension RigidArray {
   public func clone() -> Self {
     clone(capacity: self.count)
   }
-  
+
   /// Copy the contents of this array into a newly allocated rigid array
   /// instance with the specified capacity.
   ///
@@ -421,7 +439,7 @@ extension RigidArray where Element: ~Copyable {
     return unsafe _storage.extracting(
       Range(uncheckedBounds: (index, index + count)))
   }
-  
+
   /// Resize the gap in the given subrange to have the specified count.
   /// This operation moves elements following the gap to be at their expected
   /// new location, and it adjusts the container's count to reflect the change.

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Container.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Container.swift
@@ -20,7 +20,7 @@ import ContainersPreview
 @available(SwiftStdlib 5.0, *)
 extension UniqueArray: BorrowingSequence where Element: ~Copyable {
   public typealias BorrowingIterator = RigidArray<Element>.BorrowingIterator
-  
+
   public var estimatedCount: EstimatedCount {
     .exactly(count)
   }
@@ -62,7 +62,7 @@ extension UniqueArray where Element: ~Copyable {
   /// start.
   ///
   /// Valid indices consist of the position of every element and a "past the
-  /// end” position that’s not valid for use as a subscript argument.
+  /// end" position that's not valid for use as a subscript argument.
   public typealias Index = Int
 
   /// The position of the first element in a nonempty array. This is always zero.
@@ -72,7 +72,7 @@ extension UniqueArray where Element: ~Copyable {
   @inline(__always)
   public var startIndex: Int { _storage.startIndex }
 
-  /// The array’s "past the end” position—that is, the position one greater than
+  /// The array's "past the end" position—that is, the position one greater than
   /// the last valid subscript argument. This is always equal to array's count.
   ///
   /// - Complexity: O(1)
@@ -141,7 +141,7 @@ extension UniqueArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @inline(__always)
   public func index(after index: Int) -> Int { index + 1 }
-  
+
   /// Returns the position immediately before the given index.
   ///
   /// - Note: To improve performance, this method does not validate that the
@@ -207,7 +207,7 @@ extension UniqueArray where Element: ~Copyable {
   public func index(_ index: Int, offsetBy n: Int) -> Int {
     index + n
   }
-  
+
   /// Returns the distance between two indices.
   ///
   /// - Note: To improve performance, this method does not validate that the
@@ -225,7 +225,7 @@ extension UniqueArray where Element: ~Copyable {
   public func distance(from start: Index, to end: Index) -> Int {
     end - start
   }
-  
+
   /// Offsets the given index by the specified distance, but no further than
   /// the given limiting index.
   ///

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Insertions.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Insertions.swift
@@ -281,7 +281,7 @@ extension UniqueArray {
   /// array at the specified position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// specified index. If you pass the array's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the array.
   ///
   /// All existing elements at or following the specified position are moved to
@@ -311,7 +311,7 @@ extension UniqueArray {
   /// array at the specified position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// specified index. If you pass the array's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the array.
   ///
   /// All existing elements at or following the specified position are moved to
@@ -339,7 +339,7 @@ extension UniqueArray {
   /// Copies the elements of a span into this array at the specified position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// specified index. If you pass the array's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the array.
   ///
   /// All existing elements at or following the specified position are moved to
@@ -369,7 +369,7 @@ extension UniqueArray {
   /// position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// specified index. If you pass the array's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the array.
   ///
   /// All existing elements at or following the specified position are moved to
@@ -404,7 +404,7 @@ extension UniqueArray {
   /// position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// specified index. If you pass the array's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the array.
   ///
   /// All existing elements at or following the specified position are moved
@@ -436,7 +436,7 @@ extension UniqueArray {
   /// position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// specified index. If you pass the array's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the array.
   ///
   /// All existing elements at or following the specified position are moved to

--- a/Sources/BasicContainers/UniqueArray/UniqueArray.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray.swift
@@ -130,6 +130,7 @@ extension UniqueArray where Element: ~Copyable {
 extension UniqueArray where Element: ~Copyable {
   /// Arbitrarily edit the storage underlying this array by invoking a
   /// user-supplied closure with a mutable `OutputSpan` view over it.
+  ///
   /// This method calls its function argument at most once, allowing it to
   /// arbitrarily modify the contents of the output span it is given.
   /// The argument is free to add, remove or reorder any items; however,
@@ -158,10 +159,14 @@ extension UniqueArray where Element: ~Copyable {
 @available(SwiftStdlib 5.0, *)
 extension UniqueArray where Element: ~Copyable {
   /// Return a borrowing span over the maximal storage chunk following the
-  /// specified position in the array. The span provides direct read-only access
-  /// to all array elements in the range `index ..< count`.
+  /// specified position in the array.
+  ///
+  /// The returned span provides direct read-only access to all array elements
+  /// in the range `index ..< count`.
   ///
   /// - Parameter index: A valid index in the array, including the end index.
+  ///   When `span(after:)` returns, `index` is equal to the array's
+  ///   `endIndex`.
   ///
   /// - Complexity: O(1)
   @inlinable
@@ -171,10 +176,14 @@ extension UniqueArray where Element: ~Copyable {
   }
 
   /// Return a borrowing span over the maximal storage chunk preceding the
-  /// specified position in the array. The span provides direct read-only access
-  /// to all array elements in the range `0 ..< index`.
+  /// specified position in the array.
+  ///
+  /// The returned span provides direct read-only access to all array elements
+  /// in the range `0 ..< index`.
   ///
   /// - Parameter index: A valid index in the array, including the end index.
+  ///   When `span(before:)` returns, `index` is equal to the array's
+  ///   `startIndex`.
   ///
   /// - Complexity: O(1)
   @inlinable
@@ -187,10 +196,14 @@ extension UniqueArray where Element: ~Copyable {
 @available(SwiftStdlib 5.0, *)
 extension UniqueArray where Element: ~Copyable {
   /// Return a mutable span over the maximal storage chunk following the
-  /// specified position in the array. The span provides direct mutating access
-  /// to all array elements in the range `index ..< count`.
+  /// specified position in the array.
+  ///
+  /// The returned span provides direct mutating access to all array elements
+  /// in the range `index ..< count`.
   ///
   /// - Parameter index: A valid index in the array, including the end index.
+  ///   When `mutableSpan(after:)` returns, `index` is equal to the array's
+  ///   `endIndex`.
   ///
   /// - Complexity: O(1)
   @_lifetime(&self)
@@ -201,10 +214,14 @@ extension UniqueArray where Element: ~Copyable {
   }
 
   /// Return a mutable span over the maximal storage chunk preceding the specified
-  /// position in the array. The span provides direct mutating access to all
-  /// array elements in the range `0 ..< index`.
+  /// position in the array.
+  ///
+  /// The returned span provides direct mutating access to all array elements
+  /// in the range `0 ..< index`.
   ///
   /// - Parameter index: A valid index in the array, including the end index.
+  ///   When `mutableSpan(before:)` returns, `index` is equal to the array's
+  ///   `startIndex`.
   ///
   /// - Complexity: O(1)
   @_lifetime(&self)
@@ -291,7 +308,7 @@ extension UniqueArray {
   public func clone() -> Self {
     UniqueArray(consuming: _storage.clone())
   }
-  
+
   /// Copy the contents of this array into a newly allocated unique array
   /// instance with the specified capacity.
   ///

--- a/Sources/BitCollections/BitArray/BitArray+Collection.swift
+++ b/Sources/BitCollections/BitArray/BitArray+Collection.swift
@@ -45,7 +45,7 @@ extension BitArray: RandomAccessCollection, MutableCollection {
   @inlinable @inline(__always)
   public var startIndex: Int { 0 }
 
-  /// The collection’s “past the end” position--that is, the position one step
+  /// The collection's "past the end" position--that is, the position one step
   /// after the last valid subscript argument.
   ///
   /// - Complexity: O(1)

--- a/Sources/BitCollections/BitSet/BitSet+BidirectionalCollection.swift
+++ b/Sources/BitCollections/BitSet/BitSet+BidirectionalCollection.swift
@@ -120,7 +120,7 @@ extension BitSet: Collection, BidirectionalCollection {
     Index(_position: _read { $0.startIndex })
   }
 
-  /// The collection’s “past the end” position--that is, the position one step
+  /// The collection's "past the end" position--that is, the position one step
   /// after the last valid subscript argument.
   ///
   /// - Complexity: O(1)

--- a/Sources/BitCollections/BitSet/BitSet+Extras.swift
+++ b/Sources/BitCollections/BitSet/BitSet+Extras.swift
@@ -80,7 +80,7 @@ extension BitSet {
     }
   }
 
-  /// Accesses the contiguous subrange of the collection’s elements that are
+  /// Accesses the contiguous subrange of the collection's elements that are
   /// contained within a specific integer range.
   ///
   ///     let bits: BitSet = [2, 5, 6, 8, 9]
@@ -122,7 +122,7 @@ extension BitSet {
     return Slice(base: self, bounds: bounds)
   }
 
-  /// Accesses the contiguous subrange of the collection’s elements that are
+  /// Accesses the contiguous subrange of the collection's elements that are
   /// contained within a specific integer range expression.
   ///
   ///     let bits: BitSet = [2, 5, 6, 8, 9]

--- a/Sources/DequeModule/Deque/Deque+Collection.swift
+++ b/Sources/DequeModule/Deque/Deque+Collection.swift
@@ -188,7 +188,7 @@ extension Deque: RandomAccessCollection {
   @inline(__always)
   public var startIndex: Int { 0 }
 
-  /// The deque’s “past the end” position—that is, the position one greater than
+  /// The deque's "past the end" position—that is, the position one greater than
   /// the last valid subscript argument.
   ///
   /// For an instance of `Deque`, `endIndex` is always equal to its `count`. If
@@ -349,7 +349,7 @@ extension Deque: RandomAccessCollection {
   ///      than or equal to `startIndex` and less than `endIndex`.
   ///
   /// - Complexity: Reading an element from a deque is O(1). Writing is O(1)
-  ///    unless the deque’s storage is shared with another deque, in which case
+  ///    unless the deque's storage is shared with another deque, in which case
   ///    writing is O(`count`).
   @inlinable
   public subscript(index: Int) -> Element {
@@ -743,7 +743,7 @@ extension Deque: RangeReplaceableCollection {
   /// Inserts a new element at the specified position.
   ///
   /// The new element is inserted before the element currently at the specified
-  /// index. If you pass the deque’s `endIndex` as the `index` parameter, the
+  /// index. If you pass the deque's `endIndex` as the `index` parameter, the
   /// new element is appended to the deque.
   ///
   /// - Parameters:

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Insertions.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Insertions.swift
@@ -142,7 +142,7 @@ extension RigidDeque where Element: ~Copyable {
     }
     assert(remainder.isEmpty)
   }
-  
+
 #if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
   /// Moves the elements of an input span into this deque,
   /// starting at the specified position, and leaving the span empty.
@@ -173,7 +173,7 @@ extension RigidDeque where Element: ~Copyable {
     }
   }
 #endif
-  
+
   /// Moves the elements of an output span into this deque,
   /// starting at the specified position, and leaving the span empty.
   ///
@@ -259,7 +259,7 @@ extension RigidDeque /* where Element: Copyable */ {
   /// deque at the specified position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the deque’s `endIndex` as the `index`
+  /// specified index. If you pass the deque's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the array.
   ///
   /// Existing elements in the deque's storage are moved as needed to make room
@@ -297,7 +297,7 @@ extension RigidDeque /* where Element: Copyable */ {
   /// deque at the specified position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the deque’s `endIndex` as the `index`
+  /// specified index. If you pass the deque's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the deque.
   ///
   /// Existing elements in the deque's storage are moved as needed to make room
@@ -325,7 +325,7 @@ extension RigidDeque /* where Element: Copyable */ {
   /// Copies the elements of a span into this deque at the specified position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the deque’s `endIndex` as the `index`
+  /// specified index. If you pass the deque's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the deque.
   ///
   /// Existing elements in the deque's storage are moved as needed to make room
@@ -391,13 +391,13 @@ extension RigidDeque /* where Element: Copyable */ {
     precondition(i == items.endIndex,
                  "Broken Collection: count doesn't match contents")
   }
-  
+
 #if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
   /// Copies the elements of a container into this deque at the specified
   /// position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the deque’s `endIndex` as the `index`
+  /// specified index. If you pass the deque's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the deque.
   ///
   /// Existing elements in the deque's storage are moved as needed to make room
@@ -429,7 +429,7 @@ extension RigidDeque /* where Element: Copyable */ {
   /// position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the deque’s `endIndex` as the `index`
+  /// specified index. If you pass the deque's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the deque.
   ///
   /// Existing elements in the deque's storage are moved as needed to make room
@@ -453,7 +453,7 @@ extension RigidDeque /* where Element: Copyable */ {
     _insertCollection(
       at: index, copying: items, newCount: items.count)
   }
-  
+
 #if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
   /// Copies the elements of a container into this deque at the specified
   /// position.

--- a/Sources/DequeModule/RigidDeque/RigidDeque.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque.swift
@@ -133,7 +133,7 @@ public struct RigidDeque<Element: ~Copyable>: ~Copyable {
   deinit {
     _handle.dispose()
   }
-  
+
   @inlinable @inline(__always)
   package mutating func _takeHandle() -> _UnsafeHandle {
     exchange(&_handle, with: .allocate(capacity: 0))
@@ -167,7 +167,7 @@ extension RigidDeque where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public var capacity: Int { _assumeNonNegative(_handle.capacity) }
-  
+
   /// The number of additional elements that can be added to this deque without
   /// exceeding its storage capacity.
   ///
@@ -175,7 +175,7 @@ extension RigidDeque where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public var freeCapacity: Int { _assumeNonNegative(capacity &- count) }
-  
+
   /// A Boolean value indicating whether this rigid deque is fully populated.
   /// If this property returns true, then the array's storage is at capacity,
   /// and it cannot accommodate any additional elements.
@@ -194,31 +194,31 @@ extension RigidDeque where Element: ~Copyable {
   /// logical start position.
   ///
   /// Valid indices consist of the position of every element and a "past the
-  /// end" position that’s not valid for use as a subscript argument.
+  /// end" position that's not valid for use as a subscript argument.
   public typealias Index = Int
-  
+
   /// A Boolean value indicating whether this deque contains no elements.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @_transparent
   public var isEmpty: Bool { _handle.count == 0 }
-  
+
   /// The number of elements in this deque.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @_transparent
   public var count: Int { _handle.count }
-  
+
   /// The position of the first element in a nonempty deque. This is always zero.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @_transparent
   public var startIndex: Int { 0 }
-  
-  /// The deque’s "past the end” position—that is, the position one greater than
+
+  /// The deque's "past the end" position—that is, the position one greater than
   /// the last valid subscript argument. This is always equal to the deque's
   /// count.
   ///
@@ -226,7 +226,7 @@ extension RigidDeque where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public var endIndex: Int { _handle.count }
-  
+
   /// The range of indices that are valid for subscripting this deque.
   ///
   /// - Complexity: O(1)
@@ -316,7 +316,7 @@ extension RigidDeque where Element: ~Copyable {
   public mutating func reallocate(capacity newCapacity: Int) {
     _handle.reallocate(capacity: newCapacity)
   }
-  
+
   /// Ensure that the deque has capacity to store the specified number of
   /// elements, by growing its storage buffer if necessary.
   ///

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Insertions.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Insertions.swift
@@ -148,7 +148,7 @@ extension UniqueDeque where Element: ~Copyable {
     }
     assert(remainder.isEmpty)
   }
-  
+
 #if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
   /// Moves the elements of an input span into this deque,
   /// starting at the specified position, and leaving the span empty.
@@ -181,7 +181,7 @@ extension UniqueDeque where Element: ~Copyable {
     }
   }
 #endif
-  
+
   /// Moves the elements of an output span into this deque,
   /// starting at the specified position, and leaving the span empty.
   ///
@@ -271,7 +271,7 @@ extension UniqueDeque /* where Element: Copyable */ {
   /// deque at the specified position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the deque’s `endIndex` as the `index`
+  /// specified index. If you pass the deque's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the array.
   ///
   /// Existing elements in the deque's storage are moved as needed to make room
@@ -311,7 +311,7 @@ extension UniqueDeque /* where Element: Copyable */ {
   /// deque at the specified position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the deque’s `endIndex` as the `index`
+  /// specified index. If you pass the deque's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the deque.
   ///
   /// Existing elements in the deque's storage are moved as needed to make room
@@ -341,7 +341,7 @@ extension UniqueDeque /* where Element: Copyable */ {
   /// Copies the elements of a span into this deque at the specified position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the deque’s `endIndex` as the `index`
+  /// specified index. If you pass the deque's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the deque.
   ///
   /// Existing elements in the deque's storage are moved as needed to make room
@@ -410,13 +410,13 @@ extension UniqueDeque /* where Element: Copyable */ {
       i == items.endIndex,
       "Broken Collection: count doesn't match contents")
   }
-  
+
 #if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
   /// Copies the elements of a container into this deque at the specified
   /// position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the deque’s `endIndex` as the `index`
+  /// specified index. If you pass the deque's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the deque.
   ///
   /// Existing elements in the deque's storage are moved as needed to make room
@@ -450,7 +450,7 @@ extension UniqueDeque /* where Element: Copyable */ {
   /// position.
   ///
   /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the deque’s `endIndex` as the `index`
+  /// specified index. If you pass the deque's `endIndex` as the `index`
   /// parameter, then the new elements are appended to the end of the deque.
   ///
   /// Existing elements in the deque's storage are moved as needed to make room
@@ -476,7 +476,7 @@ extension UniqueDeque /* where Element: Copyable */ {
     _insertCollection(
       at: index, copying: items, newCount: items.count)
   }
-  
+
 #if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
   /// Copies the elements of a container into this deque at the specified
   /// position.

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque.swift
@@ -103,7 +103,7 @@ public struct UniqueDeque<Element: ~Copyable>: ~Copyable {
 public struct UniqueDeque<Element: ~Copyable>: ~Copyable {
   @usableFromInline
   package var _storage: RigidDeque<Element>
-  
+
   @_alwaysEmitIntoClient
   @inline(__always)
   package init(_storage: consuming RigidDeque<Element>) {
@@ -138,7 +138,7 @@ extension UniqueDeque where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public var capacity: Int { _assumeNonNegative(_storage.capacity) }
-  
+
   /// The number of additional elements that can be added to this array without
   /// reallocating its storage.
   ///
@@ -146,7 +146,7 @@ extension UniqueDeque where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public var freeCapacity: Int { _assumeNonNegative(_storage.freeCapacity) }
-  
+
   @_alwaysEmitIntoClient
   @_transparent
   public var _isFull: Bool { _storage.isFull }
@@ -177,7 +177,7 @@ extension UniqueDeque where Element: ~Copyable {
   @_transparent
   public var startIndex: Int { _storage.startIndex }
 
-  /// The deque’s "past the end” position—that is, the position one greater than
+  /// The deque's "past the end" position—that is, the position one greater than
   /// the last valid subscript argument. This is always equal to deque's count.
   ///
   /// - Complexity: O(1)
@@ -270,14 +270,14 @@ extension UniqueDeque where Element: ~Copyable {
     _storage.reserveCapacity(n)
   }
 
-  
+
   @_alwaysEmitIntoClient
   @_transparent
   internal mutating func _ensureFreeCapacity(_ freeCapacity: Int) {
     guard _storage.freeCapacity < freeCapacity else { return }
     _ensureFreeCapacitySlow(freeCapacity)
   }
-  
+
   @_alwaysEmitIntoClient
   @_transparent
   internal func _grow(freeCapacity: Int) -> Int {

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Collection.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Collection.swift
@@ -128,7 +128,7 @@ extension TreeDictionary: Collection {
     return Index(_root: _root.unmanaged, version: _version, path: path)
   }
 
-  /// The collection’s “past the end” position—that is, the position one greater
+  /// The collection's "past the end" position—that is, the position one greater
   /// than the last valid subscript argument.
   ///
   /// - Complexity: O(1)

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Keys.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Keys.swift
@@ -14,7 +14,7 @@ import InternalCollectionsUtilities
 #endif
 
 extension TreeDictionary {
-  /// A view of a persistent dictionary’s keys, as a standalone collection.
+  /// A view of a persistent dictionary's keys, as a standalone collection.
   @frozen
   public struct Keys {
     @usableFromInline

--- a/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Values.swift
+++ b/Sources/HashTreeCollections/TreeDictionary/TreeDictionary+Values.swift
@@ -14,7 +14,7 @@ import InternalCollectionsUtilities
 #endif
 
 extension TreeDictionary {
-  /// A view of a dictionary’s values.
+  /// A view of a dictionary's values.
   @frozen
   public struct Values {
     @usableFromInline

--- a/Sources/HashTreeCollections/TreeSet/TreeSet+Collection.swift
+++ b/Sources/HashTreeCollections/TreeSet/TreeSet+Collection.swift
@@ -128,7 +128,7 @@ extension TreeSet: Collection {
     return Index(_root: _root.unmanaged, version: _version, path: path)
   }
 
-  /// The collection’s “past the end” position—that is, the position one greater
+  /// The collection's "past the end" position—that is, the position one greater
   /// than the last valid subscript argument.
   ///
   /// - Complexity: O(1)

--- a/Sources/HashTreeCollections/TreeSet/TreeSet+Extras.swift
+++ b/Sources/HashTreeCollections/TreeSet/TreeSet+Extras.swift
@@ -21,7 +21,7 @@ extension TreeSet {
   /// Calling this method invalidates all existing indices of the collection.
   ///
   /// - Parameter position: The index of the member to remove. `position` must
-  ///    be a valid index of the set, and it must not be equal to the set’s
+  ///    be a valid index of the set, and it must not be equal to the set's
   ///    end index.
   /// - Returns: The element that was removed from the set.
   /// - Complexity: O(log(`count`)) if set storage might be shared; O(1)

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.SubSequence.swift
@@ -103,7 +103,7 @@ extension OrderedDictionary.Elements.SubSequence {
 }
 
 extension OrderedDictionary.Elements.SubSequence: Sequence {
-  // A type representing the collection’s elements.
+  // A type representing the collection's elements.
   public typealias Element = OrderedDictionary.Element
 
   /// The type that allows iteration over the collection's elements.

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Values.swift
@@ -273,7 +273,7 @@ extension OrderedDictionary.Values: RandomAccessCollection {
     end - start
   }
 
-  /// Call `body(p)`, where `p` is a buffer pointer to the collection’s
+  /// Call `body(p)`, where `p` is a buffer pointer to the collection's
   /// contiguous storage. `OrderedDictionary.Values` values always have
   /// contiguous storage.
   ///

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+RandomAccessCollection.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+RandomAccessCollection.swift
@@ -43,7 +43,7 @@ extension OrderedSet: Sequence {
     return (Iterator(_elements: self, _position: copied), copied)
   }
 
-  /// Call `body(p)`, where `p` is a buffer pointer to the collection’s
+  /// Call `body(p)`, where `p` is a buffer pointer to the collection's
   /// contiguous storage. Ordered sets always have contiguous storage.
   ///
   /// - Parameter body: A function to call. The function must not escape its

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+SubSequence.swift
@@ -70,7 +70,7 @@ extension OrderedSet.SubSequence: CustomDebugStringConvertible {
 #endif
 
 extension OrderedSet.SubSequence: Sequence {
-  // A type representing the collection’s elements.
+  // A type representing the collection's elements.
   public typealias Element = OrderedSet.Element
   /// The type that allows iteration over the collection's elements.
   public typealias Iterator = IndexingIterator<Self>
@@ -104,7 +104,7 @@ extension OrderedSet.SubSequence: Sequence {
             copied)
   }
 
-  /// Call `body(p)`, where `p` is a buffer pointer to the collection’s
+  /// Call `body(p)`, where `p` is a buffer pointer to the collection's
   /// contiguous storage. Ordered sets always have contiguous storage.
   ///
   /// - Parameter body: A function to call. The function must not escape its

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary+Initializers.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary+Initializers.swift
@@ -114,7 +114,7 @@ extension SortedDictionary {
   /// by the given closure and whose values are arrays of the elements that
   /// returned each key.
   ///
-  /// The arrays in the “values” position of the new sorted dictionary each contain at least
+  /// The arrays in the "values" position of the new sorted dictionary each contain at least
   /// one element, with the elements in the same order as the source sequence.
   /// The following example declares an array of names, and then creates a sorted dictionary
   /// from that array by grouping the names by first letter:
@@ -123,7 +123,7 @@ extension SortedDictionary {
   ///     let studentsByLetter = SortedDictionary(grouping: students, by: { $0.first! })
   ///     // ["A": ["Abena", "Akosua"], "E": ["Efua"], "K": ["Kofi", "Kweku"]]
   ///
-  /// The new `studentsByLetter` sorted dictionary has three entries, with students’ names
+  /// The new `studentsByLetter` sorted dictionary has three entries, with students' names
   /// grouped by the keys `"A"`, `"E"`, and `"K"`
   ///
   ///

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary+Partial RangeReplaceableCollection.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary+Partial RangeReplaceableCollection.swift
@@ -130,7 +130,7 @@ extension SortedDictionary {
   ///
   /// - Parameter index: The position of the key-value pair to remove. `index`
   ///     must be a valid index of the sorted dictionary, and must not equal the sorted
-  ///     dictionary’s end index.
+  ///     dictionary's end index.
   /// - Returns: The key-value pair that correspond to `index`.
   /// - Complexity: O(`log n`) where `n` is the number of key-value pairs in the
   ///   sorted dictionary.

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary+Subscripts.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary+Subscripts.swift
@@ -18,7 +18,7 @@ extension SortedDictionary {
   /// the dictionary, or nil if the key is not found.
   ///
   /// When you assign a value for a key and that key already exists, the dictionary overwrites
-  /// the existing value. If the dictionary doesn’t contain the key, the key and value are added
+  /// the existing value. If the dictionary doesn't contain the key, the key and value are added
   /// as a new key-value pair.
   ///
   /// - Parameter key: The key to find in the dictionary.
@@ -72,7 +72,7 @@ extension SortedDictionary {
     }
   }
   
-  /// Accesses the value with the given key. If the dictionary doesn’t contain the given
+  /// Accesses the value with the given key. If the dictionary doesn't contain the given
   /// key, accesses the provided default value as if the key and default value existed
   /// in the dictionary.
   ///
@@ -81,7 +81,7 @@ extension SortedDictionary {
   ///
   /// - Parameters:
   ///   - key: The key the look up in the dictionary.
-  ///   - defaultValue: The default value to use if key doesn’t exist in the dictionary.
+  ///   - defaultValue: The default value to use if key doesn't exist in the dictionary.
   /// - Returns: The value associated with key in the dictionary; otherwise, defaultValue.
   /// - Complexity: O(`log n`)
   @inlinable

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary.swift
@@ -141,7 +141,7 @@ extension SortedDictionary {
   ///   - value: The new value to add to the dictionary.
   ///   - key: The key to associate with value. If key already exists in the
   ///       dictionary, value replaces the existing associated value. If key
-  ///       isn’t already a key of the dictionary, the `(key, value)` pair
+  ///       isn't already a key of the dictionary, the `(key, value)` pair
   ///       is added.
   /// - Returns: The value that was replaced, or nil if a new key-value
   ///     pair was added.

--- a/Sources/SortedCollections/SortedSet/SortedSet+Partial RangeReplaceableCollection.swift
+++ b/Sources/SortedCollections/SortedSet/SortedSet+Partial RangeReplaceableCollection.swift
@@ -130,7 +130,7 @@ extension SortedSet {
   ///
   /// - Parameter index: The position of the key-value pair to remove. `index`
   ///     must be a valid index of the sorted dictionary, and must not equal the sorted
-  ///     dictionary’s end index.
+  ///     dictionary's end index.
   /// - Returns: The key-value pair that correspond to `index`.
   /// - Complexity: O(`log n`) where `n` is the number of members in the
   ///   sorted set.


### PR DESCRIPTION
The indexes passed to span(after:) and friends on UniqueArray and RigidArray are modified before return. This adds notes about the updated values to the method documentation, along with a few other minor formatting changes (dropping smart quotes, single-sentence abstracts).

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
