### PR TITLE
fix: reserveCapacity DocC link in RigidArray

### DIFF
--- a/Sources/BasicContainers/RigidArray/RigidArray.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray.swift
@@ -61,7 +61,7 @@ public struct RigidArray<Element: ~Copyable>: ~Copyable {
 ///
 /// It is possible to extend or shrink the capacity of a rigid array instance,
 /// but this needs to be done explicitly, with operations dedicated to this
-/// purpose (such as ``reserveCapacity`` and ``reallocate(capacity:)``).
+/// purpose (such as ``reserveCapacity(_:)`` and ``reallocate(capacity:)``).
 /// The array never resizes itself automatically.
 ///
 /// It therefore requires careful manual analysis or up front runtime capacity


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Collections!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:

    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Add parameter label to `reserveCapacity(_:)` so DocC resolves it as a hyperlink instead of plain text.

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
