### PR TITLE
[BasicContainers] RigidSet.insert(maximumCount:from:): Fix spurious capacity overflow caused by incorrect accounting

### DIFF
--- a/Sources/BasicContainers/RigidSet/RigidSet+Insertions.swift
+++ b/Sources/BasicContainers/RigidSet/RigidSet+Insertions.swift
@@ -198,10 +198,10 @@ extension RigidSet where Element: ~Copyable {
     while remainder > 0 {
       var span = drain.drainNext(maximumCount: remainder)
       guard !span.isEmpty else { break }
+      remainder &-= span.count
       while let next = span.popFirst() {
         self.insert(next)
       }
-      remainder &-= span.count
     }
   }
 #endif

--- a/Tests/BasicContainersTests/RigidSetTests.swift
+++ b/Tests/BasicContainersTests/RigidSetTests.swift
@@ -428,6 +428,36 @@ class RigidSetTests: CollectionTestCase {
       }
     }
   }
+
+  func test_insert_drain_maximumCount() {
+    withEvery("capacity", in: [5, 10, 100]) { capacity in
+      withEvery("drainLength", in: [0, 1, 2, 4, 10, capacity]) { drainLength in
+        withEvery("maxCount", in: [0, 1, 2, 3, 5]) { maxCount in
+          withEvery("chunkSize", in: [1, 2, 3, 10]) { chunkSize in
+            withLifetimeTracking { tracker in
+              var s = RigidSet<LifetimeTracked<Int>>(capacity: capacity)
+
+              var i = 0
+              var drain = CustomDrain<LifetimeTracked<Int>>(
+                underestimatedCount: 0,
+                chunkSize: chunkSize
+              ) {
+                guard i < drainLength else { return nil }
+                defer { i += 1 }
+                return tracker.instance(for: i)
+              }
+              s.insert(maximumCount: maxCount, from: &drain)
+              expectConsistentSet(s)
+
+              let expectedCount = Swift.min(maxCount, drainLength)
+              expectEqual(s.count, expectedCount)
+              expectEqual(i, expectedCount)
+            }
+          }
+        }
+      }
+    }
+  }
 #endif
 
   func test_remove_one() {


### PR DESCRIPTION
The `remainder` variable wasn't properly updated, leading to the insertion sometimes over-consuming the drain, causing an unexpected runtime trap (due to capacity overflow).

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
