### PR TITLE
[HashTreeCollections] Fix invariant violation in _HashNode._regularNode

### DIFF
--- a/Sources/HashTreeCollections/HashNode/_HashNode+Initializers.swift
+++ b/Sources/HashTreeCollections/HashNode/_HashNode+Initializers.swift
@@ -166,8 +166,10 @@ extension _HashNode {
       count: child1.count &+ child2.count
     ) { children, items in
       assert(items.count == 0 && children.count == 2)
-      children.initializeElement(at: 0, to: child1)
-      children.initializeElement(at: 1, to: child2)
+      let i1 = child1Bucket < child2Bucket ? 0 : 1
+      let i2 = 1 &- i1
+      children.initializeElement(at: i1, to: child1)
+      children.initializeElement(at: i2, to: child2)
     }
     r.node._invariantCheck()
     return r.node

--- a/Tests/HashTreeCollectionsTests/TreeDictionary Tests.swift
+++ b/Tests/HashTreeCollectionsTests/TreeDictionary Tests.swift
@@ -1533,6 +1533,24 @@ class TreeDictionaryTests: CollectionTestCase {
     }
   }
 
+  func test_merge_collision_node_ordering() {
+    // Regression test for child ordering issue.
+    let a1 = RawCollider(1, "B")  // level-0 bucket = 11
+    let a2 = RawCollider(2, "B")  // same hash → collision node with a1
+    let b1 = RawCollider(3, "A")  // level-0 bucket = 10
+    let b2 = RawCollider(4, "A")  // same hash → collision node with b1
+
+    var left: TreeDictionary<RawCollider, Int> = [a1: 1, a2: 2]
+    let right: TreeDictionary<RawCollider, Int> = [b1: 3, b2: 4]
+    left.merge(right, uniquingKeysWith: { a, _ in a })
+
+    expectEqual(left.count, 4)
+    expectEqual(left[a1], 1)
+    expectEqual(left[a2], 2)
+    expectEqual(left[b1], 3)
+    expectEqual(left[b2], 4)
+  }
+
   func test_merge_exhaustive() {
     withEverySubset("a", of: testItems) { a in
       withEverySubset("b", of: testItems) { b in

--- a/Tests/HashTreeCollectionsTests/TreeSet Tests.swift
+++ b/Tests/HashTreeCollectionsTests/TreeSet Tests.swift
@@ -560,6 +560,24 @@ class TreeSetTests: CollectionTestCase {
     }
   }
 
+  func test_union_collision_node_ordering() {
+    // Regression test for child ordering issue.
+    let a1 = RawCollider(1, "B")  // level-0 bucket = 11
+    let a2 = RawCollider(2, "B")  // same hash → collision node with a1
+    let b1 = RawCollider(3, "A")  // level-0 bucket = 10
+    let b2 = RawCollider(4, "A")  // same hash → collision node with b1
+
+    let left = TreeSet([a1, a2])
+    let right = TreeSet([b1, b2])
+    let union = left.union(right)
+
+    expectEqual(union.count, 4)
+    expectTrue(union.contains(a1))
+    expectTrue(union.contains(a2))
+    expectTrue(union.contains(b1))
+    expectTrue(union.contains(b2))
+  }
+
   func test_symmetricDifference_exhaustive() {
     withEverySubset("a", of: testItems) { a in
       let x = TreeSet(a)


### PR DESCRIPTION
The two-child variant of `_HashNode._regularNode` did not check bucket ordering before placing children, leading to it generating inaccessible nodes half of the time.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
