### PR TITLE
Add tests that build the ContainersPreview module

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,6 +20,18 @@ jobs:
       enable_android_sdk_build: true
       enable_android_sdk_checks: true
 
+  containers-tests:
+    name: Containers Test
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.8
+    with:
+      linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}]'
+      windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}]'
+      macos_exclude_xcode_versions: '[{"xcode_version": "26.0"}, {"xcode_version": "16.3"}, {"xcode_version": "16.4"}]'
+      enable_macos_checks: true
+      enable_linux_checks: false
+      enable_windows_checks: false
+      swift_flags: --traits UnstableContainersPreview
+
   embedded-swift:
     name: Build with Embedded Swift
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.8


### PR DESCRIPTION
Adds a group of test workflows that build/test with the `UnstableContainersPreview` trait enabled.

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
