### PR TITLE
Fix _trim(first:) returning wrong buffer region

### DIFF
--- a/Sources/BasicContainers/RigidArray/RigidArray+Consumption.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Consumption.swift
@@ -182,6 +182,7 @@ extension RigidArray where Element: ~Copyable {
       // to avoid exclusivity violations.
       self._base._pointer.pointee
         ._closeGap(at: _offsetRange.lowerBound, count: _offsetRange.count)
+      self._base._pointer.pointee._count -= _offsetRange.count
     }
   }
 }

--- a/Sources/InternalCollectionsUtilities/UnsafeMutableBufferPointer+Extras.swift
+++ b/Sources/InternalCollectionsUtilities/UnsafeMutableBufferPointer+Extras.swift
@@ -158,7 +158,7 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable {
     guard cut > 0 else { return .init(start: nil, count: 0) }
     let oldStart = baseAddress.unsafelyUnwrapped
     self = Self(start: oldStart + cut, count: count - cut)
-    return Self(start: baseAddress, count: cut)
+    return Self(start: oldStart, count: cut)
   }
 
   @_alwaysEmitIntoClient

--- a/Tests/BasicContainersTests/RigidArrayTests.swift
+++ b/Tests/BasicContainersTests/RigidArrayTests.swift
@@ -1467,5 +1467,23 @@ class RigidArrayTests: CollectionTestCase {
     expectUniqueArrayContents(transformed, equalTo: expected)
   }
 #endif
+
+#if compiler(>=6.4) && COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  func test_consume_subrange_drainNext() {
+    withLifetimeTracking { tracker in
+      var a = RigidArray<LifetimeTracked<Int>>(capacity: 4)
+      for i in 0 ..< 4 {
+        a.append(tracker.instance(for: i))
+      }
+
+      var consumer = a.consume(0 ..< 2)
+      let span = consumer.drainNext(maximumCount: .max)
+
+      expectEqual(span.count, 2)
+      expectEqual(span[0].payload, 0)
+      expectEqual(span[1].payload, 1)
+    }
+  }
+#endif
 }
 #endif


### PR DESCRIPTION
After reassigning self on line 160, baseAddress on line 161 resolves to the new self's baseAddress (oldStart + cut) instead of the original start. This causes the returned buffer to point past the actual elements into uninitialized memory. Use the captured oldStart instead.