### PR TITLE
Add `async` overloads of all `OutputSpan` providing APIs

### DIFF
--- a/Sources/BasicContainers/RigidArray/RigidArray+Append.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Append.swift
@@ -89,6 +89,37 @@ extension RigidArray where Element: ~Copyable {
     }
     return try initializer(&span)
   }
+
+  /// Append a given number of items to the end of this array by populating
+  /// an output span.
+  ///
+  /// If the array does not have sufficient capacity to store the new items in
+  /// the buffer, then this triggers a runtime error.
+  ///
+  /// - Parameters
+  ///    - count: The number of items to append to the array.
+  ///    - body: A callback that gets called precisely once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is allowed to initialize fewer than `count` items. The array is
+  ///       appended however many items the callback adds to the output span
+  ///       before it returns (or before it throws an error).
+  ///
+  /// - Complexity: O(`count`)
+  @_alwaysEmitIntoClient
+  public nonisolated(nonsending) mutating func append<E: Error, Result: ~Copyable>(
+      count: Int,
+      initializingWith body: nonisolated(nonsending) (inout OutputSpan<Element>) async throws(E) -> Result
+  ) async throws(E) -> Result {
+    // FIXME: This is extremely similar to `edit()`, except it provides a narrower span.
+    precondition(freeCapacity >= count, "RigidArray capacity overflow")
+    let buffer = _freeSpace._extracting(first: count)
+    var span = OutputSpan(buffer: buffer, initializedCount: 0)
+    defer {
+        _count &+= span.finalize(for: buffer)
+        span = OutputSpan()
+    }
+    return try await body(&span)
+  }
 }
 
 @available(SwiftStdlib 5.0, *)

--- a/Sources/BasicContainers/RigidArray/RigidArray+Initializers.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Initializers.swift
@@ -62,6 +62,25 @@ extension RigidArray where Element: ~Copyable {
     self.init(capacity: capacity)
     try edit(initializer)
   }
+
+  /// Creates a new array with the specified capacity, directly initializing
+  /// its storage using an async closure that populates an output span.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array.
+  ///   - body: A callback that gets called precisely once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is allowed to add fewer than `capacity` items. The array is
+  ///       initialized with however many items the callback adds to the
+  ///       output span before it returns (or before it throws an error).
+  @inlinable
+  public nonisolated(nonsending) init<E: Error>(
+    capacity: Int,
+    initializingWith body: nonisolated(nonsending) (inout OutputSpan<Element>) async throws(E) -> Void
+  ) async throws(E) {
+    self.init(capacity: capacity)
+    try await edit(body)
+  }
 }
 
 @available(SwiftStdlib 5.0, *)

--- a/Sources/BasicContainers/RigidArray/RigidArray+Insertions.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Insertions.swift
@@ -117,6 +117,46 @@ extension RigidArray where Element: ~Copyable {
     }
     try initializer(&span)
   }
+
+  /// Inserts a given number of new items into this array at the specified
+  /// position, using an async callback to directly initialize array storage by
+  /// populating an output span.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new items.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - count: The number of items to insert into the array.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///    - body: A callback that gets called precisely once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is called with an empty output span of capacity matching the
+  ///       supplied count, and it must fully populate it before returning.
+  ///
+  /// - Complexity: O(`self.count` + `count`)
+  @inlinable
+  public nonisolated(nonsending) mutating func insert<Result: ~Copyable>(
+    count: Int,
+    at index: Int,
+    initializingWith body: nonisolated(nonsending) (inout OutputSpan<Element>) async -> Result
+  ) async -> Result {
+    // FIXME: This does not allow `body` to throw, to prevent having to move the tail twice. Is that okay?
+    precondition(index >= 0 && index <= self.count, "Index out of bounds")
+    precondition(count <= freeCapacity, "RigidArray capacity overflow")
+    let target = unsafe _openGap(at: index, count: count)
+    var span = OutputSpan(buffer: target, initializedCount: 0)
+    defer {
+      let c = span.finalize(for: target)
+      precondition(c == count, "Inserted fewer items than promised")
+      _count &+= c
+      span = OutputSpan()
+    }
+    return await body(&span)
+  }
 }
 
 @available(SwiftStdlib 5.0, *)

--- a/Sources/BasicContainers/RigidArray/RigidArray+Replacements.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Replacements.swift
@@ -99,6 +99,45 @@ extension RigidArray where Element: ~Copyable {
     }
     try initializer(&span)
   }
+
+  @_alwaysEmitIntoClient
+  public nonisolated(nonsending) mutating func replace<Result: ~Copyable>(
+    removing subrange: Range<Int>,
+    addingCount newItemCount: Int,
+    initializingWith initializer: nonisolated(nonsending) (inout OutputSpan<Element>) async -> Result
+  ) async -> Result {
+    _checkValidBounds(subrange)
+    precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    precondition(
+      newItemCount - subrange.count <= freeCapacity,
+      "RigidArray capacity overflow")
+    return await _uncheckedReplace(
+      removing: subrange,
+      addingCount: newItemCount,
+      initializingWith: initializer)
+  }
+
+  @_alwaysEmitIntoClient
+  internal nonisolated(nonsending) mutating func _uncheckedReplace<Result: ~Copyable>(
+    removing subrange: Range<Int>,
+    addingCount newItemCount: Int,
+    initializingWith initializer: nonisolated(nonsending) (inout OutputSpan<Element>) async -> Result
+  ) async -> Result {
+    unsafe _items.extracting(subrange).deinitialize()
+    let target = _resizeGap(in: subrange, to: newItemCount)
+    var span = OutputSpan(buffer: target, initializedCount: 0)
+    defer {
+      let c = span.finalize(for: target)
+      if c < newItemCount {
+        self._closeGap(
+          at: subrange.lowerBound &+ c,
+          count: newItemCount &- c)
+        _count &-= newItemCount &- c
+      }
+      span = OutputSpan()
+    }
+    return await initializer(&span)
+  }
 }
 
 @available(SwiftStdlib 5.0, *)

--- a/Sources/BasicContainers/RigidArray/RigidArray.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray.swift
@@ -227,6 +227,35 @@ extension RigidArray where Element: ~Copyable {
     return try body(&span)
   }
 
+  /// Arbitrarily edit the storage underlying this array by invoking a
+  /// user-supplied async closure with a mutable `OutputSpan` view over it.
+  /// This method calls its function argument precisely once, allowing it to
+  /// arbitrarily modify the contents of the output span it is given.
+  /// The argument is free to add, remove or reorder any items; however,
+  /// it is not allowed to replace the span or change its capacity.
+  ///
+  /// When the function argument finishes (whether by returning or throwing an
+  /// error) the rigid array instance is updated to match the final contents of
+  /// the output span.
+  ///
+  /// - Parameter body: A function that edits the contents of this array through
+  ///    an `OutputSpan` argument. This method invokes this function
+  ///    precisely once.
+  /// - Returns: This method returns the result of its function argument.
+  /// - Complexity: Adds O(1) overhead to the complexity of the function
+  ///    argument.
+  @inlinable
+  public nonisolated(nonsending) mutating func edit<E: Error, R: ~Copyable>(
+    _ body: nonisolated(nonsending) (inout OutputSpan<Element>) async throws(E) -> R
+  ) async throws(E) -> R {
+    var span = OutputSpan(buffer: _storage, initializedCount: _count)
+    defer {
+      _count = span.finalize(for: _storage)
+      span = OutputSpan()
+    }
+    return try await body(&span)
+  }
+
   // FIXME: Stop using and remove this in favor of `edit`
   @unsafe
   @inlinable

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Append.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Append.swift
@@ -68,6 +68,31 @@ extension UniqueArray where Element: ~Copyable {
       addingCount: newItemCount,
       initializingWith: initializer)
   }
+
+  /// Append a given number of items to the end of this array by populating
+  /// an output span with an async closure.
+  ///
+  /// If the array does not have sufficient capacity to hold the requested
+  /// number of new elements, then this reallocates the array's storage to
+  /// grow its capacity, using a geometric growth rate.
+  ///
+  /// - Parameters
+  ///    - count: The number of items to append to the array.
+  ///    - body: A callback that gets called precisely once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is allowed to initialize fewer than `count` items. The array is
+  ///       appended however many items the callback adds to the output span
+  ///       before it returns (or before it throws an error).
+  ///
+  /// - Complexity: O(`count`)
+  @_alwaysEmitIntoClient
+  public nonisolated(nonsending) mutating func append<E: Error, Result: ~Copyable>(
+    count: Int,
+    initializingWith body: nonisolated(nonsending) (inout OutputSpan<Element>) async throws(E) -> Result
+  ) async throws(E) -> Result {
+    _ensureFreeCapacity(count)
+    return try await _storage.append(count: count, initializingWith: body)
+  }
 }
 
 @available(SwiftStdlib 5.0, *)

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Initializers.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Initializers.swift
@@ -53,6 +53,25 @@ extension UniqueArray where Element: ~Copyable {
     self.init(minimumCapacity: capacity)
     try edit(body)
   }
+
+  /// Creates a new array with the specified capacity, directly initializing
+  /// its storage using an async closure that populates an output span.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array.
+  ///   - body: A callback that gets called precisely once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is allowed to add fewer than `capacity` items. The array is
+  ///       initialized with however many items the callback adds to the
+  ///       output span before it returns (or before it throws an error).
+  @inlinable
+  public nonisolated(nonsending) init<E: Error>(
+    capacity: Int,
+    initializingWith body: nonisolated(nonsending) (inout OutputSpan<Element>) async throws(E) -> Void
+  ) async throws(E) {
+    self.init(capacity: capacity)
+    try await edit(body)
+  }
 }
 
 @available(SwiftStdlib 5.0, *)

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Insertions.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Insertions.swift
@@ -94,6 +94,38 @@ extension UniqueArray where Element: ~Copyable {
       at: index,
       initializingWith: initializer)
   }
+
+  /// Inserts a given number of new items into this array at the specified
+  /// position, using an async callback to directly initialize array storage by
+  /// populating an output span.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new items.
+  ///
+  /// If the array does not have sufficient capacity to hold the new elements,
+  /// then this reallocates storage to extend its capacity, using a geometric
+  /// growth rate.
+  ///
+  /// - Parameters:
+  ///    - count: The number of items to insert into the array.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///    - body: A callback that gets called precisely once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is called with an empty output span of capacity matching the
+  ///       supplied count, and it must fully populate it before returning.
+  ///
+  /// - Complexity: O(`self.count` + `count`)
+  @inlinable
+  public nonisolated(nonsending) mutating func insert<Result: ~Copyable>(
+    count: Int,
+    at index: Int,
+    initializingWith body: nonisolated(nonsending) (inout OutputSpan<Element>) async -> Result
+  ) async -> Result {
+    // FIXME: This does not allow `body` to throw, to prevent having to move the tail twice. Is that okay?
+    _ensureFreeCapacity(count)
+    return await _storage.insert(count: count, at: index, initializingWith: body)
+  }
 }
 
 @available(SwiftStdlib 5.0, *)

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Replacements.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Replacements.swift
@@ -76,6 +76,47 @@ extension UniqueArray where Element: ~Copyable {
       addingCount: newItemCount,
       initializingWith: initializer)
   }
+
+  /// Replace the specified subrange of elements with new items populated by an
+  /// async callback function directly into the newly allocated storage.
+  ///
+  /// This method first removes any existing items from the target subrange.
+  /// If the array does not have sufficient capacity to accommodate the new
+  /// elements after the removal, then this reallocates the array's storage to
+  /// grow its capacity, using a geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, then
+  /// this method is equivalent to calling
+  /// `insert(count: newCount, initializingWith: body)`.
+  ///
+  /// Likewise, if you pass a zero for `newCount`, then this method
+  /// removes the elements in the given subrange without any replacement.
+  /// Calling `removeSubrange(subrange)` is preferred in this case.
+  ///
+  /// - Parameters
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///      the range must be valid indices in the array.
+  ///   - newCount: the number of items to replace the old subrange.
+  ///   - body: A callback that gets called precisely once to directly
+  ///      populate newly reserved storage within the array. The function
+  ///      is called with an empty output span of capacity `newCount`,
+  ///      and it must fully populate it before returning.
+  ///
+  /// - Complexity: O(`self.count` + `newCount`)
+  @inlinable
+  public nonisolated(nonsending) mutating func replaceSubrange<Result: ~Copyable>(
+    _ subrange: Range<Int>,
+    newCount: Int,
+    initializingWith body: nonisolated(nonsending) (inout OutputSpan<Element>) async -> Result
+  ) async -> Result {
+    // FIXME: Should we allow throwing (and a partially filled output span)?
+    // FIXME: Should we have a version of this with two closures, to allow custom-consuming the old items?
+    // replaceSubrange(5..<10, newCount: 3, consumingWith: {...}, initializingWith: {...})
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(newCount - subrange.count)
+    return await _storage.replace(
+      removing: subrange, addingCount: newCount, initializingWith: body)
+  }
 }
 
 @available(SwiftStdlib 5.0, *)

--- a/Sources/BasicContainers/UniqueArray/UniqueArray.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray.swift
@@ -154,6 +154,30 @@ extension UniqueArray where Element: ~Copyable {
   ) throws(E) -> R {
     try _storage.edit(body)
   }
+
+  /// Arbitrarily edit the storage underlying this array by invoking a
+  /// user-supplied async closure with a mutable `OutputSpan` view over it.
+  /// This method calls its function argument precisely once, allowing it to
+  /// arbitrarily modify the contents of the output span it is given.
+  /// The argument is free to add, remove or reorder any items; however,
+  /// it is not allowed to replace the span or change its capacity.
+  ///
+  /// When the function argument finishes (whether by returning or throwing an
+  /// error) the rigid array instance is updated to match the final contents of
+  /// the output span.
+  ///
+  /// - Parameter body: A function that edits the contents of this array through
+  ///    an `OutputSpan` argument. This method invokes this function
+  ///    precisely once.
+  /// - Returns: This method returns the result of its function argument.
+  /// - Complexity: Adds O(1) overhead to the complexity of the function
+  ///    argument.
+  @inlinable @inline(__always)
+  public nonisolated(nonsending) mutating func edit<E: Error, R: ~Copyable>(
+    _ body: nonisolated(nonsending) (inout OutputSpan<Element>) async throws(E) -> R
+  ) async throws(E) -> R {
+    try await _storage.edit(body)
+  }
 }
 
 //MARK: - Container primitives

--- a/Tests/BasicContainersTests/ArrayLayout.swift
+++ b/Tests/BasicContainersTests/ArrayLayout.swift
@@ -73,6 +73,44 @@ func withSomeArrayLayouts<E: Error>(
   }
 }
 
+func withSomeArrayLayouts<E: Error>(
+    _ label: String,
+    ofCapacities capacities: some Sequence<Int>,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    run body: (ArrayLayout) async throws(E) -> Void
+) async throws(E) {
+    let context = TestContext.current
+    for capacity in capacities {
+        var counts: Set<Int> = []
+        counts.insert(0)
+        counts.insert(capacity)
+        counts.insert(capacity / 2)
+        if capacity >= 1 {
+            counts.insert(1)
+            counts.insert(capacity - 1)
+        }
+        if capacity >= 2 {
+            counts.insert(2)
+            counts.insert(capacity - 2)
+        }
+        for count in counts {
+            let layout = ArrayLayout(capacity: capacity, count: count)
+            let entry = context.push("\(label): \(layout)", file: file, line: line)
+            
+            var done = false
+            defer {
+                context.pop(entry)
+                if !done {
+                    print(context.currentTrace(title: "Throwing trace"))
+                }
+            }
+            try await body(layout)
+            done = true
+        }
+    }
+}
+
 #if compiler(>=6.2)
 extension RigidArray where Element: ~Copyable {
   init(layout: ArrayLayout, using generator: (Int) -> Element) {

--- a/Tests/_CollectionsTestSupport/AssertionContexts/Combinatorics.swift
+++ b/Tests/_CollectionsTestSupport/AssertionContexts/Combinatorics.swift
@@ -59,6 +59,28 @@ public func withEvery<S: Sequence>(
   }
 }
 
+public func withEvery<S: Sequence>(
+    _ label: String,
+    in items: S,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    run body: (S.Element) async throws -> Void
+) async rethrows {
+    let context = TestContext.current
+    for item in items {
+        let entry = context.push("\(label): \(item)", file: file, line: line)
+        var done = false
+        defer {
+            context.pop(entry)
+            if !done {
+                print(context.currentTrace(title: "Throwing trace"))
+            }
+        }
+        try await body(item)
+        done = true
+    }
+}
+
 public func withEveryRange<T: Strideable>(
   _ label: String,
   in bounds: Range<T>,
@@ -82,6 +104,31 @@ public func withEveryRange<T: Strideable>(
       done = true
     }
   }
+}
+
+public func withEveryRange<T: Strideable>(
+    _ label: String,
+    in bounds: Range<T>,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    run body: (Range<T>) async throws -> Void
+) async rethrows where T.Stride == Int {
+    let context = TestContext.current
+    for lowerBound in bounds.lowerBound ... bounds.upperBound {
+        for upperBound in lowerBound ... bounds.upperBound {
+            let range = lowerBound ..< upperBound
+            let entry = context.push("\(label): \(range)", file: file, line: line)
+            var done = false
+            defer {
+                context.pop(entry)
+                if !done {
+                    print(context.currentTrace(title: "Throwing trace"))
+                }
+            }
+            try await body(range)
+            done = true
+        }
+    }
 }
 
 internal func _samples<C: Collection>(from items: C) -> [C.Element] {

--- a/Tests/_CollectionsTestSupport/Utilities/LifetimeTracker.swift
+++ b/Tests/_CollectionsTestSupport/Utilities/LifetimeTracker.swift
@@ -95,3 +95,14 @@ public func withLifetimeTracking<E: Error, R>(
   defer { tracker.check(file: file, line: line) }
   return try body(tracker)
 }
+
+@inlinable
+public func withLifetimeTracking<E: Error, R>(
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ body: (LifetimeTracker) async throws(E) -> R
+) async throws(E) -> R {
+    let tracker = LifetimeTracker()
+    defer { tracker.check(file: file, line: line) }
+    return try await body(tracker)
+}


### PR DESCRIPTION
## Motivation

It is currently not possible to use the new `OutputSpan` based APIs in asynchronous contexts. In particular, it is not possible to initialize or append to a `Unique/RigidArray` by reading asynchronously from the network or a file.

## Modifications

This PR adds new overloads to all the existing APIs that provide an `OutputSpan` to take an asynchronous closure. The PR also adds tests for all those new methods to show that they are properly working.

## Result

We can now interact with these output spans asynchronously.
