### PR TITLE
[RigidArray, HashTrees] Mark deinitializers inlinable

### DIFF
--- a/Sources/BasicContainers/RigidArray.swift
+++ b/Sources/BasicContainers/RigidArray.swift
@@ -86,6 +86,7 @@ public struct RigidArray<Element: ~Copyable>: ~Copyable {
   @usableFromInline
   internal var _count: Int
 
+  @_alwaysEmitIntoClient
   deinit {
     unsafe _storage.extracting(0 ..< _count).deinitialize()
     unsafe _storage.deallocate()

--- a/Sources/HashTreeCollections/HashNode/_HashNode+Storage.swift
+++ b/Sources/HashTreeCollections/HashNode/_HashNode+Storage.swift
@@ -42,6 +42,7 @@ extension _HashNode {
     @usableFromInline
     internal typealias UnsafeHandle = _HashNode<Key, Value>.UnsafeHandle
 
+    @inlinable
     deinit {
       UnsafeHandle.update(self) { handle in
         handle.children.deinitialize()


### PR DESCRIPTION
`RigidArray` had its deinitializer non-inlinable, and that is a minor performance issue. It also triggers bugs in the compiler/runtime due to noncopyable interactions with unspecialized generics.

The storage node deinitializer in HashTreeCollections had the same issue, with far less drastic effects.

rdar://168725862


### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
