### PR TITLE
`RigidArray`/`UniqueArray`: Add new copying span initializers

### DIFF
--- a/Sources/BasicContainers/RigidArray/RigidArray+Initializers.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Initializers.swift
@@ -171,6 +171,24 @@ extension RigidArray /*where Element: Copyable*/ {
     self.init(capacity: capacity ?? contents.count)
     self.append(copying: contents)
   }
+
+  /// Creates a new array with the specified capacity, holding a copy
+  /// of the contents of the given span.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array, or nil to allocate
+  ///      just enough capacity to store the contents of the span.
+  ///   - span: The span whose contents to copy into the new array.
+  ///      The span must not contain more than `capacity` elements.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public init(
+    capacity: Int? = nil,
+    copying span: Span<Element>
+  ) {
+    self.init(capacity: capacity ?? span.count)
+    self.append(copying: span)
+  }
 }
 
 // FIXME: Add init(moving:), init(consuming:)

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Initializers.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Initializers.swift
@@ -139,6 +139,23 @@ extension UniqueArray /*where Element: Copyable*/ {
   }
 #endif
 
+  /// Creates a new array with the specified capacity, holding a copy
+  /// of the contents of the given span.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array, or nil to allocate
+  ///      just enough capacity to store the contents of the span.
+  ///   - span: The span whose contents to copy into the new array.
+  ///      The span must not contain more than `capacity` elements.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public init(
+    capacity: Int? = nil,
+    copying span: Span<Element>
+  ) {
+    self.init(capacity: capacity ?? span.count)
+    self.append(copying: span)
+  }
 }
 
 #endif

--- a/Tests/BasicContainersTests/RigidArrayTests.swift
+++ b/Tests/BasicContainersTests/RigidArrayTests.swift
@@ -191,6 +191,29 @@ class RigidArrayTests: CollectionTestCase {
 #endif
 #endif
 
+  func test_init_copying_Span() {
+    withSomeArrayLayouts("layout", ofCapacities: [0, 10, 100]) { layout in
+      withLifetimeTracking { tracker in
+        let a = tracker.rigidArray(layout: layout)
+        let b = RigidArray(capacity: layout.capacity, copying: a.span)
+        expectEqual(tracker.instances, layout.count)
+        expectEqual(b.capacity, layout.capacity)
+        expectEqual(b.count, layout.count)
+        expectEqual(b.freeCapacity, layout.capacity - layout.count)
+        expectEqual(b.isEmpty, layout.count == 0)
+        expectEqual(b.isFull, layout.count == layout.capacity)
+        for i in 0 ..< layout.count {
+          expectEqual(b[i].payload, i)
+        }
+        expectIterableContents(
+          b,
+          equivalentTo: 0 ..< layout.count,
+          by: { $0.payload == $1 },
+          printer: { "\($0.payload)" })
+      }
+    }
+  }
+
   func test_span() {
     withSomeArrayLayouts("layout", ofCapacities: [0, 10, 100]) { layout in
       withLifetimeTracking { tracker in

--- a/Tests/BasicContainersTests/UniqueArrayTests.swift
+++ b/Tests/BasicContainersTests/UniqueArrayTests.swift
@@ -227,6 +227,28 @@ class UniqueArrayTests: CollectionTestCase {
 #endif
 #endif
 
+  func test_init_copying_Span() {
+    withSomeArrayLayouts("layout", ofCapacities: [0, 10, 100]) { layout in
+      withLifetimeTracking { tracker in
+        let a = tracker.uniqueArray(layout: layout)
+        let b = UniqueArray(capacity: layout.capacity, copying: a.span)
+        expectEqual(tracker.instances, layout.count)
+        expectEqual(b.capacity, layout.capacity)
+        expectEqual(b.count, layout.count)
+        expectEqual(b.freeCapacity, layout.capacity - layout.count)
+        expectEqual(b.isEmpty, layout.count == 0)
+        for i in 0 ..< layout.count {
+          expectEqual(b[i].payload, i)
+        }
+        expectIterableContents(
+          b,
+          equivalentTo: 0 ..< layout.count,
+          by: { $0.payload == $1 },
+          printer: { "\($0.payload)" })
+      }
+    }
+  }
+
   func test_span() {
     withSomeArrayLayouts("layout", ofCapacities: [0, 10, 100]) { layout in
       withLifetimeTracking { tracker in


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Collections!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:

    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
