### PR TITLE
[ContainersPreview] Don’t require `Container.Index` to conform to `Comparable`

### DIFF
--- a/Sources/ContainersPreview/CMakeLists.txt
+++ b/Sources/ContainersPreview/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(${module_name} PRIVATE
   "Protocols/Container/RandomAccessContainer.swift"
   "Protocols/Container/RangeExpression2.swift"
   "Protocols/Container/RangeReplaceableContainer.swift"
+  "Protocols/Container/Strideable+Limits.swift"
   "Protocols/BorrowingIteratorProtocol.swift"
   "Protocols/BorrowingIteratorProtocol+Copy.swift"
   "Protocols/BorrowingIteratorProtocol+ElementsEqual.swift"

--- a/Sources/ContainersPreview/Protocols/Container/BidirectionalContainer.swift
+++ b/Sources/ContainersPreview/Protocols/Container/BidirectionalContainer.swift
@@ -15,10 +15,9 @@
 
 @available(SwiftStdlib 5.0, *)
 public protocol BidirectionalContainer<Element>: Container, ~Copyable, ~Escapable
-where Element: ~Copyable
+where Element: ~Copyable, Index: Comparable
 {
   func index(before i: Index) -> Index
-
   func formIndex(before i: inout Index)
 
   @_lifetime(borrow self)
@@ -37,6 +36,119 @@ where Self: ~Copyable & ~Escapable, Element: ~Copyable {
   @_lifetime(borrow self)
   public func previousSpan(before index: inout Index) -> Span<Element> {
     previousSpan(before: &index, maximumCount: Int.max)
+  }
+
+  @inlinable
+  public func distance(from start: Index, to end: Index) -> Int {
+    var i = self.index(alignedDown: start)
+    let end = self.index(alignedDown: end)
+    var d = 0
+    if start <= end {
+      // FIXME: Use bulk iteration here, with binary search within the final chunk.
+      while i != end {
+        self.formIndex(after: &i)
+        d += 1
+      }
+    } else {
+      // FIXME: Use bulk iteration here, with binary search within the final chunk.
+      while i != end {
+        self.formIndex(before: &i)
+        d -= 1
+      }
+    }
+    return d
+  }
+
+  @inlinable
+  public func index(_ index: Index, offsetBy n: Int) -> Index {
+    var index = self.index(alignedDown: index)
+    var n = n
+    if n >= 0 {
+      while n > 0 {
+        let span = self.nextSpan(after: &index, maximumCount: n)
+        precondition(
+          !span.isEmpty,
+          "Cannot advance index beyond the end of the container")
+        n &-= span.count
+      }
+    } else {
+      n = -n
+      while n > 0 {
+        let span = self.previousSpan(before: &index, maximumCount: n)
+        precondition(
+          !span.isEmpty,
+          "Cannot advance index beyond the end of the container")
+        n &-= span.count
+      }
+    }
+    return index
+  }
+
+  @inlinable
+  public func formIndex(
+    _ index: inout Index, offsetBy n: inout Int, limitedBy limit: Index
+  ) {
+    index = self.index(alignedDown: index)
+    var n = n
+    let limit = self.index(alignedDown: limit)
+    if n >= 0 {
+      if index > limit {
+        index = self.index(index, offsetBy: n)
+        n = 0
+        return
+      }
+      // Skip forward until we find our target or overshoot the limit.
+      while n > 0 {
+        var j = index
+        let span = self.nextSpan(after: &j, maximumCount: n)
+        precondition(
+          !span.isEmpty,
+          "Cannot advance index beyond the end of the container")
+        if j > limit {
+          break
+        }
+        index = j
+        n &-= span.count
+      }
+      // Step through to find the precise target when we hit the limit.
+      // FIXME: Figure out a way to use binary search here (with `index(_:offsetBy:)`)
+      while n != 0 {
+        if index == limit {
+          return
+        }
+        formIndex(after: &index)
+        n &-= 1
+      }
+      return
+    }
+    // n < 0
+    if index < limit {
+      index = self.index(index, offsetBy: n)
+      n = 0
+      return
+    }
+    // Skip backward until we find our target or overshoot the limit.
+    while n < 0 {
+      var j = index
+      let span = self.previousSpan(before: &j, maximumCount: -n)
+      precondition(
+        !span.isEmpty,
+        "Cannot move index before the start of the container")
+      if j < limit {
+        break
+      }
+      index = j
+      n &+= span.count
+    }
+    // Step through to find the precise target when we hit the limit.
+    // FIXME: Figure out a way to use binary search here (with `index(_:offsetBy:)`)
+    while n != 0 {
+      if index == limit {
+        return
+      }
+      formIndex(before: &index)
+      n &+= 1
+    }
   }
 }
 #endif

--- a/Sources/ContainersPreview/Protocols/Container/Container.swift
+++ b/Sources/ContainersPreview/Protocols/Container/Container.swift
@@ -14,11 +14,12 @@
 #if compiler(>=6.4) && COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
 
 @available(SwiftStdlib 5.0, *)
-public protocol Container<Element>: BorrowingSequence_, ~Copyable, ~Escapable
-where Element: ~Copyable, Element == Element_
+public protocol Container<Element>:
+  BorrowingSequence_, ~Copyable, ~Escapable
+  where Element: ~Copyable, Element == Element_
 {
   associatedtype Element: ~Copyable
-  associatedtype Index: Comparable
+  associatedtype Index: Equatable
   // FIXME: Ideally Index should also be required to be Hashable.
   // FIXME: If we discard the separate BorrowingSequence abstraction, then we
   // should consider dropping Comparable and just having Equatable indices, so
@@ -28,6 +29,7 @@ where Element: ~Copyable, Element == Element_
   // somewhere -- `RandomAccessContainer` or `BidirectionalContainer` would be
   // the obvious candidates.
 
+  var isEmpty: Bool { get }
   var count: Int { get }
 
   var startIndex: Index { get }
@@ -164,10 +166,41 @@ where Element: ~Copyable, Element == Element_
   func nextSpan(after index: inout Index, maximumCount: Int) -> Span<Element>
 
   //  subscript(index: Index) -> Element { borrow }
-  
-  // FIXME: Do we want these as standard requirements this time?
+
+  /// Return the nearest valid index in this container less than or equal to
+  /// the given index value, which must be valid in at least one view of self.
+  ///
+  /// This operation is important for container types that provide multiple
+  /// alternative projections (or "views") over the same underlying
+  /// representation, with each view conforming to `Container`, and sharing
+  /// the same `Index`. (Like `String` does with its UTF-8, UTF-16,
+  /// Unicode ccalar and character views in the `Collection` world.)
+  /// This rounding operation enables clients to convert/normalize valid index
+  /// values in one container view into valid indices in another, allowing them
+  /// to (easily) decide whether two (potentially misaligned) index values
+  /// address the same element.
+  ///
+  /// The default implementation of this operation simply returns `index`.
   func index(alignedDown index: Index) -> Index
+
+  /// Return the nearest valid index in this container greater than or equal to
+  /// the given index value, which must be valid in at least one view of self.
+  ///
+  /// This operation is important for container types that provide multiple
+  /// alternative projections (or "views") over the same underlying
+  /// representation, with each view conforming to `Container`, and sharing
+  /// the same `Index`. (Like `String` does with its UTF-8, UTF-16,
+  /// Unicode ccalar and character views in the `Collection` world.)
+  /// This rounding operation enables clients to convert/normalize valid index
+  /// values in one container view into valid indices in another, allowing them
+  /// to (easily) decide whether two (potentially misaligned) index values
+  /// address the same element.
+  ///
+  /// The default implementation of this operation simply returns `index`.
   func index(alignedUp index: Index) -> Index
+
+  func _customIndexOfEquatableElement(_ element: borrowing Element) -> Index??
+  func _customLastIndexOfEquatableElement(_ element: borrowing Element) -> Index??
 }
 
 @available(SwiftStdlib 5.0, *)
@@ -229,77 +262,41 @@ extension Container where Self: ~Copyable & ~Escapable, Element: ~Copyable {
 @available(SwiftStdlib 5.0, *)
 extension Container where Self: ~Copyable & ~Escapable, Element: ~Copyable {
   @inlinable
+  public var isEmpty: Bool {
+    startIndex == endIndex
+  }
+
+  @inlinable
+  public var count: Int {
+    distance(from: startIndex, to: endIndex)
+  }
+
+  @inlinable
   public func formIndex(after index: inout Index) {
     index = self.index(after: index)
   }
 
   @inlinable
   public func index(_ index: Index, offsetBy n: Int) -> Index {
-    _defaultIndex(index, advancedBy: n)
-  }
-  
-  @inlinable
-  public func formIndex(
-    _ index: inout Index, offsetBy n: inout Int, limitedBy limit: Index
-  ) {
-    _defaultFormIndex(&index, advancedBy: &n, limitedBy: limit)
-  }
-
-  @inlinable
-  public func distance(from start: Index, to end: Index) -> Int {
-    _defaultDistance(from: start, to: end)
-  }
-
-  @inlinable
-  public func index(alignedDown index: Index) -> Index { index }
-
-  @inlinable
-  public func index(alignedUp index: Index) -> Index { index }
-}
-
-
-@available(SwiftStdlib 5.0, *)
-extension Container where Self: ~Copyable & ~Escapable, Element: ~Copyable {
-  @inlinable
-  public func _defaultDistance(from start: Index, to end: Index) -> Int {
-    // FIXME: Use binary search here (with nextSpan(after:maximumCount:))
-    var start = index(alignedDown: start)
-    let end = index(alignedDown: end)
-    if start > end {
-      return -_defaultDistance(from: end, to: start)
-    }
-    var count = 0
-    while start != end {
-      count = count + 1
-      formIndex(after: &start)
-    }
-    return count
-  }
-
-  @inlinable
-  public func _defaultIndex(_ i: Index, advancedBy distance: Int) -> Index {
     precondition(
-      distance >= 0,
+      n >= 0,
       "Only BidirectionalContainers can be advanced by a negative amount")
 
-    var i = index(alignedDown: i)
-    var distance = distance
+    var index = self.index(alignedDown: index)
+    var n = n
 
-    #if true // with nextSpan(after:maximumCount:)
-    while distance > 0 {
-      let span = self.nextSpan(after: &i, maximumCount: distance)
+#if true // with nextSpan(after:maximumCount:)
+    while n > 0 {
+      let span = self.nextSpan(after: &index, maximumCount: n)
       precondition(
         !span.isEmpty,
         "Cannot advance index beyond the end of the container")
-      distance &-= span.count
+      n &-= span.count
     }
-    return i
-    #else // without nextSpan(after:maximumCount:)
-    // FIXME: This implementation can be wasteful for contiguous containers,
-    // as iterating over spans will overshoot the target immediately.
-    // Reintroducing `nextSpan(after:maximumCount:)` would help avoid
-    // having to use a second loop to refine the result, but it would
-    // complicate conformances.
+    return index
+#else // without nextSpan(after:maximumCount:)
+    // FIXME: This implementation can be wasteful for piecewise contiguous
+    // containers, as iterating over spans will tend to overshoot the target.
 
     // Skip forward until we find the span that contains our target.
     while distance > 0 {
@@ -318,75 +315,100 @@ extension Container where Self: ~Copyable & ~Escapable, Element: ~Copyable {
       distance &-= 1
     }
     return i
-    #endif
+#endif
   }
 
   @inlinable
-  public func _defaultFormIndex(
-    _ i: inout Index,
-    advancedBy distance: inout Int,
-    limitedBy limit: Index
+  public func formIndex(
+    _ index: inout Index, offsetBy n: inout Int, limitedBy limit: Index
   ) {
     precondition(
-      distance >= 0,
+      n >= 0,
       "Only BidirectionalContainers can be advanced by a negative amount")
 
-    i = index(alignedDown: i)
-    let limit = index(alignedDown: limit)
-    if i > limit {
-      i = self.index(i, offsetBy: distance)
-      distance = 0
-      return
-    }
+    index = self.index(alignedDown: index)
+    let limit = self.index(alignedDown: limit)
 
-#if true // with nextSpan(after:maximumCount:)
-    // Skip forward until find our target or overshoot the limit.
-    while distance > 0, i < limit {
-      var j = i
-      let span = self.nextSpan(after: &j, maximumCount: distance)
-      precondition(
-        !span.isEmpty,
-        "Cannot advance index beyond the end of the container")
-      if j > limit {
-        break
-      }
-      i = j
-      distance &-= span.count
+    // Note: with Index not conforming to `Comparable`, we cannot do bulk
+    // iteration here, as we have no way to decide if we stepped over `limit`.
+    while n > 0, index != limit {
+      self.formIndex(after: &index)
+      n &-= 1
     }
-    // Step through to find the precise target.
-    // FIXME: Use binary search here
-    while distance != 0 {
-      if i == limit {
-        return
+  }
+
+  @inlinable
+  public func distance(from start: Index, to end: Index) -> Int {
+#if true
+    // This variant does not require that `start` precede `end`, but it's
+    // slower/larger.
+    // FIXME: Linked lists may require an even slower implementation
+    // to avoid looping (turtle/hare cycle detection).
+    let start = self.index(alignedDown: start)
+    let end = self.index(alignedDown: end)
+    let limit = self.endIndex
+    var a = start
+    var b = end
+    var d = 0
+    while true {
+      if a == end { return d }
+      if b == start { return -d }
+      if a == limit {
+        while b != end {
+          self.formIndex(after: &b)
+          d += 1
+        }
+        return -d
       }
-      formIndex(after: &i)
-      distance &-= 1
-    }
-#else // without nextSpan(after:maximumCount:)
-    // Skip forward until we find the span that contains our target.
-    while distance > 0 {
-      var j = i
-      let span = self.nextSpan(after: &j)
-      precondition(
-        !span.isEmpty,
-        "Cannot advance index beyond the end of the container")
-      guard span.count <= distance, j < limit else {
-        break
+      if b == limit {
+        while a != end {
+          self.formIndex(after: &a)
+          d += 1
+        }
+        return d
       }
-      i = j
-      distance &-= span.count
+      self.formIndex(after: &a)
+      self.formIndex(after: &b)
+      d += 1
     }
-    // Step through to find the precise target.
-    while distance != 0 {
-      if i == limit {
-        return
-      }
-      formIndex(after: &i)
-      distance &-= 1
+#else
+    // This variant requires that `start` precede `end`, but we cannot ensure
+    // that with a quick check, so we need to compare against the `endIndex` to
+    // avoid looping indefinitely.
+    // FIXME: Linked lists may require an even slower implementation
+    // to avoid looping (turtle/hare cycle detection).
+    let i = self.index(alignedDown: start)
+    let target = self.index(alignedDown: end)
+    let limit = self.endIndex
+    var count = 0
+    while i != target {
+      self.formIndex(after: &i)
+      precondition(i != limit, "Only BidirectionalContainers can have end come before start")
+      count += 1
     }
+    return count
 #endif
   }
+
+  @inlinable
+  public func index(alignedDown index: Index) -> Index { index }
+
+  @inlinable
+  public func index(alignedUp index: Index) -> Index { index }
+
+  @inlinable
+  public func _customIndexOfEquatableElement(_: borrowing Element) -> Index?? {
+    nil
+  }
+
+  @inlinable
+  public func _customLastIndexOfEquatableElement(
+    _ element: borrowing Element
+  ) -> Index?? {
+    nil
+  }
 }
+
 
 @available(SwiftStdlib 5.0, *)
 extension Container where Self: ~Copyable & ~Escapable, Element: ~Copyable {
@@ -395,40 +417,4 @@ extension Container where Self: ~Copyable & ~Escapable, Element: ~Copyable {
 }
 
 #endif
-
-extension Strideable {
-  @inlinable
-  package mutating func _advance(
-    by distance: inout Stride, limitedBy limit: Self
-  ) {
-    if distance >= 0 {
-      guard limit >= self else {
-        self = self.advanced(by: distance)
-        distance = 0
-        return
-      }
-      let d = Swift.min(distance, self.distance(to: limit))
-      self = self.advanced(by: d)
-      distance -= d
-    } else {
-      guard limit <= self else {
-        self = self.advanced(by: distance)
-        distance = 0
-        return
-      }
-      let d = Swift.max(distance, self.distance(to: limit))
-      self = self.advanced(by: d)
-      distance -= d
-    }
-  }
-
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  @inlinable
-  public mutating func advance(
-    by distance: inout Stride, limitedBy limit: Self
-  ) {
-    _advance(by: &distance, limitedBy: limit)
-  }
-#endif
-}
 

--- a/Sources/ContainersPreview/Protocols/Container/ContainerIterator.swift
+++ b/Sources/ContainersPreview/Protocols/Container/ContainerIterator.swift
@@ -52,24 +52,11 @@ where
 {
   public typealias Element_ = Base.Element
 
-#if true
   @_unsafeNonescapableResult // FIXME: we cannot convert from a borrow to an inout dependence?!
   @_lifetime(&self)
   public mutating func nextSpan_(maximumCount: Int) -> Span<Base.Element> {
     _base.value.nextSpan(after: &self._position, maximumCount: maximumCount)
   }
-#else
-  @_lifetime(copy self)
-  public mutating func nextSpan(maximumCount: Int) -> Span<Base.Element> {
-    var i = self._position
-    let span = _base.value.nextSpan(
-      after: &i,
-      maximumCount: maximumCount)
-    self._position = i
-    let result = _overrideLifetime(span, copying: self)
-    return result
-  }
-#endif
 
   @_lifetime(self: copy self)
   public mutating func skip_(by maximumOffset: Int) -> Int {

--- a/Sources/ContainersPreview/Protocols/Container/RangeReplaceableContainer.swift
+++ b/Sources/ContainersPreview/Protocols/Container/RangeReplaceableContainer.swift
@@ -22,7 +22,9 @@ import InternalCollectionsUtilities
 @available(SwiftStdlib 5.0, *)
 public protocol RangeReplaceableContainer<Element>
 : Container, ~Copyable, ~Escapable
-where Element: ~Copyable
+where
+  Element: ~Copyable,
+  Index: Comparable // For `Range<Index>`
 {
   // Core requirements
 

--- a/Sources/ContainersPreview/Protocols/Container/Strideable+Limits.swift
+++ b/Sources/ContainersPreview/Protocols/Container/Strideable+Limits.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0 WITH Swift-exception
+//
+//===----------------------------------------------------------------------===//
+
+extension Strideable {
+  @inlinable
+  package mutating func _advance(
+    by distance: inout Stride, limitedBy limit: Self
+  ) {
+    if distance >= 0 {
+      guard limit >= self else {
+        self = self.advanced(by: distance)
+        distance = 0
+        return
+      }
+      let d = Swift.min(distance, self.distance(to: limit))
+      self = self.advanced(by: d)
+      distance -= d
+    } else {
+      guard limit <= self else {
+        self = self.advanced(by: distance)
+        distance = 0
+        return
+      }
+      let d = Swift.max(distance, self.distance(to: limit))
+      self = self.advanced(by: d)
+      distance -= d
+    }
+  }
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  @inlinable
+  public mutating func advance(
+    by distance: inout Stride, limitedBy limit: Self
+  ) {
+    _advance(by: &distance, limitedBy: limit)
+  }
+#endif
+}

--- a/Xcode/Collections.xcodeproj/project.pbxproj
+++ b/Xcode/Collections.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		7D9748D62E9748930098631A /* BigString+Chunk+Character.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D9748CF2E9748930098631A /* BigString+Chunk+Character.swift */; };
 		7D9748D72E9748930098631A /* BigString+Chunk+Index.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D9748D02E9748930098631A /* BigString+Chunk+Index.swift */; };
 		7D9748D82E9748930098631A /* BigString+Chunk+UTF8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D9748D22E9748930098631A /* BigString+Chunk+UTF8.swift */; };
+		7D974BC42F91BCD0009A4F88 /* Strideable+Limits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D974BC32F91BCD0009A4F88 /* Strideable+Limits.swift */; };
 		7D9B75772F3E65E00048157E /* _HTable+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D9B75762F3E65DB0048157E /* _HTable+Debug.swift */; };
 		7D9B859729E4F74400B291CD /* BitArray+Shifts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D9B859129E4F74400B291CD /* BitArray+Shifts.swift */; };
 		7D9B859829E4F74400B291CD /* BitArray+Descriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D9B859229E4F74400B291CD /* BitArray+Descriptions.swift */; };
@@ -759,6 +760,7 @@
 		7D9748D12E9748930098631A /* BigString+Chunk+UnicodeScalar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BigString+Chunk+UnicodeScalar.swift"; sourceTree = "<group>"; };
 		7D9748D22E9748930098631A /* BigString+Chunk+UTF8.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BigString+Chunk+UTF8.swift"; sourceTree = "<group>"; };
 		7D9748D32E9748930098631A /* BigString+Chunk+UTF16.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BigString+Chunk+UTF16.swift"; sourceTree = "<group>"; };
+		7D974BC32F91BCD0009A4F88 /* Strideable+Limits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Strideable+Limits.swift"; sourceTree = "<group>"; };
 		7D9B75762F3E65DB0048157E /* _HTable+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HTable+Debug.swift"; sourceTree = "<group>"; };
 		7D9B859129E4F74400B291CD /* BitArray+Shifts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BitArray+Shifts.swift"; sourceTree = "<group>"; };
 		7D9B859229E4F74400B291CD /* BitArray+Descriptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BitArray+Descriptions.swift"; sourceTree = "<group>"; };
@@ -1417,17 +1419,18 @@
 		7D57EDCE2F647DB10029D5E3 /* Container */ = {
 			isa = PBXGroup;
 			children = (
-				7D57EDC52F647DB10029D5E3 /* BidirectionalContainer.swift */,
 				7D57EDC62F647DB10029D5E3 /* Container.swift */,
 				7D57EDEA2F649CEF0029D5E3 /* Container+Filter.swift */,
 				7D57EDC72F647DB10029D5E3 /* Container+SpanwiseZip.swift */,
 				7D57EDEC2F649F0C0029D5E3 /* ContainerIterator.swift */,
-				7D57EDC82F647DB10029D5E3 /* DynamicContainer.swift */,
-				7D57EDC92F647DB10029D5E3 /* MutableContainer.swift */,
-				7D57EDCA2F647DB10029D5E3 /* PermutableContainer.swift */,
+				7D57EDC52F647DB10029D5E3 /* BidirectionalContainer.swift */,
 				7D57EDCB2F647DB10029D5E3 /* RandomAccessContainer.swift */,
+				7D57EDCA2F647DB10029D5E3 /* PermutableContainer.swift */,
+				7D57EDC92F647DB10029D5E3 /* MutableContainer.swift */,
 				7D57EDCC2F647DB10029D5E3 /* RangeExpression2.swift */,
 				7D57EDCD2F647DB10029D5E3 /* RangeReplaceableContainer.swift */,
+				7D57EDC82F647DB10029D5E3 /* DynamicContainer.swift */,
+				7D974BC32F91BCD0009A4F88 /* Strideable+Limits.swift */,
 			);
 			path = Container;
 			sourceTree = "<group>";
@@ -2655,6 +2658,7 @@
 				7D479CBD2F46D05600A8CB59 /* RigidSet+Lookup.swift in Sources */,
 				7DE9212B29CA70F4004483EB /* TreeSet+SetAlgebra subtracting.swift in Sources */,
 				7D57EDE92F6499750029D5E3 /* BorrowingIteratorProtocol+Filter.swift in Sources */,
+				7D974BC42F91BCD0009A4F88 /* Strideable+Limits.swift in Sources */,
 				7DE920F629CA70F4004483EB /* BitArray+Equatable.swift in Sources */,
 				7D9B859829E4F74400B291CD /* BitArray+Descriptions.swift in Sources */,
 				7DE9212329CA70F4004483EB /* TreeSet+SetAlgebra isEqualSet.swift in Sources */,


### PR DESCRIPTION
This slows down the default implementations of `distance(from:to:)` and `index(_:offsetBy:limitedBy:)`, but it allows linked lists to conform to `Container`. The trade off seems fair.

While we’re here, flesh out the `BidirectionalContainer` refinements a little, and add `Container.isEmpty` and `._custom[Last]IndexOfEquatableElement(_:)`.

This code is still untested.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
