### PR TITLE
[BasicContainers, DequeModule]: Assorted fixes

### DIFF
--- a/Sources/BasicContainers/RigidDictionary/RigidDictionary+Insertions.swift
+++ b/Sources/BasicContainers/RigidDictionary/RigidDictionary+Insertions.swift
@@ -136,7 +136,8 @@ extension RigidDictionary where Key: ~Copyable, Value: ~Copyable {
         if let value = value.take() { // Simple update
           _valuePtr(at: bucket).initialize(to: value)
         } else { // Removal
-          _ = _removeValue(at: bucket)
+          self._keyPtr(at: bucket).deinitialize(count: 1)
+          _resolveHole(at: bucket)
         }
       } else if let value = value.take() { // Insertion
         self._insertNew(key.take()!, hashValue: r.hashValue, value)

--- a/Sources/BasicContainers/RigidDictionary/RigidDictionary+Removals.swift
+++ b/Sources/BasicContainers/RigidDictionary/RigidDictionary+Removals.swift
@@ -25,9 +25,19 @@ extension RigidDictionary where Key: ~Copyable, Value: ~Copyable {
   @inlinable
   package mutating func _removeValue(at bucket: _Bucket) -> Value {
     assert(self._keys._table.isOccupied(bucket))
-    self._keys._table.createHole(at: bucket)
     self._keyPtr(at: bucket).deinitialize(count: 1)
     let oldValue = self._valuePtr(at: bucket).move()
+    _resolveHole(at: bucket)
+    return oldValue
+  }
+  
+  /// Remove the entry at `bucket`, assuming its value slot has already been
+  /// moved out (e.g., by `updateValue(forKey:with:)`). Handles key
+  /// deinitialization and hole resolution without touching the value slot.
+  @inlinable
+  package mutating func _resolveHole(at bucket: _Bucket) {
+    assert(self._keys._table.isOccupied(bucket))
+    self._keys._table.createHole(at: bucket)
     let seed = self._keys._seed
     let keys = self._keys._members.unsafelyUnwrapped
     let values = self._values.unsafelyUnwrapped
@@ -40,9 +50,8 @@ extension RigidDictionary where Key: ~Copyable, Value: ~Copyable {
         (keys + $1.offset).initialize(to: (keys + $0.offset).move())
         (values + $1.offset).initialize(to: (values + $0.offset).move())
       })
-    return oldValue
   }
-  
+
   /// Remove the member currently at the specified occupied bucket,
   /// and mark it as unoccupied, without restoring the hash table's
   /// invariants. Lookup operations may fail after this.

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Append.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Append.swift
@@ -73,7 +73,7 @@ extension RigidDeque where Element: ~Copyable {
   ///         i += 1
   ///       }
   ///     }
-  ///     // `buffer` now contains [999, 0, 1, 2, 3, 4, 5, 6]
+  ///     // `buffer` now contains [999, 0, 1, 2, 3, 4, 5]
   ///
   /// The newly appended items are not guaranteed to form a single contiguous
   /// storage region. Therefore, the supplied callback may be invoked multiple

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Consumption.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Consumption.swift
@@ -53,6 +53,7 @@ extension RigidDeque where Element: ~Copyable {
     if let second = segments.second {
       var span = InputSpan(buffer: second, initializedCount: second.count)
       consumer(&span)
+      _ = consume span
     }
     _handle.closeGap(offsets: subrange)
   }

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Consumption.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Consumption.swift
@@ -55,6 +55,7 @@ extension RigidDeque where Element: ~Copyable {
       var span = InputSpan(buffer: second, initializedCount: second.count)
       consumer(&span)
     }
+    _handle.closeGap(offsets: subrange)
   }
 
   /// Remove the specified subrange of items from this deque,

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Consumption.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Consumption.swift
@@ -33,9 +33,8 @@ extension RigidDeque where Element: ~Copyable {
   /// may not be called at all.
   ///
   /// - Parameter subrange: The subrange of items to consume from this deque.
-  /// - Parameter consumer: A function taking an input span of the removed items,
+  /// - Parameter consumer: A function taking an input span of removed items,
   ///    allowing them to be consumed straight out of the deque's storage.
-  ///    The function is called at most once.
   ///
   /// - Complexity: O(`self.count`)
   @_alwaysEmitIntoClient
@@ -72,7 +71,6 @@ extension RigidDeque where Element: ~Copyable {
   /// - Parameter subrange: The subrange of items to consume from this deque.
   /// - Parameter consumer: A function taking an input span of the removed items,
   ///    allowing them to be consumed straight out of the deque's storage.
-  ///    The function is called at most once.
   ///
   /// - Complexity: O(`self.count`)
   @_alwaysEmitIntoClient
@@ -96,7 +94,6 @@ extension RigidDeque where Element: ~Copyable {
   ///
   /// - Parameter consumer: A function taking an input span of the removed items,
   ///    allowing them to be consumed straight out of the deque's storage.
-  ///    The function is called at most once.
   /// - Complexity: O(`self.count`)
   @_alwaysEmitIntoClient
   @inline(__always)

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Container.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Container.swift
@@ -137,6 +137,8 @@ extension RigidDeque where Element: ~Copyable {
   public mutating func nextMutableSpan(
     after index: inout Int, maximumCount: Int
   ) -> MutableSpan<Element> {
+    _checkValidIndex(index)
+    precondition(maximumCount > 0, "maximumCount must be positive")
     let segment = self._handle
       .nextSegment(after: index)
       ._extracting(first: maximumCount)

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Insertions.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Insertions.swift
@@ -102,6 +102,7 @@ extension RigidDeque where Element: ~Copyable {
   ) throws(E) {
     _checkValidIndex(index)
     precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    guard newItemCount > 0 else { return }
     precondition(newItemCount <= freeCapacity, "RigidDeque capacity overflow")
     try _handle.uncheckedInsert(
       addingCount: newItemCount, at: index, initializingWith: initializer)

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Prepend.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Prepend.swift
@@ -111,6 +111,7 @@ extension RigidDeque where Element: ~Copyable {
     initializingWith body: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) -> Void {
     precondition(newItemCount >= 0, "Cannot prepend a negative number of items")
+    guard newItemCount > 0 else { return }
     precondition(freeCapacity >= newItemCount, "RigidDeque capacity overflow")
     try _handle.uncheckedPrepend(addingCount: newItemCount, initializingWith: body)
   }

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Prepend.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Prepend.swift
@@ -427,7 +427,7 @@ extension RigidDeque /*where Element: Copyable*/ {
   }
   
 #if compiler(>=6.4) && COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Copies the elements of a borrowing sequence to the end of this deque.
+  /// Copies the elements of a borrowing sequence to the front of this deque.
   ///
   /// If the deque does not have sufficient capacity to hold all items in the
   /// sequence, then this triggers a runtime error.
@@ -443,7 +443,7 @@ extension RigidDeque /*where Element: Copyable*/ {
     self._prepend(copying: items)
   }
 
-  /// Copies the elements of a borrowing sequence to the end of this deque.
+  /// Copies the elements of a borrowing sequence to the front of this deque.
   ///
   /// If the deque does not have sufficient capacity to hold all items in the
   /// sequence, then this triggers a runtime error.
@@ -459,7 +459,7 @@ extension RigidDeque /*where Element: Copyable*/ {
     self._prepend(copying: items, exactCount: items.count)
   }
 
-  /// Copies the elements of a container to the end of this deque.
+  /// Copies the elements of a container to the front of this deque.
   ///
   /// If the deque does not have sufficient capacity to hold all items in the
   /// sequence, then this triggers a runtime error.
@@ -475,7 +475,7 @@ extension RigidDeque /*where Element: Copyable*/ {
     self._prepend(copying: items, exactCount: items.count)
   }
 
-  /// Copies the elements of a container to the end of this deque.
+  /// Copies the elements of a container to the front of this deque.
   ///
   /// If the deque does not have sufficient capacity to hold all items in the
   /// sequence, then this triggers a runtime error.

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Prepend.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Prepend.swift
@@ -67,13 +67,13 @@ extension RigidDeque where Element: ~Copyable {
   ///     var buffer = RigidDeque<Int>(capacity: 20)
   ///     buffer.append(999)
   ///     var i = 0
-  ///     buffer.prepend(count: 6) { target in
+  ///     buffer.prepend(addingCount: 6) { target in
   ///       while !target.isFull {
   ///         target.append(i)
   ///         i += 1
   ///       }
   ///     }
-  ///     // `buffer` now contains [0, 1, 2, 3, 4, 5, 6, 999]
+  ///     // `buffer` now contains [0, 1, 2, 3, 4, 5, 999]
   ///
   /// The newly prepended items are not guaranteed to form a single contiguous
   /// storage region. Therefore, the supplied callback may be invoked multiple
@@ -203,7 +203,6 @@ extension RigidDeque where Element: ~Copyable {
   /// - Parameters:
   ///    - maximumCount: The maximum number of items to prepend to the deque, or
   ///       nil to use all available capacity.
-
   ///    - producer: A producer that generates the items to prepend.
   ///
   /// - Complexity: O(`newItemCount ?? self.freeCapacity`)

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Replacements.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Replacements.swift
@@ -497,6 +497,9 @@ extension RigidDeque /* where Element: Copyable */ {
         items.formIndex(after: &i)
       }
     }
+    precondition(
+      i == items.endIndex,
+      "Broken Collection: count doesn't match contents")
   }
 
 #if compiler(>=6.4) && COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Replacements.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Replacements.swift
@@ -43,7 +43,7 @@ extension RigidDeque where Element: ~Copyable {
   /// times to initialize each successive chunk of storage. However, invocations
   /// cease if the callback fails to fully populate its output span or if
   /// it throws an error. In such cases, the deque keeps all items that were
-  /// successfully initialized before the callback terminated the prepend.
+  /// successfully initialized before the callback terminated the replacement.
   ///
   /// Partial insertions create a gap in ring buffer storage that needs to be
   /// closed by moving newly inserted items to their correct positions given

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Append.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Append.swift
@@ -56,7 +56,7 @@ extension UniqueDeque where Element: ~Copyable {
   ///         i += 1
   ///       }
   ///     }
-  ///     // `buffer` now contains [999, 0, 1, 2, 3, 4, 5, 6]
+  ///     // `buffer` now contains [999, 0, 1, 2, 3, 4, 5]
   ///
   /// The newly appended items are not guaranteed to form a single contiguous
   /// storage region. Therefore, the supplied callback may be invoked multiple

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Consumption.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Consumption.swift
@@ -83,7 +83,6 @@ extension UniqueDeque where Element: ~Copyable {
   ///
   /// - Parameter consumer: A function taking an input span of the removed items,
   ///    allowing them to be consumed straight out of the deque's storage.
-  ///    The function is called at most once.
   /// - Complexity: O(`self.count`)
   @_alwaysEmitIntoClient
   @inline(__always)

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Consumption.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Consumption.swift
@@ -35,7 +35,6 @@ extension UniqueDeque where Element: ~Copyable {
   /// - Parameter subrange: The subrange of items to consume from this deque.
   /// - Parameter consumer: A function taking an input span of the removed items,
   ///    allowing them to be consumed straight out of the deque's storage.
-  ///    The function is called at most once.
   ///
   /// - Complexity: O(`self.count`)
   @_alwaysEmitIntoClient
@@ -61,7 +60,6 @@ extension UniqueDeque where Element: ~Copyable {
   /// - Parameter subrange: The subrange of items to consume from this deque.
   /// - Parameter consumer: A function taking an input span of the removed items,
   ///    allowing them to be consumed straight out of the deque's storage.
-  ///    The function is called at most once.
   ///
   /// - Complexity: O(`self.count`)
   @_alwaysEmitIntoClient

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Insertions.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Insertions.swift
@@ -79,7 +79,7 @@ extension UniqueDeque where Element: ~Copyable {
   /// times to initialize each successive chunk of storage. However, invocations
   /// cease if the callback fails to fully populate its output span or if
   /// it throws an error. In such cases, the deque keeps all items that were
-  /// successfully initialized before the callback terminated the prepend.
+  /// successfully initialized before the callback terminated the insertion.
   ///
   /// Partial insertions create a gap in ring buffer storage that needs to be
   /// closed by moving already inserted items to their correct positions given

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Insertions.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Insertions.swift
@@ -106,6 +106,7 @@ extension UniqueDeque where Element: ~Copyable {
   ) throws(E) {
     _storage._checkValidIndex(index)
     precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    guard newItemCount > 0 else { return }
     _ensureFreeCapacity(newItemCount)
     try _storage._handle.uncheckedInsert(
       addingCount: newItemCount, at: index, initializingWith: initializer)

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Prepend.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Prepend.swift
@@ -47,7 +47,7 @@ extension UniqueDeque where Element: ~Copyable {
   /// number of new elements, then this method reallocates the deque's storage
   /// to grow it, using a geometric growth rate.
   ///
-  ///     var buffer = RigidDeque<Int>()
+  ///     var buffer = UniqueDeque<Int>()
   ///     buffer.append(999)
   ///     var i = 0
   ///     buffer.prepend(addingCount: 6) { target in
@@ -56,7 +56,7 @@ extension UniqueDeque where Element: ~Copyable {
   ///         i += 1
   ///       }
   ///     }
-  ///     // `buffer` now contains [0, 1, 2, 3, 4, 5, 6, 999]
+  ///     // `buffer` now contains [0, 1, 2, 3, 4, 5, 999]
   ///
   /// The newly prepended items are not guaranteed to form a single contiguous
   /// storage region. Therefore, the supplied callback may be invoked multiple
@@ -70,7 +70,7 @@ extension UniqueDeque where Element: ~Copyable {
   /// the adjusted count. This adds some overhead compared to adding exactly as
   /// many items as promised.
   ///
-  ///     var buffer = RigidDeque<Int>()
+  ///     var buffer = UniqueDeque<Int>()
   ///     buffer.append(999)
   ///     var i = 0
   ///     buffer.prepend(addingCount: 6) { target in

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Prepend.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Prepend.swift
@@ -259,7 +259,7 @@ extension UniqueDeque where Element: ~Copyable {
 @available(SwiftStdlib 5.0, *)
 extension UniqueDeque /*where Element: Copyable*/ {
   /// Copies the elements of a buffer and prepend them to the front of this
-  /// rigid deque.
+  /// deque.
   ///
   /// If the deque doesn't have sufficient capacity to accommodate the specified
   /// number of new elements, then this method reallocates the deque's storage
@@ -396,13 +396,14 @@ extension UniqueDeque /*where Element: Copyable*/ {
   /// Prepend the elements of a sequence to the front of this deque by copying
   /// them.
   ///
-  /// If the deque does not have sufficient capacity to hold all items in the
-  /// sequence, then this triggers a runtime error.
+  /// If the deque does not have sufficient capacity to accommodate the new
+  /// elements, then this method reallocates the deque's storage to grow it,
+  /// using a geometric growth rate.
   ///
   /// This example prepends the elements of a `Range<Int>` instance
-  /// to a rigid deque of integers.
+  /// to a unique deque of integers.
   ///
-  ///     var numbers = RigidDeque<Int>(capacity: 10)
+  ///     var numbers = UniqueDeque<Int>()
   ///     numbers.append(copying: [1, 2, 3, 4, 5])
   ///     numbers.prepend(copying: 10...15)
   ///     // `numbers` now contains [10, 11, 12, 13, 14, 15, 1, 2, 3, 4, 5]
@@ -433,13 +434,14 @@ extension UniqueDeque /*where Element: Copyable*/ {
   /// Prepend the elements of a collection to the front of this deque by copying
   /// them.
   ///
-  /// If the deque does not have sufficient capacity to hold all items in the
-  /// sequence, then this triggers a runtime error.
+  /// If the deque does not have sufficient capacity to accommodate the new
+  /// elements, then this method reallocates the deque's storage to grow it,
+  /// using a geometric growth rate.
   ///
   /// This example prepends the elements of a `Range<Int>` instance
-  /// to a rigid deque of integers.
+  /// to a unique deque of integers.
   ///
-  ///     var numbers = RigidDeque<Int>(capacity: 10)
+  ///     var numbers = UniqueDeque<Int>()
   ///     numbers.append(copying: [1, 2, 3, 4, 5])
   ///     numbers.prepend(copying: 10...15)
   ///     // `numbers` now contains [10, 11, 12, 13, 14, 15, 1, 2, 3, 4, 5]

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Replacements.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Replacements.swift
@@ -85,7 +85,7 @@ extension UniqueDeque where Element: ~Copyable {
     _ensureFreeCapacity(newItemCount - subrange.count)
     try _storage._handle.uncheckedReplace(
       removing: subrange,
-      addingCount: capacity,
+      addingCount: newItemCount,
       initializingWith: initializer)
   }
   

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Replacements.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Replacements.swift
@@ -506,6 +506,9 @@ extension UniqueDeque /* where Element: Copyable */ {
         items.formIndex(after: &i)
       }
     }
+    precondition(
+      i == items.endIndex,
+      "Broken Collection: count doesn't match contents")
   }
 
 #if compiler(>=6.4) && COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque.swift
@@ -308,10 +308,10 @@ extension UniqueDeque {
     UniqueDeque(_storage: _storage.clone())
   }
 
-  /// Copy the contents of this deque into a newly allocated rigid deque
+  /// Copy the contents of this deque into a newly allocated unique deque
   /// instance with the specified capacity.
   ///
-  /// - Parameter capacity: The desired capacity of the resulting rigid deque.
+  /// - Parameter capacity: The desired capacity of the resulting unique deque.
   ///    `capacity` must be greater than or equal to `count`.
   ///
   /// - Complexity: O(`count`)

--- a/Sources/OrderedCollections/HashTable/_HashTable+UnsafeHandle.swift
+++ b/Sources/OrderedCollections/HashTable/_HashTable+UnsafeHandle.swift
@@ -166,7 +166,7 @@ extension _HashTable.UnsafeHandle {
   }
 
   /// Return the index of the word logically preceding `word` in this hash table.
-  /// The buckets form a cycle, so the first word is logically preceded by the first.
+  /// The buckets form a cycle, so the first word is logically preceded by the last.
   ///
   /// Note that the last word may be only partially filled if `scale` is less than 6.
   @inlinable
@@ -229,11 +229,11 @@ extension _HashTable.UnsafeHandle {
   @inlinable
   subscript(word word: Int) -> UInt64 {
     @inline(__always) get {
-      assert(word >= 0 && word < bucketCount)
+      assert(word >= 0 && word < wordCount)
       return _buckets[word]
     }
     @inline(__always) nonmutating set {
-      assert(word >= 0 && word < bucketCount)
+      assert(word >= 0 && word < wordCount)
       assertMutable()
       _buckets[word] = newValue
     }

--- a/Sources/RopeModule/BigString/Basics/BigString+Contents.swift
+++ b/Sources/RopeModule/BigString/Basics/BigString+Contents.swift
@@ -553,6 +553,7 @@ extension BigString {
     _rope.formIndex(after: &ri)
     while ri < endRopeIndex {
       body(_rope[ri]._bytes)
+      _rope.formIndex(after: &ri)
     }
 
     body(_rope[ri]._bytes.extracting(..<end._chunkIndex.utf8Offset))

--- a/Tests/BasicContainersTests/RigidDictionaryTests.swift
+++ b/Tests/BasicContainersTests/RigidDictionaryTests.swift
@@ -346,6 +346,40 @@ class RigidDictionaryTests: CollectionTestCase {
   }
 #endif
 
+  func test_updateValue_with_remove() {
+    typealias Key = LifetimeTracked<Int>
+    typealias Value = LifetimeTracked<String>
+    withEvery("capacity", in: [1, 2, 10, 100, 200]) { capacity in
+      withEvery("count", in: [1, capacity / 3, capacity / 2, 2 * capacity / 3, capacity - 1, capacity] as Set) { count in
+        guard count > 0 else { return }
+        withSome("key", in: 0 ..< count) { key in
+          withLifetimeTracking { tracker in
+            var d = RigidDictionary<Key, Value>(capacity: capacity)
+            for i in 0 ..< count {
+              d.insertValue(tracker.instance(for: "\(i)"), forKey: tracker.instance(for: i))
+            }
+
+            d.updateValue(forKey: tracker.instance(for: key)) { value in
+              expectNotNil(value) { expectEqual($0.payload, "\(key)") }
+              value = nil
+            }
+
+            expectEqual(d.count, count - 1)
+            expectEqual(d.capacity, capacity)
+            for i in 0 ..< count {
+              let found = d.withValue(forKey: tracker.instance(for: i)) { $0 }
+              if i == key {
+                expectNil(found)
+              } else {
+                expectEqual(found?.payload, "\(i)")
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   func test_removeValueForKey_one() {
     typealias Key = LifetimeTracked<Int>
     typealias Value = LifetimeTracked<String>

--- a/Tests/DequeTests/RigidDequeCrashTests.swift
+++ b/Tests/DequeTests/RigidDequeCrashTests.swift
@@ -79,6 +79,36 @@ struct RigidDequeCrashTests {
       deque.removeLast() // Can't remove last element of an empty RigidDeque
     }
   }
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  @Test("nextMutableSpan with out-of-bounds index traps")
+  func nextMutableSpanOutOfBoundsIndex() async {
+    await #expect(processExitsWith: .failure) {
+      var deque = RigidDeque(copying: [1, 2, 3])
+      var index = -1
+      _ = deque.nextMutableSpan(after: &index, maximumCount: 1)
+    }
+    await #expect(processExitsWith: .failure) {
+      var deque = RigidDeque(copying: [1, 2, 3])
+      var index = 4  // valid range is 0...3 (count == 3)
+      _ = deque.nextMutableSpan(after: &index, maximumCount: 1)
+    }
+  }
+
+  @Test("nextMutableSpan with non-positive maximumCount traps")
+  func nextMutableSpanNonPositiveMaximumCount() async {
+    await #expect(processExitsWith: .failure) {
+      var deque = RigidDeque(copying: [1, 2, 3])
+      var index = 0
+      _ = deque.nextMutableSpan(after: &index, maximumCount: 0)
+    }
+    await #expect(processExitsWith: .failure) {
+      var deque = RigidDeque(copying: [1, 2, 3])
+      var index = 0
+      _ = deque.nextMutableSpan(after: &index, maximumCount: -1)
+    }
+  }
+#endif
 }
 #endif
 #endif

--- a/Tests/DequeTests/RigidDequeTests.swift
+++ b/Tests/DequeTests/RigidDequeTests.swift
@@ -1553,5 +1553,23 @@ final class RigidDequeTests: CollectionTestCase {
       }
     }
   }
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  func test_consume_subrange() {
+    withEveryDeque("layout", ofCapacities: [0, 1, 2, 3, 5, 10]) { layout in
+      withEvery("from", in: 0 ... layout.count) { from in
+        withEvery("to", in: from ... layout.count) { to in
+          withLifetimeTracking { tracker in
+            var data = tracker.rigidDeque(with: layout)
+            data.deque.consume(from ..< to, consumingWith: { _ in })
+            data.contents.removeSubrange(from ..< to)
+            expectEqual(data.deque.count, data.contents.count)
+            expectRigidDequeContents(data.deque, equalTo: data.contents)
+          }
+        }
+      }
+    }
+  }
+#endif
 }
 #endif

--- a/Tests/DequeTests/RigidDequeTests.swift
+++ b/Tests/DequeTests/RigidDequeTests.swift
@@ -1570,6 +1570,33 @@ final class RigidDequeTests: CollectionTestCase {
       }
     }
   }
+
+  func test_nextMutableSpan() {
+    withEveryDeque("layout", ofCapacities: [0, 1, 2, 3, 5, 10]) { layout in
+      withEvery("maximumCount", in: [1, 2, 3, 5, 100]) { maximumCount in
+        var deque = RigidDeque(layout: layout, contents: layout.valueRange)
+        var index = deque.startIndex
+        var totalSeen = 0
+        while index < deque.endIndex {
+          let oldIndex = index
+          var span = deque.nextMutableSpan(after: &index, maximumCount: maximumCount)
+          expectGreaterThan(span.count, 0)
+          expectLessThanOrEqual(span.count, maximumCount)
+          expectEqual(index, oldIndex + span.count)
+          // Overwrite each element with its logical position in the deque.
+          for i in 0 ..< span.count {
+            span[i] = totalSeen + i
+          }
+          totalSeen += span.count
+        }
+        expectEqual(totalSeen, layout.count)
+        // Confirm the writes landed in the right places.
+        for i in 0 ..< deque.count {
+          expectEqual(deque[i], i)
+        }
+      }
+    }
+  }
 #endif
 }
 #endif

--- a/Tests/DequeTests/UniqueDequeTests.swift
+++ b/Tests/DequeTests/UniqueDequeTests.swift
@@ -192,6 +192,30 @@ final class UniqueDequeTests: CollectionTestCase {
     }
   }
 
+  func test_replace_removing_addingCount() {
+    withEveryDeque("layout", ofCapacities: [0, 1, 2, 3, 5, 10]) { layout in
+      withEvery("from", in: 0 ... layout.count) { from in
+        withEvery("to", in: from ... layout.count) { to in
+          withEvery("newCount", in: 0 ... 4) { newCount in
+            withLifetimeTracking { tracker in
+              var data = tracker.uniqueDeque(with: layout)
+              let newItems = tracker.instances(for: 100 ..< 100 + newCount)
+              var src = newItems.makeIterator()
+              data.deque.replace(removing: from ..< to, addingCount: newCount) { target in
+                while !target.isFull, let item = src.next() {
+                  target.append(item)
+                }
+              }
+              data.contents.replaceSubrange(from ..< to, with: newItems)
+              expectEqual(data.deque.count, data.contents.count)
+              expectUniqueDequeContents(data.deque, equalTo: data.contents)
+            }
+          }
+        }
+      }
+    }
+  }
+
   func test_growth() {
     let expectedCapacities = [
       0, 1, 2, 3, 5, 8, 12, 18, 27, 41, 62, 93, 140, 210, 315

--- a/Tests/RopeModuleTests/TestBigString.swift
+++ b/Tests/RopeModuleTests/TestBigString.swift
@@ -137,6 +137,16 @@ class TestBigString: CollectionTestCase {
     checkHashable(equivalenceClasses: classes.map { [$0.utf16] })
   }
 
+  func test_utf8_hashing_infinite_loop() {
+    let str = String(repeating: "a", count: 400)
+    let big = BigString(str)
+    let sub = BigSubstring(big, in: big.startIndex ..< big.endIndex)
+
+    // Both paths feed the same UTF-8 bytes to the same Hasher API and must agree.
+    expectEqual(sub.utf8.hashValue, big.utf8.hashValue)
+    expectEqual(sub.unicodeScalars.hashValue, big.unicodeScalars.hashValue)
+  }
+
   @discardableResult
   func checkCharacterIndices(
     _ flat: String,


### PR DESCRIPTION
Do a tool-assisted audit of the `RigidArray`, `UniqueArray`, `RigidSet`, `UniqueSet`, `RigidDictionary`, `UniqueDictionary`, `RigidDeque` and `UniqueDeque` implementations, resolving issues uncovered.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [X] I've updated the documentation if necessary.
