### PR TITLE
[RigidArray, RigidDeque].nextSpan: Validate `maximumCount`

### DIFF
--- a/Sources/BasicContainers/RigidArray/RigidArray+Consumption.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Consumption.swift
@@ -35,9 +35,7 @@ extension RigidArray where Element: ~Copyable {
     _ subrange: Range<Int>,
     consumingWith consumer: (inout InputSpan<Element>) -> Void
   ) {
-    precondition(
-      subrange.lowerBound >= 0 && subrange.upperBound <= _count,
-      "Subrange out of bounds")
+    _checkValidBounds(subrange)
     guard !subrange.isEmpty else {
       var span = InputSpan<Element>()
       consumer(&span)

--- a/Sources/BasicContainers/RigidArray/RigidArray+Container.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Container.swift
@@ -88,13 +88,37 @@ extension RigidArray where Element: ~Copyable {
   @inlinable
   @inline(__always)
   public var indices: Range<Int> { unsafe Range(uncheckedBounds: (0, count)) }
+  
+  @_alwaysEmitIntoClient
+  @_transparent
+  package func _checkItemIndex(_ index: Int) {
+    precondition(
+      UInt(bitPattern: index) < UInt(bitPattern: _count),
+      "Index out of bounds")
+  }
+  
+  @_alwaysEmitIntoClient
+  @_transparent
+  package func _checkValidIndex(_ index: Int) {
+    precondition(
+      UInt(bitPattern: index) <= UInt(bitPattern: _count),
+      "Index out of bounds")
+  }
+  
+  @_alwaysEmitIntoClient
+  @_transparent
+  package func _checkValidBounds(_ subrange: Range<Int>) {
+    precondition(
+      subrange.lowerBound >= 0 && subrange.upperBound <= _count,
+      "Index range out of bounds")
+  }
 }
 
 @available(SwiftStdlib 5.0, *)
 extension RigidArray where Element: ~Copyable {
   @inlinable @inline(__always)
   internal func _ptr(to index: Int) -> UnsafePointer<Element> {
-    precondition(index >= 0 && index < _count, "Index out of bounds")
+    _checkItemIndex(index)
     let p = _storage.baseAddress.unsafelyUnwrapped.advanced(by: index)
     return UnsafePointer(p)
   }
@@ -103,7 +127,7 @@ extension RigidArray where Element: ~Copyable {
   internal mutating func _mutablePtr(
     to index: Int
   ) -> UnsafeMutablePointer<Element> {
-    precondition(index >= 0 && index < _count, "Index out of bounds")
+    _checkItemIndex(index)
     return _storage.baseAddress.unsafelyUnwrapped.advanced(by: index)
   }
 
@@ -140,9 +164,8 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(1)
   @inlinable
   public mutating func swapAt(_ i: Int, _ j: Int) {
-    precondition(
-      i >= 0 && i < _count && j >= 0 && j < _count,
-      "Index out of bounds")
+    _checkItemIndex(i)
+    _checkItemIndex(j)
     unsafe _items.swapAt(i, j)
   }
 }
@@ -310,7 +333,7 @@ extension RigidArray where Element: ~Copyable {
   public func nextSpan(
     after index: inout Int, maximumCount: Int
   ) -> Span<Element> {
-    precondition(UInt(bitPattern: index) <= _count, "Index out of bounds")
+    _checkValidIndex(index)
     precondition(maximumCount > 0, "maximumCount must be positive")
     let start = index
     index = start &+ Swift.min(maximumCount, _count &- start)

--- a/Sources/BasicContainers/RigidArray/RigidArray+Experimental.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Experimental.swift
@@ -22,7 +22,7 @@ extension RigidArray where Element: ~Copyable {
   @inlinable
   @_lifetime(borrow self)
   public func borrowElement(at index: Int) -> Borrow<Element> {
-    precondition(index >= 0 && index < _count, "Index out of bounds")
+    _checkItemIndex(index)
     return unsafe Borrow(
       unsafeAddress: _storage.baseAddress.unsafelyUnwrapped.advanced(by: index),
       borrowing: self
@@ -37,7 +37,7 @@ extension RigidArray where Element: ~Copyable {
   @inlinable
   @_lifetime(&self)
   public mutating func mutateElement(at index: Int) -> Mut<Element> {
-    precondition(index >= 0 && index < _count)
+    _checkItemIndex(index)
     return unsafe Mut(
       unsafeAddress: _storage.baseAddress.unsafelyUnwrapped.advanced(by: index),
       mutating: &self

--- a/Sources/BasicContainers/RigidArray/RigidArray+Insertions.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Insertions.swift
@@ -37,7 +37,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`self.count`)
   @inlinable
   public mutating func insert(_ item: consuming Element, at index: Int) {
-    precondition(index >= 0 && index <= count, "Index out of bounds")
+    _checkValidIndex(index)
     precondition(!isFull, "RigidArray capacity overflow")
     if index < count {
       let source = unsafe _storage.extracting(index ..< count)
@@ -99,7 +99,7 @@ extension RigidArray where Element: ~Copyable {
     at index: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) {
-    precondition(index >= 0 && index <= self.count, "Index out of bounds")
+    _checkValidIndex(index)
     precondition(newItemCount >= 0, "Cannot add a negative number of items")
     precondition(newItemCount <= freeCapacity, "RigidArray capacity overflow")
     let target = unsafe _openGap(at: index, count: newItemCount)
@@ -381,7 +381,7 @@ extension RigidArray {
     copying items: some Collection<Element>,
     newCount: Int
   ) {
-    precondition(index >= 0 && index <= _count, "Index out of bounds")
+    _checkValidIndex(index)
     precondition(newCount <= freeCapacity, "RigidArray capacity overflow")
     let gap = unsafe _openGap(at: index, count: newCount)
 

--- a/Sources/BasicContainers/RigidArray/RigidArray+Removals.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Removals.swift
@@ -31,7 +31,7 @@ extension RigidArray where Element: ~Copyable {
   @inlinable
   @discardableResult
   public mutating func remove(at index: Int) -> Element {
-    precondition(index >= 0 && index < _count, "Index out of bounds")
+    _checkItemIndex(index)
     let old = unsafe _storage.moveElement(from: index)
     _closeGap(at: index, count: 1)
     _count -= 1
@@ -97,9 +97,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`count`)
   @inlinable
   public mutating func removeSubrange(_  bounds: Range<Int>) {
-    precondition(
-      bounds.lowerBound >= 0 && bounds.upperBound <= _count,
-      "Subrange out of bounds")
+    _checkValidBounds(bounds)
     guard !bounds.isEmpty else { return }
     unsafe _storage.extracting(bounds).deinitialize()
     _closeGap(at: bounds.lowerBound, count: bounds.count)

--- a/Sources/BasicContainers/RigidArray/RigidArray+Replacements.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Replacements.swift
@@ -64,9 +64,7 @@ extension RigidArray where Element: ~Copyable {
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) -> Void {
-    precondition(
-      subrange.lowerBound >= 0 && subrange.upperBound <= _count,
-      "Index range out of bounds")
+    _checkValidBounds(subrange)
     precondition(newItemCount >= 0, "Cannot add a negative number of items")
     precondition(
       newItemCount - subrange.count <= freeCapacity,
@@ -158,9 +156,7 @@ extension RigidArray where Element: ~Copyable {
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) -> Void {
-    precondition(
-      subrange.lowerBound >= 0 && subrange.upperBound <= _count,
-      "Index range out of bounds")
+    _checkValidBounds(subrange)
     precondition(newItemCount >= 0, "Cannot add a negative number of items")
     precondition(
       newItemCount - subrange.count <= freeCapacity,

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Replacements.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Replacements.swift
@@ -65,9 +65,7 @@ extension UniqueArray where Element: ~Copyable {
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) -> Void {
-    precondition(
-      subrange.lowerBound >= 0 && subrange.upperBound <= self.count,
-      "Index range out of bounds")
+    _storage._checkValidBounds(subrange)
     precondition(newItemCount >= 0, "Cannot add a negative number of items")
     // FIXME: Avoid moving the subsequent elements twice on resize.
     _ensureFreeCapacity(newItemCount - subrange.count)
@@ -136,9 +134,7 @@ extension UniqueArray where Element: ~Copyable {
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) -> Void {
-    precondition(
-      subrange.lowerBound >= 0 && subrange.upperBound <= self.count,
-      "Index range out of bounds")
+    _storage._checkValidBounds(subrange)
     precondition(newItemCount >= 0, "Cannot add a negative number of items")
     _ensureFreeCapacity(newItemCount - subrange.count)
     try _storage._uncheckedReplace(

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Consumption.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Consumption.swift
@@ -42,9 +42,7 @@ extension RigidDeque where Element: ~Copyable {
     _ subrange: Range<Index>,
     consumingWith consumer: (inout InputSpan<Element>) -> Void
   ) {
-    precondition(
-      subrange.lowerBound >= 0 && subrange.upperBound <= self.count,
-      "Subrange out of bounds")
+    _checkValidBounds(subrange)
     let segments = self._handle.mutableSegments(forOffsets: subrange)
     
     var span = InputSpan(buffer: segments.first, initializedCount: segments.first.count)
@@ -232,6 +230,7 @@ extension RigidDeque where Element: ~Copyable {
     @inline(__always)
     @_lifetime(&_base)
     internal init(_base: inout RigidDeque, offsetRange: Range<Int>) {
+      _base._checkValidBounds(subrange)
       let segments = _base._handle.mutableSegments(forOffsets: offsetRange)
       self._buffer1 = segments.first
       self._buffer2 = segments.second ?? .init(start: nil, count: 0)

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Container.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Container.swift
@@ -93,7 +93,7 @@ extension RigidDeque where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_lifetime(borrow self)
   public func nextSpan(after index: inout Int, maximumCount: Int) -> Span<Element> {
-    precondition(index >= 0 && index <= count, "Index out of bounds")
+    _checkValidIndex(index)
     precondition(maximumCount > 0, "maximumCount must be positive")
     let segment = self._handle
       .nextSegment(from: index)

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Experimental.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Experimental.swift
@@ -23,7 +23,7 @@ extension RigidDeque where Element: ~Copyable {
   @_transparent
   @_lifetime(borrow self)
   public func borrowElement(at index: Int) -> Borrow<Element> {
-    precondition(index >= 0 && index < count, "Index out of bounds")
+    _checkItemIndex(index)
     let slot = _handle.slot(forOffset: index)
     return Borrow(unsafeAddress: _handle.ptr(at: slot), borrowing: self)
   }
@@ -32,7 +32,7 @@ extension RigidDeque where Element: ~Copyable {
   @_transparent
   @_lifetime(&self)
   public mutating func mutateElement(at index: Int) -> Inout<Element> {
-    precondition(index >= 0 && index < count, "Index out of bounds")
+    _checkItemIndex(index)
     let slot = _handle.slot(forOffset: index)
     return Inout(unsafeAddress: _handle.mutablePtr(at: slot), mutating: &self)
   }

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Insertions.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Insertions.swift
@@ -40,7 +40,7 @@ extension RigidDeque where Element: ~Copyable {
   @inline(__always)
   public mutating func insert(_ item: consuming Element, at index: Int) {
     precondition(!isFull, "RigidDeque capacity overflow")
-    precondition(index >= 0 && index <= count, "Index out of bounds")
+    _checkValidIndex(index)
     _handle.uncheckedInsert(item, at: index)
   }
 }
@@ -98,7 +98,7 @@ extension RigidDeque where Element: ~Copyable {
     at index: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) {
-    precondition(index >= 0 && index <= self.count, "Index out of bounds")
+    _checkValidIndex(index)
     precondition(newItemCount >= 0, "Cannot add a negative number of items")
     precondition(newItemCount <= freeCapacity, "RigidDeque capacity overflow")
     try _handle.uncheckedInsert(

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Removals.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Removals.swift
@@ -32,7 +32,7 @@ extension RigidDeque where Element: ~Copyable {
   @discardableResult
   @_alwaysEmitIntoClient
   public mutating func remove(at index: Int) -> Element {
-    precondition(index >= 0 && index < count, "Index out of bounds")
+    _checkItemIndex(index)
     return _handle.uncheckedRemove(at: index)
   }
   

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Replacements.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Replacements.swift
@@ -64,9 +64,7 @@ extension RigidDeque where Element: ~Copyable {
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) -> Void {
-    precondition(
-      subrange.lowerBound >= 0 && subrange.upperBound <= count,
-      "Subrange out of bounds")
+    _checkValidBounds(subrange)
     precondition(newItemCount >= 0, "Cannot add a negative number of items")
     precondition(
       count - subrange.count + newItemCount <= capacity,
@@ -141,9 +139,7 @@ extension RigidDeque where Element: ~Copyable {
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) -> Void {
-    precondition(
-      subrange.lowerBound >= 0 && subrange.upperBound <= count,
-      "Subrange out of bounds")
+    _checkValidBounds(subrange)
     precondition(newItemCount >= 0, "Cannot add a negative number of items")
     precondition(
       count - subrange.count + newItemCount <= capacity,

--- a/Sources/DequeModule/RigidDeque/RigidDeque.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque.swift
@@ -235,19 +235,43 @@ extension RigidDeque where Element: ~Copyable {
   public var indices: Range<Int> { unsafe Range(uncheckedBounds: (0, count)) }
 
   @_alwaysEmitIntoClient
+  @_transparent
+  package func _checkItemIndex(_ index: Int) {
+    precondition(
+      UInt(bitPattern: index) < UInt(bitPattern: _handle.count),
+      "Index out of bounds")
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  package func _checkValidIndex(_ index: Int) {
+    precondition(
+      UInt(bitPattern: index) <= UInt(bitPattern: _handle.count),
+      "Index out of bounds")
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  package func _checkValidBounds(_ subrange: Range<Int>) {
+    precondition(
+      subrange.lowerBound >= 0 && subrange.upperBound <= _handle.count,
+      "Index range out of bounds")
+  }
+
+  @_alwaysEmitIntoClient
   public subscript(position: Int) -> Element {
     // FIXME: Replace with borrow/mutate accessors
     @inline(__always)
     @_transparent
     unsafeAddress {
-      precondition(position >= 0 && position < count, "Index out of bounds")
+      _checkItemIndex(position)
       let slot = _handle.slot(forOffset: position)
       return _handle.ptr(at: slot)
     }
     @inline(__always)
     @_transparent
     unsafeMutableAddress {
-      precondition(position >= 0 && position < count, "Index out of bounds")
+      _checkItemIndex(position)
       let slot = _handle.slot(forOffset: position)
       return _handle.mutablePtr(at: slot)
     }
@@ -267,9 +291,8 @@ extension RigidDeque where Element: ~Copyable {
   /// - Complexity: O(1)
   @inlinable
   public mutating func swapAt(_ i: Int, _ j: Int) {
-    precondition(
-      i >= 0 && i < count && j >= 0 && j < count,
-      "Index out of bounds")
+    _checkItemIndex(i)
+    _checkItemIndex(j)
     _handle.uncheckedSwapAt(i, j)
   }
 }

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Insertions.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Insertions.swift
@@ -41,7 +41,7 @@ extension UniqueDeque where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public mutating func insert(_ item: consuming Element, at index: Int) {
-    precondition(index >= 0 && index <= self.count, "Index out of bounds")
+    _storage._checkValidIndex(index)
     _ensureFreeCapacity(1)
     _storage._handle.uncheckedInsert(item, at: index)
   }
@@ -102,7 +102,7 @@ extension UniqueDeque where Element: ~Copyable {
     at index: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) {
-    precondition(index >= 0 && index <= self.count, "Index out of bounds")
+    _storage._checkValidIndex(index)
     precondition(newItemCount >= 0, "Cannot add a negative number of items")
     _ensureFreeCapacity(newItemCount)
     try _storage._handle.uncheckedInsert(

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Replacements.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Replacements.swift
@@ -78,9 +78,7 @@ extension UniqueDeque where Element: ~Copyable {
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) -> Void {
-    precondition(
-      subrange.lowerBound >= 0 && subrange.upperBound <= count,
-      "Subrange out of bounds")
+    _storage._checkValidBounds(subrange)
     precondition(newItemCount >= 0, "Cannot add a negative number of items")
     _ensureFreeCapacity(newItemCount - subrange.count)
     try _storage._handle.uncheckedReplace(
@@ -148,9 +146,7 @@ extension UniqueDeque where Element: ~Copyable {
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) -> Void {
-    precondition(
-      subrange.lowerBound >= 0 && subrange.upperBound <= count,
-      "Subrange out of bounds")
+    _storage._checkValidBounds(subrange)
     precondition(newItemCount >= 0, "Cannot add a negative number of items")
     _ensureFreeCapacity(newItemCount - subrange.count)
     try _storage._handle.uncheckedReplace(


### PR DESCRIPTION
`nextSpan(after:,maximumCount:)` failed to validate that `maximumCount > 0`, potentially allowing out-of-bounds access.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
