### PR TITLE
Update docs for Container.nextSpan(after:maximumCount:)

### DIFF
--- a/Sources/BasicContainers/RigidArray/RigidArray+Container.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Container.swift
@@ -285,25 +285,73 @@ extension RigidArray where Element: ~Copyable {
     index._advance(by: &n, limitedBy: limit)
   }
 
-  /// Return a span over the array's storage that begins with the element at the given index,
-  /// and extends to the end of the contiguous storage chunk that contains it. On return, the index
-  /// is updated to address the next item following the end of the returned span.
+  /// Return a span over the array's storage that begins with the element at
+  /// the given index, and extends to the end of the contiguous storage chunk
+  /// that contains it, but no more than `maximumCount` items.
   ///
-  /// This method can be used to efficiently process the items of a container in bulk, by
-  /// directly iterating over its piecewise contiguous pieces of storage:
+  /// On return, the index is updated to address the next item following the
+  /// end of the returned span.
+  ///
+  /// This method can be used to efficiently process the items of a container in
+  /// bulk, by directly iterating over its piecewise contiguous pieces of
+  /// storage:
   ///
   ///     var index = items.startIndex
   ///     while true {
-  ///       let span = items.nextSpan(after: &index)
+  ///       let span = items.nextSpan(after: &index, maximumCount: 4)
   ///       if span.isEmpty { break }
   ///       // Process items in `span`
   ///     }
   ///
-  /// - Parameter index: A valid index in the array, including the end index. On return, this
-  ///     index is advanced by the count of the resulting span, to simplify iteration.
-  /// - Returns: A span over contiguous storage that starts at the given index. If the input index
-  ///     is the end index, then this returns an empty span. Otherwise the result is non-empty,
-  ///     with its first element matching the element at the input index.
+  /// The `maximumCount` argument gives the caller control over the number of
+  /// items it receives from the iterator. This lets the caller avoid getting
+  /// more elements than it would be able to immediately process, which would
+  /// significantly complicate container use.
+  ///
+  /// If the caller is able to process any number available items, it can signal
+  /// that by passing `Int.max` as the `maximumCount`, or simply by calling the
+  /// `nexSpan(after:)` method, which does precisely that. This is frequently
+  /// the case when the caller simply wants to iterate over the entire
+  /// container in a single loop.
+  ///
+  /// `maximumCount` sets an upper bound. To read a specific number of items,
+  /// the caller usually needs to invoke `nextSpan` in a loop:
+  ///
+  ///     var items: some Container<Int>
+  ///     var index = items.startIndex
+  ///     var remainder = numberOfItemsToRead
+  ///     while remainder > 0 {
+  ///       let next = items.nextSpan(after: &index, maximumCount: remainder)
+  ///       guard !next.isEmpty else {
+  ///         // Container does not have enough items
+  ///         break
+  ///       }
+  ///       remainder -= next.count
+  ///       // Process items in `next`
+  ///     }
+  ///
+  /// - Note: The spans returned by this method are not guaranteed to be
+  ///    disjunct. Some containers may use the same storage chunk (or parts of a
+  ///    storage chunk) multiple times, to repeat their contents.
+  ///
+  /// - Note: Repeated invocations of `nextSpan` on the same container and index
+  ///    are not guaranteed to return identical results. (This is particularly
+  ///    the case with containers that can store contents in their "inline"
+  ///    representation. Such containers may not always have a unique address
+  ///    in memory; the locations of the spans exposed by this method may vary
+  ///    between different borrows of the same container.)
+  ///
+  /// - Parameter index: A valid index in the container, including the end
+  ///     index. On return, this index is advanced by the count of the resulting
+  ///     span, to simplify iteration.
+  /// - Parameter maximumCount: The maximum number of items the caller is able
+  ///     to process immediately. `maximumCount` must be greater than zero.
+  ///     If you are able to process an arbitrary number of items, set
+  ///     `maximumCount` to `Int.max`, or call the `nextSpan(after:)` method.
+  /// - Returns: A span over contiguous storage that starts at the given index.
+  ///     If the input index is the end index, then this returns an empty span.
+  ///     Otherwise the result is non-empty, with its first element matching the
+  ///     element at the input index.
   /// - Complexity: O(1)
   @inlinable
   @_lifetime(borrow self)

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Container.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Container.swift
@@ -264,25 +264,73 @@ extension UniqueArray where Element: ~Copyable {
     _storage.formIndex(&index, offsetBy: &n, limitedBy: limit)
   }
 
-  /// Return a span over the array's storage that begins with the element at the given index,
-  /// and extends to the end of the contiguous storage chunk that contains it. On return, the index
-  /// is updated to address the next item following the end of the returned span.
+  /// Return a span over the array's storage that begins with the element at
+  /// the given index, and extends to the end of the contiguous storage chunk
+  /// that contains it, but no more than `maximumCount` items.
   ///
-  /// This method can be used to efficiently process the items of a container in bulk, by
-  /// directly iterating over its piecewise contiguous pieces of storage:
+  /// On return, the index is updated to address the next item following the
+  /// end of the returned span.
+  ///
+  /// This method can be used to efficiently process the items of a container in
+  /// bulk, by directly iterating over its piecewise contiguous pieces of
+  /// storage:
   ///
   ///     var index = items.startIndex
   ///     while true {
-  ///       let span = items.nextSpan(after: &index)
+  ///       let span = items.nextSpan(after: &index, maximumCount: 4)
   ///       if span.isEmpty { break }
   ///       // Process items in `span`
   ///     }
   ///
-  /// - Parameter index: A valid index in the array, including the end index. On return, this
-  ///     index is advanced by the count of the resulting span, to simplify iteration.
-  /// - Returns: A span over contiguous storage that starts at the given index. If the input index
-  ///     is the end index, then this returns an empty span. Otherwise the result is non-empty,
-  ///     with its first element matching the element at the input index.
+  /// The `maximumCount` argument gives the caller control over the number of
+  /// items it receives from the iterator. This lets the caller avoid getting
+  /// more elements than it would be able to immediately process, which would
+  /// significantly complicate container use.
+  ///
+  /// If the caller is able to process any number available items, it can signal
+  /// that by passing `Int.max` as the `maximumCount`, or simply by calling the
+  /// `nexSpan(after:)` method, which does precisely that. This is frequently
+  /// the case when the caller simply wants to iterate over the entire
+  /// container in a single loop.
+  ///
+  /// `maximumCount` sets an upper bound. To read a specific number of items,
+  /// the caller usually needs to invoke `nextSpan` in a loop:
+  ///
+  ///     var items: some Container<Int>
+  ///     var index = items.startIndex
+  ///     var remainder = numberOfItemsToRead
+  ///     while remainder > 0 {
+  ///       let next = items.nextSpan(after: &index, maximumCount: remainder)
+  ///       guard !next.isEmpty else {
+  ///         // Container does not have enough items
+  ///         break
+  ///       }
+  ///       remainder -= next.count
+  ///       // Process items in `next`
+  ///     }
+  ///
+  /// - Note: The spans returned by this method are not guaranteed to be
+  ///    disjunct. Some containers may use the same storage chunk (or parts of a
+  ///    storage chunk) multiple times, to repeat their contents.
+  ///
+  /// - Note: Repeated invocations of `nextSpan` on the same container and index
+  ///    are not guaranteed to return identical results. (This is particularly
+  ///    the case with containers that can store contents in their "inline"
+  ///    representation. Such containers may not always have a unique address
+  ///    in memory; the locations of the spans exposed by this method may vary
+  ///    between different borrows of the same container.)
+  ///
+  /// - Parameter index: A valid index in the container, including the end
+  ///     index. On return, this index is advanced by the count of the resulting
+  ///     span, to simplify iteration.
+  /// - Parameter maximumCount: The maximum number of items the caller is able
+  ///     to process immediately. `maximumCount` must be greater than zero.
+  ///     If you are able to process an arbitrary number of items, set
+  ///     `maximumCount` to `Int.max`, or call the `nextSpan(after:)` method.
+  /// - Returns: A span over contiguous storage that starts at the given index.
+  ///     If the input index is the end index, then this returns an empty span.
+  ///     Otherwise the result is non-empty, with its first element matching the
+  ///     element at the input index.
   /// - Complexity: O(1)
   @inlinable
   @_lifetime(borrow self)


### PR DESCRIPTION
Oops, the docs did not explain `maximumCount`.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [X] I've updated the documentation if necessary.
