### PR TITLE
Enable full test suite for Wasm with `main` snapshots

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,9 +15,20 @@ jobs:
       linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}]'
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}]'
       macos_exclude_xcode_versions: '[{"xcode_version": "26.0"}]'
+      wasm_exclude_swift_versions: '[{"swift_version": "6.2"}, {"swift_version": "nightly-6.2"}]'
       enable_macos_checks: true
       enable_wasm_sdk_build: true
       wasm_sdk_build_command: 'swift test'
+
+  wasm-build:
+    name: Build for Wasm
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      wasm_exclude_swift_versions: '[{"swift_version": "nightly"}]'
+      enable_macos_checks: false
+      enable_linux_checks: false
+      enable_wasm_sdk_build: true
+      enable_windows_checks: false
 
   embedded-swift:
     name: Build with Embedded Swift


### PR DESCRIPTION
We should use `swift test` as `wasm_sdk_build_command` in `pull_request.yml` to actually run the tests. Previously only the library itself was built but not tested, because released versions of Swift that support Wasm didn't have working `swift test` when using non-embedded Swift SDK for Wasm.

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [N/A] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [N/A] I've updated the documentation if necessary.
