### PR TITLE
Remove workaround for bug in OutputSpan.wUMBP

### DIFF
--- a/Sources/BasicContainers/RigidArray/RigidArray+Append.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Append.swift
@@ -150,7 +150,7 @@ extension RigidArray where Element: ~Copyable {
   public mutating func append(
     moving items: inout OutputSpan<Element>
   ) {
-    items._withUnsafeMutableBufferPointer { buffer, count in
+    items.withUnsafeMutableBufferPointer { buffer, count in
       let source = buffer._extracting(first: count)
       unsafe self.append(moving: source)
       count = 0

--- a/Sources/BasicContainers/RigidArray/RigidArray+Insertions.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Insertions.swift
@@ -197,7 +197,7 @@ extension RigidArray where Element: ~Copyable {
     moving items: inout OutputSpan<Element>,
     at index: Int
   ) {
-    items._withUnsafeMutableBufferPointer { buffer, count in
+    items.withUnsafeMutableBufferPointer { buffer, count in
       let source = buffer._extracting(first: count)
       unsafe self.insert(moving: source, at: index)
       count = 0

--- a/Sources/BasicContainers/RigidArray/RigidArray+Replacements.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Replacements.swift
@@ -242,7 +242,7 @@ extension RigidArray where Element: ~Copyable {
     moving newElements: UnsafeMutableBufferPointer<Element>,
   ) {
     replace(removing: subrange, addingCount: newElements.count) { target in
-      target._withUnsafeMutableBufferPointer { buffer, count in
+      target.withUnsafeMutableBufferPointer { buffer, count in
         count = unsafe buffer._moveInitializePrefix(from: newElements)
       }
     }
@@ -319,7 +319,7 @@ extension RigidArray where Element: ~Copyable {
     removing subrange: Range<Int>,
     moving items: inout OutputSpan<Element>
   ) {
-    items._withUnsafeMutableBufferPointer { buffer, count in
+    items.withUnsafeMutableBufferPointer { buffer, count in
       let source = buffer._extracting(first: count)
       unsafe self.replace(removing: subrange, moving: source)
       count = 0
@@ -442,7 +442,7 @@ extension RigidArray {
     copying newElements: UnsafeBufferPointer<Element>
   ) {
     replace(removing: subrange, addingCount: newElements.count) { target in
-      target._withUnsafeMutableBufferPointer { buffer, count in
+      target.withUnsafeMutableBufferPointer { buffer, count in
         count = unsafe buffer._initializePrefix(copying: newElements)
       }
     }
@@ -552,7 +552,7 @@ extension RigidArray {
     newCount: Int
   ) {
     self.replace(removing: subrange, addingCount: newCount) { target in
-      target._withUnsafeMutableBufferPointer { dst, dstCount in
+      target.withUnsafeMutableBufferPointer { dst, dstCount in
         let done: Void? = newElements.withContiguousStorageIfAvailable { src in
           let i = unsafe dst._initializePrefix(copying: src)
           precondition(

--- a/Sources/ContainersPreview/Extensions/OutputSpan+Extras.swift
+++ b/Sources/ContainersPreview/Extensions/OutputSpan+Extras.swift
@@ -41,7 +41,7 @@ extension OutputSpan where Element: ~Copyable {
   @inlinable
   package mutating func _popLast() -> Element? {
     // FIXME: This needs to be in the stdlib.
-    _withUnsafeMutableBufferPointer { buffer, count in
+    withUnsafeMutableBufferPointer { buffer, count in
       guard count > 0 else { return nil }
       count &-= 1
       return buffer.moveElement(from: count)
@@ -59,7 +59,7 @@ extension OutputSpan where Element: ~Copyable {
   ) {
     // FIXME: This needs to be in the stdlib.
     guard source.count > 0 else { return }
-    self._withUnsafeMutableBufferPointer { dst, dstCount in
+    self.withUnsafeMutableBufferPointer { dst, dstCount in
       let dstEnd = dstCount + source.count
       precondition(dstEnd <= dst.count, "OutputSpan capacity overflow")
       dst
@@ -92,7 +92,7 @@ extension OutputSpan where Element: ~Copyable {
   @_lifetime(self: copy self)
   package mutating func _append(moving source: inout OutputSpan<Element>) {
     // FIXME: This needs to be in the stdlib.
-    source._withUnsafeMutableBufferPointer { src, srcCount in
+    source.withUnsafeMutableBufferPointer { src, srcCount in
       let items = src._extracting(uncheckedFrom: 0, to: srcCount)
       self._append(moving: items)
       srcCount = 0
@@ -106,7 +106,7 @@ extension OutputSpan /*where Element: Copyable*/ {
   @_lifetime(self: copy self)
   package mutating func _append(copying source: UnsafeBufferPointer<Element>) {
     // FIXME: This needs to be in the stdlib.
-    self._withUnsafeMutableBufferPointer { dst, dstCount in
+    self.withUnsafeMutableBufferPointer { dst, dstCount in
       let dstEnd = dstCount + source.count
       precondition(dstEnd <= dst.count, "OutputSpan capacity overflow")
       dst
@@ -122,41 +122,6 @@ extension OutputSpan /*where Element: Copyable*/ {
     // FIXME: This needs to be in the stdlib.
     source.withUnsafeBufferPointer { buffer in
       self._append(copying: buffer)
-    }
-  }
-}
-
-@available(SwiftStdlib 5.0, *)
-extension OutputSpan where Element: ~Copyable {
-  @_alwaysEmitIntoClient
-  @inlinable // FIXME: This should be implied by @_aeic
-  @_lifetime(self: copy self)
-  package mutating func _withUnsafeMutableBufferPointer<E: Error, R: ~Copyable>(
-    _ body: (
-      UnsafeMutableBufferPointer<Element>,
-      _ initializedCount: inout Int
-    ) throws(E) -> R
-  ) throws(E) -> R {
-    // FIXME: Work around https://github.com/apple/swift-collections/issues/561 / rdar://169036911
-    let capacity = self.capacity
-    let r = try self.withUnsafeMutableBufferPointer { buffer, initializedCount throws(E) -> R? in
-      if buffer.count == capacity {
-        return try body(buffer, &initializedCount)
-      }
-      return nil
-    }
-    if let r { return r }
-
-    let start = self.span.withUnsafeBufferPointer { $0.baseAddress } // Wow.
-    let correctedBuffer = UnsafeMutableRawBufferPointer(
-      start: .init(mutating: start), // Wow, wow.
-      count: self.capacity &* MemoryLayout<Element>.stride)
-    return try correctedBuffer.withMemoryRebound(to: Element.self) { correctBuffer throws(E) in
-      precondition(correctBuffer.count == self.capacity)
-      return try self.withUnsafeMutableBufferPointer { badBuffer, count throws(E) in
-        precondition(badBuffer.baseAddress == correctBuffer.baseAddress)
-        return try body(correctBuffer,  &count)
-      }
     }
   }
 }

--- a/Sources/ContainersPreview/Protocols/BorrowingIteratorProtocol.swift
+++ b/Sources/ContainersPreview/Protocols/BorrowingIteratorProtocol.swift
@@ -146,7 +146,7 @@ where Self: ~Copyable & ~Escapable, Element: Copyable
   @_lifetime(self: copy self)
   @_transparent
   public mutating func copyContents(into target: inout OutputSpan<Element>) {
-    target._withUnsafeMutableBufferPointer { dst, dstCount in
+    target.withUnsafeMutableBufferPointer { dst, dstCount in
       var tail = dst._extracting(droppingFirst: dstCount)
       while !tail.isEmpty {
         let src = nextSpan(maximumCount: tail.count)

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Append.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Append.swift
@@ -169,7 +169,7 @@ extension RigidDeque where Element: ~Copyable {
   public mutating func append(
     moving items: inout OutputSpan<Element>
   ) {
-    items._withUnsafeMutableBufferPointer { buffer, count in
+    items.withUnsafeMutableBufferPointer { buffer, count in
       let source = buffer._extracting(first: count)
       unsafe self.append(moving: source)
       count = 0

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Insertions.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Insertions.swift
@@ -134,7 +134,7 @@ extension RigidDeque where Element: ~Copyable {
     guard !items.isEmpty else { return }
     var remainder = items
     insert(addingCount: items.count, at: index) { target in
-      target._withUnsafeMutableBufferPointer { buffer, count in
+      target.withUnsafeMutableBufferPointer { buffer, count in
         buffer.moveInitializeAll(
           fromContentsOf: remainder._trim(first: buffer.count))
         count = buffer.count
@@ -196,7 +196,7 @@ extension RigidDeque where Element: ~Copyable {
     moving items: inout OutputSpan<Element>,
     at index: Int
   ) {
-    items._withUnsafeMutableBufferPointer { buffer, count in
+    items.withUnsafeMutableBufferPointer { buffer, count in
       let source = buffer._extracting(first: count)
       unsafe self.insert(moving: source, at: index)
       count = 0
@@ -282,7 +282,7 @@ extension RigidDeque /* where Element: Copyable */ {
     guard items.count > 0 else { return }
     var remainder = items
     insert(addingCount: remainder.count, at: index) { target in
-      target._withUnsafeMutableBufferPointer { buffer, count in
+      target.withUnsafeMutableBufferPointer { buffer, count in
         buffer.initializeAll(
           fromContentsOf: remainder._extracting(first: buffer.count))
         remainder = remainder._extracting(droppingFirst: buffer.count)

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Prepend.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Prepend.swift
@@ -173,7 +173,7 @@ extension RigidDeque where Element: ~Copyable {
   public mutating func prepend(
     moving items: inout OutputSpan<Element>
   ) {
-    items._withUnsafeMutableBufferPointer { buffer, count in
+    items.withUnsafeMutableBufferPointer { buffer, count in
       let source = buffer._extracting(first: count)
       unsafe self.prepend(moving: source)
       count = 0

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Replacements.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Replacements.swift
@@ -194,7 +194,7 @@ extension RigidDeque where Element: ~Copyable {
   ) {
     var remainder = items
     replace(removing: subrange, addingCount: remainder.count) { target in
-      target._withUnsafeMutableBufferPointer { buffer, count in
+      target.withUnsafeMutableBufferPointer { buffer, count in
         buffer.moveInitializeAll(
           fromContentsOf: remainder._trim(first: buffer.count))
         count = buffer.count
@@ -274,7 +274,7 @@ extension RigidDeque where Element: ~Copyable {
     removing subrange: Range<Int>,
     moving items: inout OutputSpan<Element>
   ) {
-    items._withUnsafeMutableBufferPointer { buffer, count in
+    items.withUnsafeMutableBufferPointer { buffer, count in
       let source = buffer._extracting(first: count)
       unsafe self.replace(removing: subrange, moving: source)
       count = 0
@@ -372,7 +372,7 @@ extension RigidDeque /* where Element: Copyable */ {
   ) {
     var remainder = items
     replace(removing: subrange, addingCount: remainder.count) { target in
-      target._withUnsafeMutableBufferPointer { dst, dstCount in
+      target.withUnsafeMutableBufferPointer { dst, dstCount in
         dst.initializeAll(fromContentsOf: remainder._trim(first: dst.count))
         dstCount += dst.count
       }

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Append.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Append.swift
@@ -159,7 +159,7 @@ extension UniqueDeque where Element: ~Copyable {
   public mutating func append(
     moving items: inout OutputSpan<Element>
   ) {
-    items._withUnsafeMutableBufferPointer { buffer, count in
+    items.withUnsafeMutableBufferPointer { buffer, count in
       let source = buffer._extracting(first: count)
       unsafe self.append(moving: source)
       count = 0

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Insertions.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Insertions.swift
@@ -140,7 +140,7 @@ extension UniqueDeque where Element: ~Copyable {
     guard !items.isEmpty else { return }
     var remainder = items
     insert(addingCount: items.count, at: index) { target in
-      target._withUnsafeMutableBufferPointer { buffer, count in
+      target.withUnsafeMutableBufferPointer { buffer, count in
         buffer.moveInitializeAll(
           fromContentsOf: remainder._trim(first: buffer.count))
         count = buffer.count
@@ -206,7 +206,7 @@ extension UniqueDeque where Element: ~Copyable {
     moving items: inout OutputSpan<Element>,
     at index: Int
   ) {
-    items._withUnsafeMutableBufferPointer { buffer, count in
+    items.withUnsafeMutableBufferPointer { buffer, count in
       let source = buffer._extracting(first: count)
       unsafe self.insert(moving: source, at: index)
       count = 0
@@ -296,7 +296,7 @@ extension UniqueDeque /* where Element: Copyable */ {
     guard items.count > 0 else { return }
     var remainder = items
     insert(addingCount: remainder.count, at: index) { target in
-      target._withUnsafeMutableBufferPointer { buffer, count in
+      target.withUnsafeMutableBufferPointer { buffer, count in
         buffer.initializeAll(
           fromContentsOf: remainder._extracting(first: buffer.count))
         remainder = remainder._extracting(droppingFirst: buffer.count)

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Prepend.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Prepend.swift
@@ -164,7 +164,7 @@ extension UniqueDeque where Element: ~Copyable {
   public mutating func prepend(
     moving items: inout OutputSpan<Element>
   ) {
-    items._withUnsafeMutableBufferPointer { buffer, count in
+    items.withUnsafeMutableBufferPointer { buffer, count in
       let source = buffer._extracting(first: count)
       unsafe self.prepend(moving: source)
       count = 0

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Replacements.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Replacements.swift
@@ -200,7 +200,7 @@ extension UniqueDeque where Element: ~Copyable {
   ) {
     var remainder = items
     replaceSubrange(subrange, addingCount: remainder.count) { target in
-      target._withUnsafeMutableBufferPointer { buffer, count in
+      target.withUnsafeMutableBufferPointer { buffer, count in
         buffer.moveInitializeAll(
           fromContentsOf: remainder._trim(first: buffer.count))
         count = buffer.count
@@ -282,7 +282,7 @@ extension UniqueDeque where Element: ~Copyable {
     _ subrange: Range<Int>,
     moving items: inout OutputSpan<Element>
   ) {
-    items._withUnsafeMutableBufferPointer { buffer, count in
+    items.withUnsafeMutableBufferPointer { buffer, count in
       let source = buffer._extracting(first: count)
       unsafe self.replaceSubrange(subrange, moving: source)
       count = 0
@@ -381,7 +381,7 @@ extension UniqueDeque /* where Element: Copyable */ {
   ) {
     var remainder = items
     replaceSubrange(subrange, addingCount: remainder.count) { target in
-      target._withUnsafeMutableBufferPointer { dst, dstCount in
+      target.withUnsafeMutableBufferPointer { dst, dstCount in
         dst.initializeAll(fromContentsOf: remainder._trim(first: dst.count))
         dstCount += dst.count
       }


### PR DESCRIPTION
This will likely fail CI until we get a newer 6.3 snapshot.

Resolves #561 

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
