### PR TITLE
[HeapModule, SortedCollections] Assorted tool-assisted fixes and adjustments

### DIFF
--- a/Sources/ContainersPreview/Protocols/BorrowingIteratorProtocol.swift
+++ b/Sources/ContainersPreview/Protocols/BorrowingIteratorProtocol.swift
@@ -21,11 +21,6 @@ import InternalCollectionsUtilities
 public protocol BorrowingIteratorProtocol_<Element_>: ~Copyable, ~Escapable {
   associatedtype Element_: ~Copyable
 
-  // FIXME: This ought to be a core requirement, but `Ref` is not a thing yet.
-//  @_lifetime(&self)
-//  @_lifetime(self: copy self)
-//  mutating func next() -> Ref<Element>?
-
   /// Advance the iterator, returning an ephemeral span over the elements
   /// that are ready to be visited.
   ///
@@ -87,12 +82,6 @@ public protocol BorrowingIteratorProtocol_<Element_>: ~Copyable, ~Escapable {
   /// `maximumOffset` must be nonnegative.
   @_lifetime(self: copy self)
   mutating func skip_(by maximumOffset: Int) -> Int
-  
-  // FIXME: Add BidirectionalBorrowingIteratorProtocol and RandomAccessBorrowingIteratorProtocol.
-  // BidirectionalBorrowingIteratorProtocol would need to have a `previousSpan`
-  // method, which considerably complicates implementation.
-  // Perhaps these would be better left to as variants of protocol Container,
-  // which do not need a separate iterator concept.
 }
 
 @available(SwiftStdlib 5.0, *)
@@ -133,13 +122,6 @@ extension BorrowingIteratorProtocol_ where Self: ~Copyable & ~Escapable {
     return Ref(_borrowing: span[unchecked: 0])
   }
 #endif
-
-  //  @_lifetime(&self)
-  //  @_lifetime(self: copy self)
-  //  public mutating func nextSpan(maximumCount: Int) -> Span<Element> {
-  //    guard let ref = next() else { return Span() }
-  //    return ref.span // FIXME
-  //  }
 }
 
 @available(SwiftStdlib 5.0, *)

--- a/Sources/ContainersPreview/Protocols/Container/Container+Filter.swift
+++ b/Sources/ContainersPreview/Protocols/Container/Container+Filter.swift
@@ -99,7 +99,6 @@ extension ContainerFilter: BorrowingIteratorProtocol_ where Element: ~Copyable {
         i &+= 1
       }
       _remainder = _remainder.extracting(droppingFirst: i)
-      // Return maximal
       if !_remainder.isEmpty {
         let c = Swift.min(_remainder.count, maximumCount)
         i = 1

--- a/Sources/HeapModule/Heap+UnsafeHandle.swift
+++ b/Sources/HeapModule/Heap+UnsafeHandle.swift
@@ -76,6 +76,7 @@ extension Heap._UnsafeHandle {
   /// Swaps the element at the given node with the supplied value.
   @inlinable @inline(__always)
   internal func swapAt(_ i: _HeapNode, with value: inout Element) {
+    assert(i.offset < count)
     let p = buffer.baseAddress.unsafelyUnwrapped + i.offset
     swap(&p.pointee, &value)
   }

--- a/Sources/HeapModule/Heap.swift
+++ b/Sources/HeapModule/Heap.swift
@@ -382,7 +382,7 @@ extension Heap {
     // that.
     //
     // FIXME: Write a benchmark to verify this heuristic.
-    let heuristicLimit = 2 * newCount / newCount._binaryLogarithm()
+    let heuristicLimit = 2 &* newCount / newCount._binaryLogarithm()
     let useFloyd = (newCount - origCount) > heuristicLimit
     _update { handle in
       if useFloyd {

--- a/Sources/SortedCollections/BTree/_BTree.swift
+++ b/Sources/SortedCollections/BTree/_BTree.swift
@@ -474,6 +474,7 @@ extension _BTree {
             return .passUnretained(node.storage)
           } else {
             // Calculate offset by summing previous subtrees
+            offset += slot
             for i in 0...slot {
               offset += handle[childAt: i].read({ $0.subtreeCount })
             }

--- a/Sources/SortedCollections/BTree/_BTree.swift
+++ b/Sources/SortedCollections/BTree/_BTree.swift
@@ -522,34 +522,35 @@ extension _BTree {
     func search(in node: Node) -> Unmanaged<Node.Storage>? {
       node.read({ handle in
         let slot = handle.endSlot(forKey: key) - 1
-        if slot > 0 {
+        if slot >= 0 {
           assert(slot < handle.elementCount, "Slot out of bounds")
-          
+
           if handle.isLeaf {
             offset += slot
             targetSlot = slot
             return .passUnretained(node.storage)
           } else {
+            offset += slot
             for i in 0...slot {
               offset += handle[childAt: i].read({ $0.subtreeCount })
             }
-            
+
             let currentOffset = offset
             let currentDepth = childSlots.depth
             childSlots.append(UInt16(slot + 1))
-            
+
             if let foundLater = search(in: handle[childAt: slot + 1]) {
               return foundLater
             } else {
               childSlots.depth = currentDepth
               targetSlot = slot
               offset = currentOffset
-              
+
               return .passUnretained(node.storage)
             }
           }
         } else {
-          // Start index exceeds node and is therefore not in this.
+          // No element in this node is <= key.
           return nil
         }
       })

--- a/Sources/SortedCollections/BTree/_BTree.swift
+++ b/Sources/SortedCollections/BTree/_BTree.swift
@@ -467,35 +467,40 @@ extension _BTree {
     func search(in node: Node) -> Unmanaged<Node.Storage>? {
       node.read({ handle in
         let slot = handle.startSlot(forKey: key)
-        if slot < handle.elementCount {
-          if handle.isLeaf {
+
+        if handle.isLeaf {
+          if slot < handle.elementCount {
             offset += slot
             targetSlot = slot
             return .passUnretained(node.storage)
-          } else {
-            // Calculate offset by summing previous subtrees
-            offset += slot
-            for i in 0...slot {
-              offset += handle[childAt: i].read({ $0.subtreeCount })
-            }
-            
-            let currentOffset = offset
-            let currentDepth = childSlots.depth
-            childSlots.append(UInt16(slot))
-            
-            if let foundEarlier = search(in: handle[childAt: slot]) {
-              return foundEarlier
-            } else {
-              childSlots.depth = currentDepth
-              targetSlot = slot
-              offset = currentOffset
-              
-              return .passUnretained(node.storage)
-            }
           }
-        } else {
-          // Start index exceeds node and is therefore not in this.
           return nil
+        }
+
+        // Internal node: advance offset to the start of child[slot].
+        // child[slot] starts after `slot` elements and `slot` preceding subtrees.
+        offset += slot
+        for i in 0..<slot {
+          offset += handle[childAt: i].read({ $0.subtreeCount })
+        }
+
+        if slot < handle.elementCount {
+          // elem[slot] >= key. Try child[slot] for an earlier occurrence first.
+          let elemOffset = offset + handle[childAt: slot].read({ $0.subtreeCount })
+          let savedDepth = childSlots.depth
+          childSlots.append(UInt16(slot))
+
+          if let foundEarlier = search(in: handle[childAt: slot]) {
+            return foundEarlier
+          }
+          childSlots.depth = savedDepth
+          targetSlot = slot
+          offset = elemOffset
+          return .passUnretained(node.storage)
+        } else {
+          // key > all elements here: descend into the rightmost child.
+          childSlots.append(UInt16(slot))
+          return search(in: handle[childAt: slot])
         }
       })
     }

--- a/Sources/SortedCollections/BTree/_BTree.swift
+++ b/Sources/SortedCollections/BTree/_BTree.swift
@@ -528,36 +528,42 @@ extension _BTree {
     func search(in node: Node) -> Unmanaged<Node.Storage>? {
       node.read({ handle in
         let slot = handle.endSlot(forKey: key) - 1
-        if slot >= 0 {
-          assert(slot < handle.elementCount, "Slot out of bounds")
 
-          if handle.isLeaf {
+        if handle.isLeaf {
+          if slot >= 0 {
             offset += slot
             targetSlot = slot
             return .passUnretained(node.storage)
-          } else {
-            offset += slot
-            for i in 0...slot {
-              offset += handle[childAt: i].read({ $0.subtreeCount })
-            }
-
-            let currentOffset = offset
-            let currentDepth = childSlots.depth
-            childSlots.append(UInt16(slot + 1))
-
-            if let foundLater = search(in: handle[childAt: slot + 1]) {
-              return foundLater
-            } else {
-              childSlots.depth = currentDepth
-              targetSlot = slot
-              offset = currentOffset
-
-              return .passUnretained(node.storage)
-            }
           }
-        } else {
-          // No element in this node is <= key.
           return nil
+        }
+
+        if slot >= 0 {
+          // elem[slot] <= key. Also check child[slot+1] for a greater
+          // element still <= key.
+          offset += slot
+          for i in 0..<slot {
+            offset += handle[childAt: i].read({ $0.subtreeCount })
+          }
+          offset += handle[childAt: slot].read({ $0.subtreeCount })
+          // offset = position of elem[slot]
+
+          let elemOffset = offset
+          let savedDepth = childSlots.depth
+          childSlots.append(UInt16(slot + 1))
+          offset += 1  // step past elem[slot] to the start of child[slot+1]
+
+          if let foundLater = search(in: handle[childAt: slot + 1]) {
+            return foundLater
+          }
+          childSlots.depth = savedDepth
+          targetSlot = slot
+          offset = elemOffset
+          return .passUnretained(node.storage)
+        } else {
+          // key < all elements here: descend into the leftmost child.
+          childSlots.append(UInt16(0))
+          return search(in: handle[childAt: 0])
         }
       })
     }

--- a/Sources/SortedCollections/BTree/_Node.UnsafeHandle+Insertion.swift
+++ b/Sources/SortedCollections/BTree/_Node.UnsafeHandle+Insertion.swift
@@ -498,7 +498,7 @@ extension _Node.UnsafeHandle {
         )
         
         if !self.isLeaf {
-          rightHandle.moveInitializeElements(
+          rightHandle.moveInitializeChildren(
             count: rightHandle.childCount,
             fromSlot: 0,
             toSlot: self.childCount,

--- a/Sources/SortedCollections/SortedSet/SortedSet+Subscripts.swift
+++ b/Sources/SortedCollections/SortedSet/SortedSet+Subscripts.swift
@@ -28,7 +28,7 @@ extension SortedSet {
     return SubSequence(_root[bounds])
   }
 
-  
+
   /// Returns a sequence of elements in the collection bounded by the provided
   /// range.
   ///
@@ -45,6 +45,58 @@ extension SortedSet {
     let end = _root.startIndex(forKey: range.upperBound)
     let range = _Tree.SubSequence(base: _root, bounds: start..<end)
     return SubSequence(range)
+  }
+
+  /// Returns the elements in the closed value range `range.lowerBound` through
+  /// `range.upperBound`, inclusive.
+  ///
+  /// - Complexity: O(log(`self.count`))
+  @inlinable
+  public subscript(range: ClosedRange<Element>) -> SubSequence {
+    let start = _root.startIndex(forKey: range.lowerBound)
+    let end = _firstTreeIndex(after: range.upperBound)
+    return SubSequence(_root[start..<end])
+  }
+
+  /// Returns the elements whose value is greater than or equal to
+  /// `range.lowerBound`.
+  ///
+  /// - Complexity: O(log(`self.count`))
+  @inlinable
+  public subscript(range: PartialRangeFrom<Element>) -> SubSequence {
+    let start = _root.startIndex(forKey: range.lowerBound)
+    return SubSequence(_root[start..<_root.endIndex])
+  }
+
+  /// Returns the elements whose value is strictly less than `range.upperBound`.
+  ///
+  /// - Complexity: O(log(`self.count`))
+  @inlinable
+  public subscript(range: PartialRangeUpTo<Element>) -> SubSequence {
+    let end = _root.startIndex(forKey: range.upperBound)
+    return SubSequence(_root[_root.startIndex..<end])
+  }
+
+  /// Returns the elements whose value is less than or equal to
+  /// `range.upperBound`.
+  ///
+  /// - Complexity: O(log(`self.count`))
+  @inlinable
+  public subscript(range: PartialRangeThrough<Element>) -> SubSequence {
+    let end = _firstTreeIndex(after: range.upperBound)
+    return SubSequence(_root[_root.startIndex..<end])
+  }
+
+  /// Returns the first `_BTree` index whose element is strictly greater than
+  /// `element`, or the tree's `endIndex` if no such element exists.
+  @inlinable
+  internal func _firstTreeIndex(after element: Element) -> _Tree.Index {
+    let i = _root.startIndex(forKey: element)
+    if i == _root.endIndex { return i }
+    if _root[i].key == element {
+      return _root.index(after: i)
+    }
+    return i
   }
 }
 

--- a/Sources/SortedCollections/SortedSet/SortedSet.Index.swift
+++ b/Sources/SortedCollections/SortedSet/SortedSet.Index.swift
@@ -24,7 +24,39 @@ extension SortedSet {
       return nil
     }
   }
-  
+
+  /// Returns the index of the smallest element that is strictly greater than
+  /// the given element, or `nil` if no such element exists.
+  ///
+  /// The element itself does not need to be a member of the set.
+  ///
+  /// - Parameter element: The element to look after.
+  /// - Complexity: O(`log n`)
+  @inlinable
+  public func firstIndex(after element: Element) -> Index? {
+    let i = self._root.startIndex(forKey: element)
+    if i == self._root.endIndex { return nil }
+    if self._root[i].key == element {
+      let next = self._root.index(after: i)
+      return next == self._root.endIndex ? nil : Index(next)
+    }
+    return Index(i)
+  }
+
+  /// Returns the index of the largest element that is strictly less than the
+  /// given element, or `nil` if no such element exists.
+  ///
+  /// The element itself does not need to be a member of the set.
+  ///
+  /// - Parameter element: The element to look before.
+  /// - Complexity: O(`log n`)
+  @inlinable
+  public func lastIndex(before element: Element) -> Index? {
+    let i = self._root.startIndex(forKey: element)
+    if i == self._root.startIndex { return nil }
+    return Index(self._root.index(before: i))
+  }
+
   /// The position of an element within a sorted set
   public struct Index {
     @usableFromInline

--- a/Tests/SortedCollectionsTests/BTree/BTree Tests.swift
+++ b/Tests/SortedCollectionsTests/BTree/BTree Tests.swift
@@ -139,6 +139,20 @@ final class BTreeTests: CollectionTestCase {
     }
   }
   
+  func test_startIndexForKey() {
+    withEvery("count", in: [1, 2, 4, 8, 16, 32, 64]) { count in
+      btreeOfSize(count) { btree, kvs in
+        withEvery("i", in: 0..<count) { i in
+          let index = btree.startIndex(forKey: kvs[i].key)
+          expectEqual(index.offset, i)
+        }
+        // Key not present: returns endIndex
+        let missing = btree.startIndex(forKey: count * 2 + 1)
+        expectEqual(missing, btree.endIndex)
+      }
+    }
+  }
+
   func test_randomInsertionOrder() {
     let kvs = [
       (key: 71, value: 142),

--- a/Tests/SortedCollectionsTests/BTree/BTree Tests.swift
+++ b/Tests/SortedCollectionsTests/BTree/BTree Tests.swift
@@ -153,6 +153,20 @@ final class BTreeTests: CollectionTestCase {
     }
   }
 
+  func test_lastIndexForKey() {
+    withEvery("count", in: [1, 2, 4, 8, 16, 32, 64]) { count in
+      btreeOfSize(count) { btree, kvs in
+        withEvery("i", in: 0..<count) { i in
+          let index = btree.lastIndex(forKey: kvs[i].key)
+          expectEqual(index.offset, i)
+        }
+        // Key smaller than every element: no element <= key, returns endIndex
+        let below = btree.lastIndex(forKey: -1)
+        expectEqual(below, btree.endIndex)
+      }
+    }
+  }
+
   func test_randomInsertionOrder() {
     let kvs = [
       (key: 71, value: 142),

--- a/Tests/SortedCollectionsTests/BTree/BTree.Builder Tests.swift
+++ b/Tests/SortedCollectionsTests/BTree/BTree.Builder Tests.swift
@@ -21,15 +21,48 @@ final class BTreeBuilderTests: CollectionTestCase {
   func test_append() {
     withEvery("size", in: 0..<1000) { size in
       var builder = _BTree<Int, Int>.Builder(capacity: 4)
-      
+
       for i in 0..<size {
         builder.append((i, -i))
       }
-      
+
       let tree = builder.finish()
       tree.checkInvariants()
       expectEqualElements(tree, (0..<size).map { (key: $0, value: -$0) })
     }
+  }
+
+  func test_join_nonLeafSimpleMerge() {
+    // Two depth-1 internal nodes whose combined element count plus the
+    // separator fits in a single internal node of capacity 4.  This
+    // exercises the simple-merge branch of
+    // `_Node.UnsafeHandle.concatenateWith` on non-leaf nodes, which must
+    // move children via `moveInitializeChildren` rather than
+    // `moveInitializeElements`.
+    let capacity = 4
+
+    var leftNode = tree {
+      tree { 0; 1; 2 }
+      3
+      tree { 4; 5 }
+    }.toNode(ofCapacity: capacity)
+
+    var rightNode = tree {
+      tree { 7; 8 }
+      9
+      tree { 10; 11; 12 }
+    }.toNode(ofCapacity: capacity)
+
+    let merged = _Node.join(
+      &leftNode,
+      with: &rightNode,
+      separatedBy: (key: 6, value: 12),
+      capacity: capacity
+    )
+
+    let btree = _BTree(rootedAt: merged, internalCapacity: capacity)
+    btree.checkInvariants()
+    expectEqualElements(btree, (0...12).map { (key: $0, value: $0 * 2) })
   }
 }
 #endif

--- a/Tests/SortedCollectionsTests/SortedSet/SortedSet Tests.swift
+++ b/Tests/SortedCollectionsTests/SortedSet/SortedSet Tests.swift
@@ -97,7 +97,68 @@ class SortedSetTests: CollectionTestCase {
       expectNil(set.index(of: count))
     }
   }
-  
+
+  func test_firstIndexAfter() {
+    withEvery("count", in: 0 ..< 40) { count in
+      // Use even numbers so we can exercise both the "present" and "absent"
+      // paths: a query of 2i hits an element, 2i+1 falls between elements.
+      let set = SortedSet((0 ..< count).map { $0 * 2 })
+      withEvery("item", in: 0 ..< count) { item in
+        let member = item * 2
+        let between = member + 1
+        if item + 1 < count {
+          let expected = (item + 1) * 2
+          expectNotNil(set.firstIndex(after: member)) { index in
+            expectEqual(set[index], expected)
+          }
+          expectNotNil(set.firstIndex(after: between)) { index in
+            expectEqual(set[index], expected)
+          }
+        } else {
+          expectNil(set.firstIndex(after: member))
+          expectNil(set.firstIndex(after: between))
+        }
+      }
+      if count > 0 {
+        expectNotNil(set.firstIndex(after: -1)) { index in
+          expectEqual(set[index], 0)
+        }
+      } else {
+        expectNil(set.firstIndex(after: -1))
+      }
+    }
+  }
+
+  func test_lastIndexBefore() {
+    withEvery("count", in: 0 ..< 40) { count in
+      let set = SortedSet((0 ..< count).map { $0 * 2 })
+      withEvery("item", in: 0 ..< count) { item in
+        let member = item * 2
+        let between = member + 1
+        if item > 0 {
+          let expected = (item - 1) * 2
+          expectNotNil(set.lastIndex(before: member)) { index in
+            expectEqual(set[index], expected)
+          }
+        } else {
+          expectNil(set.lastIndex(before: member))
+        }
+        // `between` is strictly greater than `member`, so the largest
+        // element less than it is always `member`.
+        expectNotNil(set.lastIndex(before: between)) { index in
+          expectEqual(set[index], member)
+        }
+      }
+      if count > 0 {
+        expectNotNil(set.lastIndex(before: count * 2)) { index in
+          expectEqual(set[index], (count - 1) * 2)
+        }
+      } else {
+        expectNil(set.lastIndex(before: 0))
+      }
+    }
+  }
+
   func test_removeAtIndex() {
     withEvery("count", in: 0 ..< 40) { count in
       withEvery("index", in: 0..<count) { index in

--- a/Tests/SortedCollectionsTests/SortedSet/SortedSet Tests.swift
+++ b/Tests/SortedCollectionsTests/SortedSet/SortedSet Tests.swift
@@ -553,6 +553,53 @@ class SortedSetTests: CollectionTestCase {
       }
     }
   }
+
+  func test_closedRangeSubscript() {
+    withEvery("count", in: [1, 5, 32, 64]) { count in
+      // Use even values so `2i+1` probes positions that fall between members.
+      let set = SortedSet((0 ..< count).map { $0 * 2 })
+      withEvery("lo", in: 0 ... 2 * count) { lo in
+        withEvery("hi", in: lo ... 2 * count) { hi in
+          let slice = set[lo ... hi]
+          let expected = (lo ... hi).filter { $0.isMultiple(of: 2) && $0 < 2 * count }
+          expectEqualElements(slice, expected)
+        }
+      }
+    }
+  }
+
+  func test_partialRangeFromSubscript() {
+    withEvery("count", in: [0, 1, 5, 32, 64]) { count in
+      let set = SortedSet((0 ..< count).map { $0 * 2 })
+      withEvery("lo", in: -1 ... 2 * count) { lo in
+        let slice = set[lo...]
+        let expected = (0 ..< count).map { $0 * 2 }.filter { $0 >= lo }
+        expectEqualElements(slice, expected)
+      }
+    }
+  }
+
+  func test_partialRangeUpToSubscript() {
+    withEvery("count", in: [0, 1, 5, 32, 64]) { count in
+      let set = SortedSet((0 ..< count).map { $0 * 2 })
+      withEvery("hi", in: 0 ... 2 * count) { hi in
+        let slice = set[..<hi]
+        let expected = (0 ..< count).map { $0 * 2 }.filter { $0 < hi }
+        expectEqualElements(slice, expected)
+      }
+    }
+  }
+
+  func test_partialRangeThroughSubscript() {
+    withEvery("count", in: [0, 1, 5, 32, 64]) { count in
+      let set = SortedSet((0 ..< count).map { $0 * 2 })
+      withEvery("hi", in: -1 ... 2 * count) { hi in
+        let slice = set[...hi]
+        let expected = (0 ..< count).map { $0 * 2 }.filter { $0 <= hi }
+        expectEqualElements(slice, expected)
+      }
+    }
+  }
 }
 
 #endif

--- a/Tests/SortedCollectionsTests/SortedSet/SortedSet Tests.swift
+++ b/Tests/SortedCollectionsTests/SortedSet/SortedSet Tests.swift
@@ -479,6 +479,19 @@ class SortedSetTests: CollectionTestCase {
       }
     }
   }
+
+  func test_rangeSubscript() {
+    withEvery("count", in: [0, 1, 5, 32, 64]) { count in
+      let set = SortedSet(0 ..< count)
+      guard count > 0 else { return }
+      withEvery("lo", in: 0 ..< count) { lo in
+        withEvery("hi", in: lo ... count) { hi in
+          let slice = set[lo ..< hi]
+          expectEqualElements(slice, lo ..< hi)
+        }
+      }
+    }
+  }
 }
 
 #endif


### PR DESCRIPTION
- Add some missing `SortedSet` operations for looking up value boundaries.
- Resolve some (related) logic issues in SortedCollections.
- Minor Heap adjustments.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
