### PR TITLE
give constant folding an opportunity to select a much faster code path for empty dictionary (and set) literals

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+ExpressibleByDictionaryLiteral.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+ExpressibleByDictionaryLiteral.swift
@@ -26,6 +26,10 @@ extension OrderedDictionary: ExpressibleByDictionaryLiteral {
   ///    high-quality hashing.
   @inlinable
   public init(dictionaryLiteral elements: (Key, Value)...) {
-    self.init(uniqueKeysWithValues: elements)
+    if elements.isEmpty {
+      self.init()
+    } else {
+      self.init(uniqueKeysWithValues: elements)
+    }
   }
 }

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+ExpressibleByArrayLiteral.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+ExpressibleByArrayLiteral.swift
@@ -27,6 +27,10 @@ extension OrderedSet: ExpressibleByArrayLiteral {
   ///    high-quality hashing.
   @inlinable
   public init(arrayLiteral elements: Element...) {
-    self.init(elements)
+    if elements.isEmpty {
+      self.init()
+    } else {
+      self.init(elements)
+    }
   }
 }


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Collections!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:

    - [x] I've completed this task
    - [ ] This task isn't completed
-->

give constant folding an opportunity to select a much faster code path for empty dictionary (and set) literals

see discussion here: https://forums.swift.org/t/poor-performance-of-element-mutation-through-ordereddictionary-values/84906

originally discovered this problem while building for WebAssembly, but the procedure call shows up at the SIL level, so it likely affects all targets not just WebAssembly

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
