### PR TITLE
[BitCollections] Fix small issues

### DIFF
--- a/Sources/BitCollections/BitArray/BitArray+Extras.swift
+++ b/Sources/BitCollections/BitArray/BitArray+Extras.swift
@@ -38,7 +38,7 @@ extension BitArray {
     at index: Int
   ) {
     precondition(count >= 0, "Cannot add a negative number of items")
-    precondition(index >= 0 && index <= count, "Index out of bounds")
+    precondition(index >= 0 && index <= self.count, "Index out of bounds")
     guard count > 0 else { return }
     _extend(by: count, with: false)
     _copy(from: index ..< self.count - count, to: index + count)

--- a/Sources/BitCollections/BitSet/BitSet._UnsafeHandle.swift
+++ b/Sources/BitCollections/BitSet/BitSet._UnsafeHandle.swift
@@ -191,6 +191,9 @@ extension _UnsafeBitSet {
     let hw = _Word(upTo: upper.bit).complement()
     guard _words[upper.word].intersection(hw).isEmpty else { return false }
 
+    for w in upper.word + 1 ..< wordCount {
+      guard _words[w].isEmpty else { return false }
+    }
     return true
   }
 

--- a/Tests/BitCollectionsTests/BitSetTests.swift
+++ b/Tests/BitCollectionsTests/BitSetTests.swift
@@ -1218,6 +1218,7 @@ final class BitSetTest: CollectionTestCase {
         "a": BitSet(10*step ..< 20*step),
         "b": BitSet(10*step ..< 20*step).subtracting(13*step ..< 14*step),
         "c": BitSet(10*step ..< 20*step - 1),
+        "d": BitSet(10*step ..< 20*step).union(100*step ..< 110*step),
       ]
 
       let tests: [(range: Range<Int>, expected: Set<String>)] = [


### PR DESCRIPTION
This PR fixes more bugs found through a tool-assisted code audit:

- Resolve an issue where `Bitset.isSubset(of:)` sometimes reports an incorrect positive result.
- Fix a name shadowing oversight issue in a `BitArray.insert(repeating:count:at:)` precondition.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
