### PR TITLE
[OrderedCollections] Add OrderedDictionary.replaceElement(at:withKey:…

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
@@ -396,7 +396,22 @@ extension OrderedDictionary.Elements {
   /// Replaces the key-value pair at the specified index with a new pair,
   /// returning the original element.
   ///
-  /// The new key must not already exist in the dictionary.
+  /// The new key must either not already exist in the dictionary, or be
+  /// equal to the key currently stored at `index`. The latter form is
+  /// useful when equal keys can be distinguished by identity or some other
+  /// means — for example, replacing a decomposed Unicode string with its
+  /// precomposed equivalent:
+  ///
+  ///     var dict: OrderedDictionary = [
+  ///         "a": 1, "e\u{301}": 2, "c": 3
+  ///     ]
+  ///     dict.elements.replaceElement(at: 1, withKey: "é", value: 2)
+  ///     // dict is now ["a": 1, "é": 2, "c": 3]
+  ///
+  /// In the general case, the new pair is appended, swapped into position,
+  /// and the old element is removed from the end — each step is O(1).
+  /// When the new key compares equal to the one being replaced, the pair
+  /// is updated in place and the hash table is left untouched.
   ///
   ///     var dict: OrderedDictionary = [
   ///         "a": 1, "b": 2, "c": 3
@@ -405,16 +420,11 @@ extension OrderedDictionary.Elements {
   ///     // old == (key: "b", value: 2)
   ///     // dict is now ["a": 1, "d": 4, "c": 3]
   ///
-  /// This method appends the new pair, swaps it into position, and removes
-  /// the old element from the end, achieving expected amortized O(1)
-  /// performance — unlike `remove(at:)` followed by an insertion, which
-  /// would be O(`count`).
-  ///
   /// - Parameters:
   ///   - index: The index of the element to replace. `index` must be a valid
   ///     index of the dictionary.
-  ///   - key: The key of the new element. The dictionary must not already
-  ///     contain this key.
+  ///   - key: The key of the new element. If the dictionary already contains
+  ///     this key, it must be at `index`.
   ///   - value: The value of the new element.
   ///
   /// - Returns: The original key-value pair that was replaced.

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
@@ -393,6 +393,45 @@ extension OrderedDictionary.Elements {
     _base.swapAt(i, j)
   }
 
+  /// Replaces the key-value pair at the specified index with a new pair,
+  /// returning the original element.
+  ///
+  /// The new key must not already exist in the dictionary.
+  ///
+  ///     var dict: OrderedDictionary = [
+  ///         "a": 1, "b": 2, "c": 3
+  ///     ]
+  ///     let old = dict.elements.replaceElement(at: 1, withKey: "d", value: 4)
+  ///     // old == (key: "b", value: 2)
+  ///     // dict is now ["a": 1, "d": 4, "c": 3]
+  ///
+  /// This method appends the new pair, swaps it into position, and removes
+  /// the old element from the end, achieving expected amortized O(1)
+  /// performance — unlike `remove(at:)` followed by an insertion, which
+  /// would be O(`count`).
+  ///
+  /// - Parameters:
+  ///   - index: The index of the element to replace. `index` must be a valid
+  ///     index of the dictionary.
+  ///   - key: The key of the new element. The dictionary must not already
+  ///     contain this key.
+  ///   - value: The value of the new element.
+  ///
+  /// - Returns: The original key-value pair that was replaced.
+  ///
+  /// - Complexity: Expected amortized O(1), if `Key` implements
+  ///   high-quality hashing.
+  @inlinable
+  @inline(__always)
+  @discardableResult
+  public mutating func replaceElement(
+    at index: Int,
+    withKey key: Key,
+    value: Value
+  ) -> Element {
+    _base.replaceElement(at: index, withKey: key, value: value)
+  }
+
   /// Reorders the elements of the dictionary such that all the elements that
   /// match the given predicate are after all the elements that don't match.
   ///

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift
@@ -29,6 +29,62 @@ extension OrderedDictionary {
     _values.swapAt(i, j)
   }
 
+  /// Replaces the key-value pair at the specified index with a new pair,
+  /// returning the original element.
+  ///
+  /// The new key must not already exist in the dictionary.
+  ///
+  ///     var dict: OrderedDictionary = [
+  ///         "a": 1, "b": 2, "c": 3
+  ///     ]
+  ///     let old = dict.replaceElement(at: 1, withKey: "d", value: 4)
+  ///     // old == (key: "b", value: 2)
+  ///     // dict is now ["a": 1, "d": 4, "c": 3]
+  ///
+  /// This method appends the new pair, swaps it into position, and removes
+  /// the old element from the end, achieving expected amortized O(1)
+  /// performance — unlike `remove(at:)` followed by an insertion, which
+  /// would be O(`count`).
+  ///
+  /// - Parameters:
+  ///   - index: The index of the element to replace. `index` must be a valid
+  ///     index of the dictionary.
+  ///   - key: The key of the new element. The dictionary must not already
+  ///     contain this key.
+  ///   - value: The value of the new element.
+  ///
+  /// - Returns: The original key-value pair that was replaced.
+  ///
+  /// - Complexity: Expected amortized O(1), if `Key` implements
+  ///   high-quality hashing.
+  @inlinable
+  @discardableResult
+  public mutating func replaceElement(
+    at index: Int,
+    withKey key: Key,
+    value: Value
+  ) -> Element {
+    precondition(index >= 0 && index < count, "Index out of range")
+
+    let (existingIndex, bucket) = _keys._find(key)
+    precondition(existingIndex == nil, "Duplicate key: '\(key)'")
+
+    // Append the new key-value pair at the end — amortized O(1)
+    _keys._appendNew(key, in: bucket)
+    _values.append(value)
+
+    // Swap the new element into the target position — O(1)
+    _keys.swapAt(index, count - 1)
+    _values.swapAt(index, count - 1)
+
+    // Remove the old element from the end — O(1)
+    let oldKey = _keys.removeLast()
+    let oldValue = _values.removeLast()
+
+    _checkInvariants()
+    return (oldKey, oldValue)
+  }
+
   /// Reorders the elements of the dictionary such that all the elements that
   /// match the given predicate are after all the elements that don't match.
   ///

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift
@@ -32,7 +32,22 @@ extension OrderedDictionary {
   /// Replaces the key-value pair at the specified index with a new pair,
   /// returning the original element.
   ///
-  /// The new key must not already exist in the dictionary.
+  /// The new key must either not already exist in the dictionary, or be
+  /// equal to the key currently stored at `index`. The latter form is
+  /// useful when equal keys can be distinguished by identity or some other
+  /// means — for example, replacing a decomposed Unicode string with its
+  /// precomposed equivalent:
+  ///
+  ///     var dict: OrderedDictionary = [
+  ///         "a": 1, "e\u{301}": 2, "c": 3
+  ///     ]
+  ///     dict.replaceElement(at: 1, withKey: "é", value: 2)
+  ///     // dict is now ["a": 1, "é": 2, "c": 3]
+  ///
+  /// In the general case, the new pair is appended, swapped into position,
+  /// and the old element is removed from the end — each step is O(1).
+  /// When the new key compares equal to the one being replaced, the pair
+  /// is updated in place and the hash table is left untouched.
   ///
   ///     var dict: OrderedDictionary = [
   ///         "a": 1, "b": 2, "c": 3
@@ -41,16 +56,11 @@ extension OrderedDictionary {
   ///     // old == (key: "b", value: 2)
   ///     // dict is now ["a": 1, "d": 4, "c": 3]
   ///
-  /// This method appends the new pair, swaps it into position, and removes
-  /// the old element from the end, achieving expected amortized O(1)
-  /// performance — unlike `remove(at:)` followed by an insertion, which
-  /// would be O(`count`).
-  ///
   /// - Parameters:
   ///   - index: The index of the element to replace. `index` must be a valid
   ///     index of the dictionary.
-  ///   - key: The key of the new element. The dictionary must not already
-  ///     contain this key.
+  ///   - key: The key of the new element. If the dictionary already contains
+  ///     this key, it must be at `index`.
   ///   - value: The value of the new element.
   ///
   /// - Returns: The original key-value pair that was replaced.
@@ -67,6 +77,17 @@ extension OrderedDictionary {
     precondition(index >= 0 && index < count, "Index out of range")
 
     let (existingIndex, bucket) = _keys._find(key)
+
+    // The new key compares equal to the one already at `index` — replace
+    // in place. The hash bucket is unchanged, so no rehash is needed.
+    if existingIndex == index {
+      let oldKey = _keys.update(key, at: index)
+      let oldValue = _values[index]
+      _values[index] = value
+      _checkInvariants()
+      return (oldKey, oldValue)
+    }
+
     precondition(existingIndex == nil, "Duplicate key: '\(key)'")
 
     // Append the new key-value pair at the end — amortized O(1)

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
@@ -995,6 +995,33 @@ class OrderedDictionaryTests: CollectionTestCase {
     }
   }
 
+  func test_replaceElement() {
+    withEvery("count", in: 1 ..< 20) { count in
+      withEvery("index", in: 0 ..< count) { index in
+        withEvery("isShared", in: [false, true]) { isShared in
+          withLifetimeTracking { tracker in
+            var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
+            let newKey = tracker.instance(for: count)
+            let newValue = tracker.instance(for: count + 100)
+            let expectedOld = reference[index]
+            reference[index] = (key: newKey, value: newValue)
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
+              let old = d.replaceElement(
+                at: index, withKey: newKey, value: newValue)
+              expectEqual(old.key, expectedOld.key)
+              expectEqual(old.value, expectedOld.value)
+              expectEquivalentElements(
+                d, reference,
+                by: { $0.key == $1.key && $0.value == $1.value })
+              expectEqual(d[newKey], newValue)
+              expectNil(d[expectedOld.key])
+            }
+          }
+        }
+      }
+    }
+  }
+
   func test_partition() {
     withEvery("seed", in: 0 ..< 10) { seed in
       withEvery("count", in: 0 ..< 30) { count in

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary Tests.swift
@@ -1022,6 +1022,34 @@ class OrderedDictionaryTests: CollectionTestCase {
     }
   }
 
+  func test_replaceElement_sameKey() {
+    withEvery("count", in: 1 ..< 20) { count in
+      withEvery("index", in: 0 ..< count) { index in
+        withEvery("isShared", in: [false, true]) { isShared in
+          withLifetimeTracking { tracker in
+            var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
+            // Same payload as the existing key at `index` — equal but a
+            // distinct instance, exercising the in-place replacement path.
+            let newKey = tracker.instance(for: index)
+            let newValue = tracker.instance(for: count + 100)
+            let expectedOld = reference[index]
+            reference[index] = (key: newKey, value: newValue)
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
+              let old = d.replaceElement(
+                at: index, withKey: newKey, value: newValue)
+              expectEqual(old.key, expectedOld.key)
+              expectEqual(old.value, expectedOld.value)
+              expectEquivalentElements(
+                d, reference,
+                by: { $0.key == $1.key && $0.value == $1.value })
+              expectEqual(d[newKey], newValue)
+            }
+          }
+        }
+      }
+    }
+  }
+
   func test_partition() {
     withEvery("seed", in: 0 ..< 10) { seed in
       withEvery("count", in: 0 ..< 30) { count in

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Elements Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Elements Tests.swift
@@ -204,6 +204,34 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
     }
   }
 
+  func test_replaceElement_sameKey() {
+    withEvery("count", in: 1 ..< 20) { count in
+      withEvery("index", in: 0 ..< count) { index in
+        withEvery("isShared", in: [false, true]) { isShared in
+          withLifetimeTracking { tracker in
+            var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
+            // Same payload as the existing key at `index` — equal but a
+            // distinct instance, exercising the in-place replacement path.
+            let newKey = tracker.instance(for: index)
+            let newValue = tracker.instance(for: count + 100)
+            let expectedOld = reference[index]
+            reference[index] = (key: newKey, value: newValue)
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
+              let old = d.elements.replaceElement(
+                at: index, withKey: newKey, value: newValue)
+              expectEqual(old.key, expectedOld.key)
+              expectEqual(old.value, expectedOld.value)
+              expectEquivalentElements(
+                d, reference,
+                by: { $0.key == $1.key && $0.value == $1.value })
+              expectEqual(d[newKey], newValue)
+            }
+          }
+        }
+      }
+    }
+  }
+
   func test_partition() {
     withEvery("seed", in: 0 ..< 10) { seed in
       withEvery("count", in: 0 ..< 30) { count in

--- a/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Elements Tests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedDictionary/OrderedDictionary+Elements Tests.swift
@@ -177,6 +177,33 @@ class OrderedDictionaryElementsTests: CollectionTestCase {
     }
   }
 
+  func test_replaceElement() {
+    withEvery("count", in: 1 ..< 20) { count in
+      withEvery("index", in: 0 ..< count) { index in
+        withEvery("isShared", in: [false, true]) { isShared in
+          withLifetimeTracking { tracker in
+            var (d, reference) = tracker.orderedDictionary(keys: 0 ..< count)
+            let newKey = tracker.instance(for: count)
+            let newValue = tracker.instance(for: count + 100)
+            let expectedOld = reference[index]
+            reference[index] = (key: newKey, value: newValue)
+            withHiddenCopies(if: isShared, of: &d, checker: { $0._checkInvariants() }) { d in
+              let old = d.elements.replaceElement(
+                at: index, withKey: newKey, value: newValue)
+              expectEqual(old.key, expectedOld.key)
+              expectEqual(old.value, expectedOld.value)
+              expectEquivalentElements(
+                d, reference,
+                by: { $0.key == $1.key && $0.value == $1.value })
+              expectEqual(d[newKey], newValue)
+              expectNil(d[expectedOld.key])
+            }
+          }
+        }
+      }
+    }
+  }
+
   func test_partition() {
     withEvery("seed", in: 0 ..< 10) { seed in
       withEvery("count", in: 0 ..< 30) { count in


### PR DESCRIPTION
## Summary

Add `replaceElement(at:withKey:value:)` to `OrderedDictionary` and `OrderedDictionary.Elements`.

This method replaces the key-value pair at a given index with a new pair in expected amortized O(1) time.

```swift
var dict: OrderedDictionary = ["a": 1, "b": 2, "c": 3]
let old = dict.replaceElement(at: 1, withKey: "d", value: 4)
// old == (key: "b", value: 2)
// dict is now ["a": 1, "d": 4, "c": 3]
```

## Motivation

`OrderedDictionary` provides O(1) primitives for updating a value by key (`updateValue(_:forKey:)`), replacing a value at an index (`values[index]`), and swapping elements (`swapAt`). However, there is no single operation to replace a key-value pair at a given index when the new key has a different hash than the old one.

| Existing approach | Issue |
|---|---|
| `dict[newKey] = value` | Appends to the end; does not replace at the target index |
| `remove(at:)` + reinsertion | Correct, but O(`count`) due to element shifting |
| `updateValue(_:forKey:)` | Updates the value for an existing key; cannot change the key itself |

Callers can compose `append` → `swapAt` → `removeLast` to work around this, but the pattern is non-obvious and requires careful duplicate-key validation and bounds checking that is easy to omit. `replaceElement(at:withKey:value:)` fills this gap as a first-class operation, consistent with how `swapAt` already exposes an index-based mutation primitive.

> **Note:** If the caller only needs to update the value for the same key at a known index, `values[index] = newValue` provides a direct O(1) alternative.

## Detailed design

**Signature:**

```swift
@discardableResult
public mutating func replaceElement(
  at index: Int,
  withKey key: Key,
  value: Value
) -> Element
```

- Added to both `OrderedDictionary` and `OrderedDictionary.Elements`, matching the existing pattern for index-based mutations.
- Returns the replaced key-value pair (`@discardableResult`).
- Traps if `index` is out of bounds or `key` already exists.
- Complexity: Expected amortized O(1), if `Key` implements high-quality hashing.

**Implementation:** Appends the new pair, swaps it into the target position, and removes the old element from the end — each step is O(1).

## Testing

Tests added in both `OrderedDictionary Tests.swift` and `OrderedDictionary+Elements Tests.swift`, covering:

- Sizes 1 through 19 with every valid index position
- Both unique and shared (copy-on-write) storage via `withHiddenCopies`
- Lifetime tracking to verify no memory leaks
- Return value correctness (old key and value)
- Forward lookup (`dict[newKey] == newValue`)
- Reverse lookup (`dict[oldKey] == nil`)
- Internal invariants via `_checkInvariants()`

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
