### PR TITLE
OrderedSet: Don't crash on negative capacity values

### DIFF
--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+ReserveCapacity.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+ReserveCapacity.swift
@@ -96,7 +96,7 @@ extension OrderedSet {
     _ minimumCapacity: Int,
     persistent: Bool
   ) {
-    precondition(minimumCapacity >= 0, "Minimum capacity cannot be negative")
+    let minimumCapacity = Swift.max(minimumCapacity, 0)
     defer { _checkInvariants() }
 
     _elements.reserveCapacity(minimumCapacity)

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -786,6 +786,28 @@ class OrderedSetTests: CollectionTestCase {
     }
   }
 
+  func test_negative_capacity() {
+    // https://github.com/apple/swift-collections/issues/608
+    let set = OrderedSet<Int>(minimumCapacity: -1)
+    expectEqual(set.__unstable.scale, 0)
+    expectEqual(set.__unstable.reservedScale, 0)
+    expectEqual(set.__unstable.minimumCapacity, 0)
+    expectTrue(set.isEmpty)
+
+    let set2 = OrderedSet<Int>(minimumCapacity: -1, persistent: true)
+    expectEqual(set2.__unstable.scale, 0)
+    expectEqual(set2.__unstable.reservedScale, 0)
+    expectEqual(set2.__unstable.minimumCapacity, 0)
+    expectTrue(set2.isEmpty)
+
+    var set3 = OrderedSet<Int>([1, 2, 3])
+    set3.reserveCapacity(-1)
+    expectEqual(set3.count, 3)
+    expectTrue(set3.contains(1))
+    expectTrue(set3.contains(2))
+    expectTrue(set3.contains(3))
+  }
+
   func test_init_minimumCapacity() {
     withEvery("capacity", in: 0 ..< 1000) { capacity in
       let expectedScale = OrderedSet<Int>._scale(forCapacity: capacity)


### PR DESCRIPTION
Fixes https://github.com/apple/swift-collections/issues/608, and starts behaving similar to Set() when initialised with negative capacity

<!--
    Thanks for contributing to Swift Collections!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:

    - [x] I've completed this task
    - [ ] This task isn't completed
-->


### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
