### PR TITLE
[BasicContainers] RigidArray.replace(removing:consumingWith:addingCount:initializingWith:): Fix correctness issue with partial initialization

### DIFF
--- a/Sources/BasicContainers/RigidArray/RigidArray+Replacements.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Replacements.swift
@@ -193,7 +193,8 @@ extension RigidArray where Element: ~Copyable {
         if c < newItemCount {
           self._closeGap(
             at: subrange.lowerBound &+ c,
-            count: capacity &- c)
+            count: newItemCount &- c)
+          _count &-= newItemCount &- c
         }
         span = OutputSpan()
       }

--- a/Tests/BasicContainersTests/RigidArrayTests.swift
+++ b/Tests/BasicContainersTests/RigidArrayTests.swift
@@ -1272,6 +1272,90 @@ class RigidArrayTests: CollectionTestCase {
     }
   }
 
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  func test_replace_consuming_full() {
+    withSomeArrayLayouts("layout", ofCapacities: [0, 5, 10]) { layout in
+      withEveryRange("subrange", in: 0 ..< layout.count) { subrange in
+        withEvery("c", in: 0 ..< subrange.count + layout.freeCapacity) { c in
+          withLifetimeTracking { tracker in
+            var a = tracker.rigidArray(layout: layout)
+
+            a.replace(
+              removing: subrange,
+              consumingWith: { span in
+                for i in 0 ..< subrange.count {
+                  expectEqual(span[i].payload, subrange.lowerBound + i)
+                }
+                span.removeAll()
+              },
+              addingCount: c
+            ) { target in
+              expectEqual(target.freeCapacity, c)
+              for i in 0 ..< c {
+                target.append(tracker.instance(for: layout.count + i))
+              }
+            }
+
+            var expected = Array(0 ..< layout.count)
+            expected.replaceSubrange(subrange, with: layout.count ..< layout.count + c)
+
+            expectRigidArrayContents(
+              a,
+              equivalentTo: expected,
+              by: { $0.payload == $1 },
+              printer: { "\($0.payload)" })
+            expectEqual(tracker.instances, layout.count - subrange.count + c)
+          }
+        }
+      }
+    }
+  }
+
+  func test_replace_consuming_partial() {
+    withSomeArrayLayouts("layout", ofCapacities: [0, 5, 10]) { layout in
+      guard !layout.isFull else { return }
+      withEveryRange("subrange", in: 0 ..< layout.count) { subrange in
+        withEvery("c", in: 1 ..< layout.freeCapacity) { c in
+          withEvery("n", in: [0, 1, c / 2, c - 1] as Set) { n in
+            withLifetimeTracking { tracker in
+              var a = tracker.rigidArray(layout: layout)
+
+              a.replace(
+                removing: subrange,
+                consumingWith: { span in
+                  for i in 0 ..< subrange.count {
+                    expectEqual(span[i].payload, subrange.lowerBound + i)
+                  }
+                  span.removeAll()
+                },
+                addingCount: c
+              ) { target in
+                expectTrue(target.isEmpty)
+                expectEqual(target.freeCapacity, c)
+                for i in 0 ..< n {
+                  target.append(tracker.instance(for: layout.count + i))
+                }
+              }
+
+              expectEqual(a.count, layout.count - subrange.count + n)
+              expectEqual(tracker.instances, layout.count - subrange.count + n)
+
+              var expected = Array(0 ..< layout.count)
+              expected.replaceSubrange(subrange, with: layout.count ..< layout.count + n)
+
+              expectRigidArrayContents(
+                a,
+                equivalentTo: expected,
+                by: { $0.payload == $1 },
+                printer: { "\($0.payload)" })
+            }
+          }
+        }
+      }
+    }
+  }
+#endif
+
   func test_replace_Collection() {
     withSomeArrayLayouts("layout", ofCapacities: [0, 5, 10]) { layout in
       withEveryRange("range", in: 0 ..< layout.count) { range in


### PR DESCRIPTION
The original code was invoking `_closeGap` with an incorrect size (from `append` rather than `replace`), leading to runtime traps and potential memory safety issues if the `resize` invocation ends up underfilling the container.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
