### PR TITLE
[BasicContainers] UniqueArray.replace(removing:copying): Fix overallocation issue

### DIFF
--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Replacements.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Replacements.swift
@@ -441,7 +441,7 @@ extension UniqueArray {
     copying newElements: UnsafeBufferPointer<Element>
   ) {
     // FIXME: Avoid moving the subsequent elements twice.
-    _ensureFreeCapacity(newElements.count)
+    _ensureFreeCapacity(newElements.count - subrange.count)
     unsafe _storage.replace(removing: subrange, copying: newElements)
   }
 
@@ -518,7 +518,7 @@ extension UniqueArray {
     copying newElements: Span<Element>
   ) {
     // FIXME: Avoid moving the subsequent elements twice.
-    _ensureFreeCapacity(newElements.count)
+    _ensureFreeCapacity(newElements.count - subrange.count)
     _storage.replace(removing: subrange, copying: newElements)
   }
   
@@ -605,7 +605,7 @@ extension UniqueArray {
   ) {
     // FIXME: Avoid moving the subsequent elements twice.
     let c = newElements.count
-    _ensureFreeCapacity(c)
+    _ensureFreeCapacity(c - subrange.count)
     _storage._replace(
       removing: subrange,
       copyingCollection: newElements,

--- a/Tests/BasicContainersTests/UniqueArrayTests.swift
+++ b/Tests/BasicContainersTests/UniqueArrayTests.swift
@@ -880,6 +880,10 @@ class UniqueArrayTests: CollectionTestCase {
                 by: { $0.payload == $1 },
                 printer: { "\($0.payload)" })
               expectEqual(tracker.instances, layout.count + c)
+
+              if c <= range.count {
+                expectEqual(a.capacity, layout.capacity)
+              }
             }
           }
         }
@@ -908,6 +912,10 @@ class UniqueArrayTests: CollectionTestCase {
               by: { $0.payload == $1 },
               printer: { "\($0.payload)" })
             expectEqual(tracker.instances, layout.count - range.count + c)
+
+            if c <= range.count {
+              expectEqual(a.capacity, layout.capacity)
+            }
           }
         }
       }
@@ -934,6 +942,43 @@ class UniqueArrayTests: CollectionTestCase {
               by: { $0.payload == $1 },
               printer: { "\($0.payload)" })
             expectEqual(tracker.instances, layout.count - range.count + c)
+
+            if c <= range.count {
+              expectEqual(a.capacity, layout.capacity)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  func test_replace_copying_UnsafeBufferPointer() {
+    withSomeArrayLayouts("layout", ofCapacities: [0, 5, 10]) { layout in
+      withEveryRange("range", in: 0 ..< layout.count) { range in
+        withEvery("c", in: [0, 1, 10, 100]) { c in
+          withLifetimeTracking { tracker in
+            var expected = Array(0 ..< layout.count)
+            let addition = (0 ..< c).map { -100 - $0 }
+            expected.replaceSubrange(range, with: addition)
+
+            let trackedAddition = RigidArray(
+              copying: addition.map { tracker.instance(for: $0) })
+
+            var a = tracker.uniqueArray(layout: layout)
+            trackedAddition.span.withUnsafeBufferPointer { buffer in
+              a.replace(removing: range, copying: buffer)
+            }
+
+            expectUniqueArrayContents(
+              a,
+              equivalentTo: expected,
+              by: { $0.payload == $1 },
+              printer: { "\($0.payload)" })
+            expectEqual(tracker.instances, layout.count - range.count + c)
+
+            if c <= range.count {
+              expectEqual(a.capacity, layout.capacity)
+            }
           }
         }
       }


### PR DESCRIPTION
`UniqueArray.replace(removing:copying:)` overloads overestimated the amount of memory they need, sometimes leading to unnecessary reallocations. Fix this.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
