### PR TITLE
[BitSet] Add `BitSet.makeIterator(from:)`

### DIFF
--- a/Benchmarks/Libraries/BitSet.json
+++ b/Benchmarks/Libraries/BitSet.json
@@ -7,6 +7,54 @@
       "kind": "group",
       "title": "BitSet Operations",
       "contents": [
+        {
+          "kind": "chart",
+          "title": "iteration-00",
+          "tasks": [
+            "BitSet iteration (0% filled)",
+            "BitSet index(after:) (0% filled)"
+          ]
+        },
+        {
+          "kind": "chart",
+          "title": "iteration-00.1%",
+          "tasks": [
+            "BitSet iteration (0.1% filled)",
+            "BitSet index(after:) (0.1% filled)"
+          ]
+        },
+        {
+          "kind": "chart",
+          "title": "iteration-1%",
+          "tasks": [
+            "BitSet iteration (1% filled)",
+            "BitSet index(after:) (1% filled)"
+          ]
+        },
+        {
+          "kind": "chart",
+          "title": "iteration-10%",
+          "tasks": [
+            "BitSet iteration (10% filled)",
+            "BitSet index(after:) (10% filled)"
+          ]
+        },
+        {
+          "kind": "chart",
+          "title": "iteration-25%",
+          "tasks": [
+            "BitSet iteration (25% filled)",
+            "BitSet index(after:) (25% filled)"
+          ]
+        },
+        {
+          "kind": "chart",
+          "title": "iteration-50%",
+          "tasks": [
+            "BitSet iteration (50% filled)",
+            "BitSet index(after:) (50% filled)"
+          ]
+        },
       ]
     },
     {

--- a/Benchmarks/Sources/Benchmarks/BitsetBenchmarks.swift
+++ b/Benchmarks/Sources/Benchmarks/BitsetBenchmarks.swift
@@ -55,6 +55,34 @@ extension Benchmark {
       }
     }
 
+    for (percentage, count) in fillRatios {
+      self.add(
+        title: "BitSet index(after:) (\(percentage) filled)",
+        input: Int.self
+      ) { input in
+        guard input > 0 else { return nil }
+
+        var set = BitSet(reservingCapacity: input)
+        for i in (0 ..< input).shuffled().prefix(count(input)) {
+          set.insert(i)
+        }
+        // Make sure the set actually fills its storage capacity.
+        set.insert(input - 1)
+
+        return { timer in
+          var c = 0
+          timer.measure {
+            var i = set.startIndex
+            while i != set.endIndex {
+              c += 1
+              set.formIndex(after: &i)
+            }
+          }
+          precondition(c == set.count)
+        }
+      }
+    }
+
     self.add(
       title: "BitSet distance(from:to:)",
       input: Int.self

--- a/Sources/BitCollections/BitSet/BitSet+BidirectionalCollection.swift
+++ b/Sources/BitCollections/BitSet/BitSet+BidirectionalCollection.swift
@@ -37,6 +37,16 @@ extension BitSet: Sequence {
     return Iterator(self)
   }
 
+  /// Returns an iterator over the elements of the bit set, starting from the
+  /// given index.
+  ///
+  /// - Parameter index: A valid index of the collection.
+  /// - Complexity: O(1)
+  @inlinable
+  public func makeIterator(from index: Index) -> Iterator {
+    return Iterator(_bitset: self, from: index)
+  }
+
   public func _customContainsEquatableElement(
     _ element: Int
   ) -> Bool? {
@@ -59,6 +69,20 @@ extension BitSet: Sequence {
       self.word = bitset._read { handle in
         guard handle.wordCount > 0 else { return .empty }
         return handle._words[0]
+      }
+    }
+
+    @usableFromInline
+    internal init(_bitset: BitSet, from start: Index) {
+      self.bitset = _bitset
+      let (word, bit) = start._position.split
+      self.index = word
+      self.word = bitset._read { handle in
+        precondition(word <= handle.wordCount, "Invalid index")
+        guard word < handle.wordCount else { return .empty }
+        var w = handle._words[word]
+        w.removeAll(upTo: bit)
+        return w
       }
     }
 

--- a/Tests/BitCollectionsTests/BitSetTests.swift
+++ b/Tests/BitCollectionsTests/BitSetTests.swift
@@ -192,6 +192,29 @@ final class BitSetTest: CollectionTestCase {
     }
   }
 
+  func test_makeIterator_from() {
+    let max = 1000
+    withInterestingSets("input", maximum: max) { input in
+      let bits = BitSet(input)
+      let values = input.sorted()
+
+      withEvery("i", in: values.indices) { i in
+        let j = bits.firstIndex(of: values[i])!
+        var it = bits.makeIterator(from: j)
+
+        for k in i ..< values.count {
+          expectNotNil(it.next()) { v in
+            expectEqual(v, values[k])
+          }
+        }
+        expectNil(it.next())
+      }
+
+      var it = bits.makeIterator(from: bits.endIndex)
+      expectNil(it.next())
+    }
+  }
+
   func test_hashable() {
     // This is a silly test, but it does exercise hashing a bit.
     let classes: [[BitSet]] = [


### PR DESCRIPTION
This enables faster iteration over subranges of a BitSet than the `Slice` type’s default indexing iterator. (Depending on the fill factor, the speedup can be as high as 4x — quite measurable.)

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
