### PR TITLE
[ContainersPreview] Producer.ProducerError ⟹ Producer.Failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ This trait enables the following types in the [`ContainersPreview`][ContainersPr
 - [`protocol MutableContainer<Element>`][MutableContainer] refines `PermutableContainer` to also support arbitrary element replacements/mutations, like `MutableCollection`.
 - [`protocol RangeReplaceableContainer<Element>`][RangeReplaceableContainer] models a (potentially fixed capacity) container with insert/append/replace operations.
 - [`protocol DynamicContainer<Element>`][DynamicContainer] refines `RangeReplaceableContainer` to add operations that require dynamic storage sizing.
-- [`protocol Producer<Element, ProducerError>`][Producer] models a generative iterator -- an abstraction for producing items on demand.
+- [`protocol Producer<Element, Failure>`][Producer] models a generative iterator -- an abstraction for producing items on demand.
 - [`protocol Drain<Element>`][Drain] refines `Producer` to model an in-place consumable elements -- primarily for use around container types.
 
 [InputSpan]: https://github.com/apple/swift-collections/blob/main/Sources/ContainersPreview/Types/InputSpan.swift

--- a/Sources/ContainersPreview/Protocols/BorrowingIteratorProtocol+Map.swift
+++ b/Sources/ContainersPreview/Protocols/BorrowingIteratorProtocol+Map.swift
@@ -59,7 +59,7 @@ where
   Base: ~Copyable & ~Escapable,
   Element: ~Copyable
 {
-  public typealias ProducerError = Error
+  public typealias Failure = Error
 
   @inlinable
   public var underestimatedCount: Int {
@@ -67,7 +67,7 @@ where
   }
 
   @inlinable
-  public mutating func next() throws(ProducerError) -> Element? {
+  public mutating func next() throws(Failure) -> Element? {
     let span = _it.nextSpan_(maximumCount: 1)
     guard !span.isEmpty else { return nil }
     return try _transform(span[unchecked: 0])

--- a/Sources/ContainersPreview/Protocols/Container/RangeReplaceableContainer.swift
+++ b/Sources/ContainersPreview/Protocols/Container/RangeReplaceableContainer.swift
@@ -151,7 +151,7 @@ where Self: ~Copyable & ~Escapable, Element: ~Copyable
     removing subrange: some RangeExpression2<Index>,
     addingCount: Int,
     from producer: inout P
-  ) throws(P.ProducerError)
+  ) throws(P.Failure)
   where P.Element: ~Copyable
   {
     try replace(

--- a/Sources/ContainersPreview/Protocols/Drain+Map.swift
+++ b/Sources/ContainersPreview/Protocols/Drain+Map.swift
@@ -28,10 +28,10 @@ extension Drain where Self: ~Copyable & ~Escapable, Element: ~Copyable {
 public struct DrainMapProducer<
   Base: Drain & ~Copyable & ~Escapable,
   Element: ~Copyable,
-  ProducerError: Error
+  Failure: Error
 >: ~Copyable, ~Escapable {
   @_alwaysEmitIntoClient
-  public let _transform: (consuming Base.Element) throws(ProducerError) -> Element
+  public let _transform: (consuming Base.Element) throws(Failure) -> Element
 
   @_alwaysEmitIntoClient
   public var _base: Base
@@ -40,7 +40,7 @@ public struct DrainMapProducer<
   @_lifetime(copy _base)
   internal init(
     _base: consuming Base,
-    transform: @escaping (consuming Base.Element) throws(ProducerError) -> Element
+    transform: @escaping (consuming Base.Element) throws(Failure) -> Element
   ) {
     self._base = _base
     self._transform = transform
@@ -59,7 +59,7 @@ where
   }
 
   @inlinable
-  public mutating func next() throws(ProducerError) -> Element? {
+  public mutating func next() throws(Failure) -> Element? {
     guard let next = _base.next() else { return nil }
     return try _transform(next)
   }

--- a/Sources/ContainersPreview/Protocols/Drain.swift
+++ b/Sources/ContainersPreview/Protocols/Drain.swift
@@ -23,7 +23,7 @@
 /// output spans.
 @available(SwiftStdlib 5.0, *)
 public protocol Drain<Element>: Producer, ~Copyable, ~Escapable
-where Element: ~Copyable, ProducerError == Never
+where Element: ~Copyable, Failure == Never
 {
   /// Returns the next span of consumable items in the sequence underlying this
   /// drain, of at most the specified maximum count. A `maximumCount` of nil
@@ -204,7 +204,7 @@ extension Drain where Self: ~Copyable & ~Escapable, Element: ~Copyable  {
   @_lifetime(self: copy self)
   public mutating func skip(
     upTo n: inout Int
-  ) -> Bool { // FIXME: Compiler crash when this declares throws(ProducerError)
+  ) -> Bool { // FIXME: Compiler crash when this declares throws(Failure)
     precondition(n >= 0, "Cannot skip a negative number of elements")
     guard n > 0 else { return true }
     let span = drainNext(maximumCount: n)

--- a/Sources/ContainersPreview/Protocols/Producer+Collect.swift
+++ b/Sources/ContainersPreview/Protocols/Producer+Collect.swift
@@ -20,7 +20,7 @@ extension Producer where Self: ~Copyable & ~Escapable, Element: ~Copyable {
     R: DynamicContainer<Element> & ~Copyable
   >(
     into container: R.Type = R.self
-  ) throws(ProducerError) -> R {
+  ) throws(Failure) -> R {
     try R(from: self)
   }
 
@@ -30,7 +30,7 @@ extension Producer where Self: ~Copyable & ~Escapable, Element: ~Copyable {
   @inlinable
   public consuming func collect(
     into container: inout some RangeReplaceableContainer<Element> & ~Copyable & ~Escapable
-  ) throws(ProducerError) {
+  ) throws(Failure) {
     // Note: this is the same algorithm as `append(from:)` on `DynamicContainer`,
     // except it applies to RRCs.
     while true {
@@ -52,7 +52,7 @@ extension Producer where Self: ~Copyable & ~Escapable, Element: ~Copyable {
   @inlinable
   public consuming func collect(
     into container: inout some DynamicContainer<Element> & ~Copyable
-  ) throws(ProducerError) {
+  ) throws(Failure) {
     try container.append(from: self)
   }
 }

--- a/Sources/ContainersPreview/Protocols/Producer+Filter.swift
+++ b/Sources/ContainersPreview/Protocols/Producer+Filter.swift
@@ -30,7 +30,7 @@ public struct ConsumingFilterProducer<
 >: ~Copyable, ~Escapable
 where Base.Element: ~Copyable {
   public typealias Element = Base.Element
-  public typealias ProducerError = Base.ProducerError
+  public typealias Failure = Base.Failure
 
   @_alwaysEmitIntoClient
   public var _base: Base
@@ -57,7 +57,7 @@ extension ConsumingFilterProducer: Escapable
 where
   Base: ~Copyable & Escapable,
   Base.Element: ~Copyable & Escapable, // FIXME: Why declare Escapable?
-  Base.ProducerError: Copyable & Escapable // FIXME: Why declare this?
+  Base.Failure: Copyable & Escapable // FIXME: Why declare this?
 {}
 #endif
 
@@ -73,7 +73,7 @@ where
   }
 
   @inlinable
-  public mutating func next() throws(ProducerError) -> Element? {
+  public mutating func next() throws(Failure) -> Element? {
     while let next = try _base.next() {
       if _isIncluded(next) { return next }
     }
@@ -86,7 +86,7 @@ where
   @_lifetime(self: copy self)
   public mutating func generate(
     into target: inout OutputSpan<Element>
-  ) throws(ProducerError) -> Bool {
+  ) throws(Failure) -> Bool {
     let startCount = target.count
     repeat {
       let prevCount = target.count

--- a/Sources/ContainersPreview/Protocols/Producer+Map.swift
+++ b/Sources/ContainersPreview/Protocols/Producer+Map.swift
@@ -17,7 +17,7 @@
 extension Producer where Self: ~Copyable & ~Escapable, Element: ~Copyable {
   @_lifetime(copy self)
   public consuming func map<T: ~Copyable>(
-    _ transform: @escaping (consuming Element) throws(ProducerError) -> T
+    _ transform: @escaping (consuming Element) throws(Failure) -> T
   ) -> ConsumingMapProducer<Self, T> {
     ConsumingMapProducer(_base: self, transform: transform)
   }
@@ -30,18 +30,18 @@ public struct ConsumingMapProducer<
 >: ~Copyable, ~Escapable
 where Base.Element: ~Copyable
 {
-  public typealias ProducerError = Base.ProducerError
+  public typealias Failure = Base.Failure
 
   @_alwaysEmitIntoClient
   public var _base: Base
   @_alwaysEmitIntoClient
-  public let _transform: (consuming Base.Element) throws(ProducerError) -> Element
+  public let _transform: (consuming Base.Element) throws(Failure) -> Element
 
   @inlinable
   @_lifetime(copy _base)
   public init(
     _base: consuming Base,
-    transform: @escaping (consuming Base.Element) throws(ProducerError) -> Element
+    transform: @escaping (consuming Base.Element) throws(Failure) -> Element
   ) {
     self._base = _base
     self._transform = transform
@@ -72,7 +72,7 @@ extension ConsumingMapProducer: Producer where Base: ~Copyable & ~Escapable {
   }
 
   @inlinable
-  public mutating func next() throws(ProducerError) -> Element? {
+  public mutating func next() throws(Failure) -> Element? {
     guard let next = try _base.next() else { return nil }
     return try _transform(next)
   }
@@ -83,11 +83,11 @@ extension ConsumingMapProducer: Producer where Base: ~Copyable & ~Escapable {
   @_lifetime(self: copy self)
   public mutating func generate(
     into target: inout OutputSpan<Element>
-  ) throws(ProducerError) -> Bool {
+  ) throws(Failure) -> Bool {
     let c = Swift.min(target.freeCapacity, _producerBufferSize)
     return try _withUnsafeTemporaryAllocation(
       of: Base.Element.self, capacity: c
-    ) { buffer throws(ProducerError) in
+    ) { buffer throws(Failure) in
       var outputSpan = OutputSpan(buffer: buffer, initializedCount: 0)
       let result = try _base.generate(into: &outputSpan)
       let c = outputSpan.finalize(for: buffer)

--- a/Sources/ContainersPreview/Protocols/Producer+Reduce.swift
+++ b/Sources/ContainersPreview/Protocols/Producer+Reduce.swift
@@ -20,12 +20,12 @@ extension Producer where Self: ~Copyable & ~Escapable, Element: ~Copyable {
     _ initialResult: consuming Result,
     _ nextPartialResult: (
       consuming Result, consuming Element
-    ) throws(ProducerError) -> Result
-  ) throws(ProducerError) -> Result {
+    ) throws(Failure) -> Result
+  ) throws(Failure) -> Result {
     var initialResult: Optional = initialResult
     return try _withUnsafeTemporaryAllocation(
       of: Element.self, capacity: _producerBufferSize
-    ) { buffer throws(ProducerError) in
+    ) { buffer throws(Failure) in
       var done = false
       var result = initialResult.take()!
       while !done {
@@ -47,12 +47,12 @@ extension Producer where Self: ~Copyable & ~Escapable, Element: ~Copyable {
     into initialResult: consuming Result,
     _ updateAccumulatingResult: (
       inout Result, consuming Element
-    ) throws(ProducerError) -> Void
-  ) throws(ProducerError) -> Result {
+    ) throws(Failure) -> Void
+  ) throws(Failure) -> Result {
     var result = initialResult
     try _withUnsafeTemporaryAllocation(
       of: Element.self, capacity: _producerBufferSize
-    ) { buffer throws(ProducerError) in
+    ) { buffer throws(Failure) in
       var done = false
       while !done {
         var span = OutputSpan(buffer: buffer, initializedCount: 0)

--- a/Sources/ContainersPreview/Protocols/Producer.swift
+++ b/Sources/ContainersPreview/Protocols/Producer.swift
@@ -23,13 +23,13 @@ public var _producerBufferSize: Int { 8 }
 /// merely providing borrowing access to them. A `Producer` instance represents
 /// an ongoing iteration over such a generative sequence.
 @available(SwiftStdlib 5.0, *)
-public protocol Producer<Element, ProducerError>: ~Copyable, ~Escapable {
+public protocol Producer<Element, Failure>: ~Copyable, ~Escapable {
   /// The type of the items that this producer generates.
   associatedtype Element: ~Copyable
   
   /// The error that this producer may throw, or `Never` if this producer
   /// always succeeds.
-  associatedtype ProducerError: Error = Never
+  associatedtype Failure: Error = Never
   
   /// A value less than or equal to the number of remaining items that this
   /// producer is able to generate until it reaches its end.
@@ -94,7 +94,7 @@ public protocol Producer<Element, ProducerError>: ~Copyable, ~Escapable {
   @_lifetime(self: copy self)
   mutating func generate(
     into target: inout OutputSpan<Element>
-  ) throws(ProducerError) -> Bool
+  ) throws(Failure) -> Bool
   
   /// Skip at most the given number items in the underlying generative sequence,
   /// decreasing it by the number of items successfully skipped.
@@ -126,7 +126,7 @@ public protocol Producer<Element, ProducerError>: ~Copyable, ~Escapable {
   ///    skip at least one item without hitting the end of the underlying
   ///    sequence.
   @_lifetime(self: copy self)
-  mutating func skip(by n: inout Int) throws(ProducerError) -> Bool
+  mutating func skip(by n: inout Int) throws(Failure) -> Bool
 
   /// Generate and return the next element in the underlying generative
   /// sequence.
@@ -160,7 +160,7 @@ public protocol Producer<Element, ProducerError>: ~Copyable, ~Escapable {
   /// implementation, but they may exhibit observably different performance
   /// metrics.
   @_lifetime(self: copy self)
-  mutating func next() throws(ProducerError) -> Element?
+  mutating func next() throws(Failure) -> Element?
 }
 
 @available(SwiftStdlib 5.0, *)
@@ -205,12 +205,12 @@ extension Producer where Self: ~Copyable & ~Escapable, Element: ~Copyable {
   ///    sequence.
   @inlinable
   @_lifetime(self: copy self)
-  public mutating func skip(by n: inout Int) throws(ProducerError) -> Bool {
+  public mutating func skip(by n: inout Int) throws(Failure) -> Bool {
     precondition(n > 0, "Cannot skip fewer than one item")
     let maxBufferSize = 8
     return try withTemporaryOutputSpan(
       of: Element.self, capacity: Swift.min(maxBufferSize, n)
-    ) { span throws(ProducerError) in
+    ) { span throws(Failure) in
       defer { n &-= span.count }
       return try self.generate(into: &span)
     }
@@ -249,10 +249,10 @@ extension Producer where Self: ~Copyable & ~Escapable, Element: ~Copyable {
   /// metrics.
   @inlinable
   @_lifetime(self: copy self)
-  public mutating func next() throws(ProducerError) -> Element? {
+  public mutating func next() throws(Failure) -> Element? {
     try _withUnsafeTemporaryAllocation(
       of: Element.self, capacity: 1
-    ) { buffer throws(ProducerError) in
+    ) { buffer throws(Failure) in
       var span = OutputSpan(buffer: buffer, initializedCount: 0)
       guard try self.generate(into: &span) else { return nil }
       return span.removeLast()
@@ -268,7 +268,7 @@ extension Producer where Self: ~Copyable & ~Escapable, Element: ~Copyable {
   ///
   /// This is useful in preconditions.
   @inlinable
-  public consuming func _isAtEnd() throws(ProducerError) -> Bool {
+  public consuming func _isAtEnd() throws(Failure) -> Bool {
     var c = 1
     return try !skip(by: &c)
   }

--- a/Tests/_CollectionsTestSupport/MinimalTypes/CustomProducer.swift
+++ b/Tests/_CollectionsTestSupport/MinimalTypes/CustomProducer.swift
@@ -21,15 +21,15 @@ import ContainersPreview
 #if compiler(>=6.4) && COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
 
 @available(SwiftStdlib 5.0, *)
-package struct CustomProducer<Element: ~Copyable, ProducerError: Error>: ~Copyable {
+package struct CustomProducer<Element: ~Copyable, Failure: Error>: ~Copyable {
   package let underestimatedCount: Int
   package let _chunkSize: Int
-  package let _generator: () throws(ProducerError) -> Element?
+  package let _generator: () throws(Failure) -> Element?
 
   package init(
     underestimatedCount: Int = 0,
     chunkSize: Int = Int.max,
-    generatingWith generator: borrowing @escaping () throws(ProducerError) -> Element?
+    generatingWith generator: borrowing @escaping () throws(Failure) -> Element?
   ) {
     self.underestimatedCount = underestimatedCount
     self._chunkSize = chunkSize
@@ -41,7 +41,7 @@ package struct CustomProducer<Element: ~Copyable, ProducerError: Error>: ~Copyab
 extension CustomProducer: Producer where Element: ~Copyable {
   package mutating func generate(
     into target: inout OutputSpan<Element>
-  ) throws(ProducerError) -> Bool {
+  ) throws(Failure) -> Bool {
     var i = 0
     while !target.isFull, i < _chunkSize {
       guard let next = try _generator() else { return false }


### PR DESCRIPTION
Reserving a unique name for Producer’s failure type seems unwise, especially if we end up Producer refining a throwing BorrowingSequence protocol.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
