### PR TITLE
[BasicContainers] Enable APIs scheduled to ship in 1.5.0

### DIFF
--- a/Sources/BasicContainers/RigidArray/RigidArray+Container.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Container.swift
@@ -400,7 +400,6 @@ extension RigidArray where Element: ~Copyable {
     return _span(in: Range(uncheckedBounds: (start, index)))
   }
 
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW // FIXME: Enable unconditionally in 1.5.0
   @inlinable
   @_lifetime(&self)
   public mutating func nextMutableSpan(after index: inout Int, maximumCount: Int) -> MutableSpan<Element> {
@@ -422,7 +421,6 @@ extension RigidArray where Element: ~Copyable {
     index = start &- Swift.min(maximumCount, start)
     return _span(in: Range(uncheckedBounds: (index, start)))
   }
-#endif
 }
 
 #endif

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Container.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Container.swift
@@ -357,7 +357,6 @@ extension UniqueArray where Element: ~Copyable {
     _storage.nextSpan(after: &index, maximumCount: maximumCount)
   }
 
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW // FIXME: Enable unconditionally in 1.5.0
   @inlinable
   @_lifetime(&self)
   public mutating func nextMutableSpan(
@@ -373,7 +372,6 @@ extension UniqueArray where Element: ~Copyable {
   ) -> Span<Element> {
     _storage.previousSpan(before: &index, maximumCount: maximumCount)
   }
-#endif
 }
 
 #endif

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Deprecated.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Deprecated.swift
@@ -15,6 +15,13 @@
 
 @available(SwiftStdlib 5.0, *)
 extension UniqueArray where Element: ~Copyable {
+  /// Initializes a new unique array with the specified capacity and no elements.
+  @available(*, deprecated, renamed: "init(minimumCapacity:)")
+  @inlinable
+  public init(capacity: Int) {
+    self.init(minimumCapacity: capacity)
+  }
+
   /// Append a given number of items to the end of this array by populating
   /// an output span.
   ///

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Initializers.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Initializers.swift
@@ -28,17 +28,9 @@ extension UniqueArray where Element: ~Copyable {
   
   /// Initializes a new unique array with the specified capacity and no elements.
   @inlinable
-  public init(capacity: Int) {
-    _storage = .init(capacity: capacity)
-  }
-
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW // FIXME: Enable unconditionally in 1.5.0
-  /// Initializes a new unique array with the specified capacity and no elements.
-  @inlinable
   public init(minimumCapacity: Int) {
     _storage = .init(capacity: minimumCapacity)
   }
-#endif
 }
 
 @available(SwiftStdlib 5.0, *)

--- a/Sources/DequeModule/CMakeLists.txt
+++ b/Sources/DequeModule/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(${module_name} PRIVATE
   "UniqueDeque/UniqueDeque+Append.swift"
   "UniqueDeque/UniqueDeque+Consumption.swift"
   "UniqueDeque/UniqueDeque+Container.swift"
+  "UniqueDeque/UniqueDeque+Deprecated.swift"
   "UniqueDeque/UniqueDeque+Descriptions.swift"
   "UniqueDeque/UniqueDeque+Equatable.swift"
   "UniqueDeque/UniqueDeque+Experimental.swift"

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Container.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Container.swift
@@ -91,21 +91,17 @@ extension RigidDeque where Element: ~Copyable {
   @inline(__always)
   public func index(after index: Int) -> Int { index + 1 }
 
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW // FIXME: Enable unconditionally in 1.5.0
   @_alwaysEmitIntoClient
   @inline(__always)
   public func index(before index: Int) -> Int { index - 1 }
-#endif
 
   @_alwaysEmitIntoClient
   @inline(__always)
   public func formIndex(after index: inout Int) { index += 1 }
 
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW // FIXME: Enable unconditionally in 1.5.0
   @_alwaysEmitIntoClient
   @inline(__always)
   public func formIndex(before index: inout Int) { index -= 1 }
-#endif
 
   @_alwaysEmitIntoClient
   @inline(__always)
@@ -132,7 +128,6 @@ extension RigidDeque where Element: ~Copyable {
     return _overrideLifetime(Span(_unsafeElements: segment), borrowing: self)
   }
 
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW // FIXME: Enable unconditionally in 1.5.0
   @_lifetime(&self)
   public mutating func nextMutableSpan(
     after index: inout Int, maximumCount: Int
@@ -159,7 +154,6 @@ extension RigidDeque where Element: ~Copyable {
     index &-= segment.count
     return _overrideLifetime(Span(_unsafeElements: segment), borrowing: self)
   }
-#endif
 }
 
 #endif

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Container.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Container.swift
@@ -60,21 +60,17 @@ extension UniqueDeque where Element: ~Copyable {
   @inline(__always)
   public func index(after index: Int) -> Int { index + 1 }
 
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW // FIXME: Enable unconditionally in 1.5.0
   @_alwaysEmitIntoClient
   @inline(__always)
   public func index(before index: Int) -> Int { index - 1 }
-#endif
 
   @_alwaysEmitIntoClient
   @inline(__always)
   public func formIndex(after index: inout Int) { index += 1 }
 
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW // FIXME: Enable unconditionally in 1.5.0
   @_alwaysEmitIntoClient
   @inline(__always)
   public func formIndex(before index: inout Int) { index -= 1 }
-#endif
 
   @_alwaysEmitIntoClient
   @inline(__always)
@@ -95,7 +91,6 @@ extension UniqueDeque where Element: ~Copyable {
     _storage.nextSpan(after: &index, maximumCount: maximumCount)
   }
 
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW // FIXME: Enable unconditionally in 1.5.0
   @_lifetime(&self)
   public mutating func nextMutableSpan(
     after index: inout Int, maximumCount: Int
@@ -108,7 +103,6 @@ extension UniqueDeque where Element: ~Copyable {
   public func previousSpan(before index: inout Int, maximumCount: Int) -> Span<Element> {
     _storage.previousSpan(before: &index, maximumCount: maximumCount)
   }
-#endif
 }
 
 #endif

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Deprecated.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Deprecated.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0 WITH Swift-exception
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.2)
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueDeque where Element: ~Copyable {
+  /// Creates an empty unique deque with the specified capacity.
+  @available(*, deprecated, renamed: "init(minimumCapacity:)")
+  @_alwaysEmitIntoClient
+  @_transparent
+  public init(capacity: Int) {
+    _storage = .init(capacity: capacity)
+  }
+}
+
+#endif

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Initializers.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Initializers.swift
@@ -32,18 +32,9 @@ extension UniqueDeque where Element: ~Copyable {
   /// Creates an empty unique deque with the specified capacity.
   @_alwaysEmitIntoClient
   @_transparent
-  public init(capacity: Int) {
-    _storage = .init(capacity: capacity)
-  }
-
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW // FIXME: Enable unconditionally in 1.5.0
-  /// Creates an empty unique deque with the specified capacity.
-  @_alwaysEmitIntoClient
-  @_transparent
   public init(minimumCapacity: Int) {
     _storage = .init(capacity: minimumCapacity)
   }
-#endif
 
   /// Creates a unique deque with the specified capacity, then calls the given
   /// closure with an output span covering the deque's uninitialized memory.

--- a/Tests/DequeTests/RigidDequeCrashTests.swift
+++ b/Tests/DequeTests/RigidDequeCrashTests.swift
@@ -80,7 +80,6 @@ struct RigidDequeCrashTests {
     }
   }
 
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
   @Test("nextMutableSpan with out-of-bounds index traps")
   func nextMutableSpanOutOfBoundsIndex() async {
     await #expect(processExitsWith: .failure) {
@@ -108,7 +107,6 @@ struct RigidDequeCrashTests {
       _ = deque.nextMutableSpan(after: &index, maximumCount: -1)
     }
   }
-#endif
 }
 #endif
 #endif

--- a/Xcode/Collections.xcodeproj/project.pbxproj
+++ b/Xcode/Collections.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		7D7246922F3D9E6800112FD0 /* RigidSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7246912F3D9E6800112FD0 /* RigidSetTests.swift */; };
 		7D72F5962F75DA62004AB792 /* BorrowingSequence+Algorithms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D72F5932F75DA62004AB792 /* BorrowingSequence+Algorithms.swift */; };
 		7D72F5982F75E5E6004AB792 /* BorrowingSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D72F5972F75E5E6004AB792 /* BorrowingSequenceTests.swift */; };
+		7D7646082FAAABE3008639E5 /* UniqueDeque+Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7646072FAAABDF008639E5 /* UniqueDeque+Deprecated.swift */; };
 		7D9748D42E9748930098631A /* BigString+Chunk+UTF16.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D9748D32E9748930098631A /* BigString+Chunk+UTF16.swift */; };
 		7D9748D52E9748930098631A /* BigString+Chunk+UnicodeScalar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D9748D12E9748930098631A /* BigString+Chunk+UnicodeScalar.swift */; };
 		7D9748D62E9748930098631A /* BigString+Chunk+Character.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D9748CF2E9748930098631A /* BigString+Chunk+Character.swift */; };
@@ -755,6 +756,7 @@
 		7D7246912F3D9E6800112FD0 /* RigidSetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RigidSetTests.swift; sourceTree = "<group>"; };
 		7D72F5932F75DA62004AB792 /* BorrowingSequence+Algorithms.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BorrowingSequence+Algorithms.swift"; sourceTree = "<group>"; };
 		7D72F5972F75E5E6004AB792 /* BorrowingSequenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorrowingSequenceTests.swift; sourceTree = "<group>"; };
+		7D7646072FAAABDF008639E5 /* UniqueDeque+Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UniqueDeque+Deprecated.swift"; sourceTree = "<group>"; };
 		7D9748CF2E9748930098631A /* BigString+Chunk+Character.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BigString+Chunk+Character.swift"; sourceTree = "<group>"; };
 		7D9748D02E9748930098631A /* BigString+Chunk+Index.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BigString+Chunk+Index.swift"; sourceTree = "<group>"; };
 		7D9748D12E9748930098631A /* BigString+Chunk+UnicodeScalar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BigString+Chunk+UnicodeScalar.swift"; sourceTree = "<group>"; };
@@ -1346,6 +1348,7 @@
 				7D2A77712F27F2BF005780C7 /* UniqueDeque+Experimental.swift */,
 				7D57A2C92F342F43002543BD /* UniqueDeque+Hashable.swift */,
 				7D2A77722F27F2BF005780C7 /* UniqueDeque+Initializers.swift */,
+				7D7646072FAAABDF008639E5 /* UniqueDeque+Deprecated.swift */,
 				7D2A77732F27F2BF005780C7 /* UniqueDeque+Insertions.swift */,
 				7D2A77742F27F2BF005780C7 /* UniqueDeque+Prepend.swift */,
 				7D2A77752F27F2BF005780C7 /* UniqueDeque+Removals.swift */,
@@ -2861,6 +2864,7 @@
 				7DE9204429CA70F3004483EB /* _HashTable.swift in Sources */,
 				7DE9206529CA70F4004483EB /* BigString+Ingester.swift in Sources */,
 				7DE9209129CA70F4004483EB /* Rope+_UnsafeHandle.swift in Sources */,
+				7D7646082FAAABE3008639E5 /* UniqueDeque+Deprecated.swift in Sources */,
 				7DE920D529CA70F4004483EB /* BitSet.swift in Sources */,
 				7DE9217D29CA70F4004483EB /* Heap.swift in Sources */,
 				7D479CC12F46D14E00A8CB59 /* RigidSet+Consumption.swift in Sources */,


### PR DESCRIPTION
- `RigidArray.nextMutableSpan(after:maximumCount:)`
- `UniqueArray.nextMutableSpan(after:maximumCount:)`
- `RigidDeque.nextMutableSpan(after:maximumCount:)`
- `UniqueDeque.nextMutableSpan(after:maximumCount:)`
- `UniqueArray.init(minimumCapacity:)` (replacing `.init(capacity:)`)
- `UniqueDeque.init(minimumCapacity:)` (replacing `.init(capacity:)`)
- `RigidDeque.index(before:)`
- `UniqueDeque.index(before:)`
- `RigidDeque.formIndex(before:)`
- `UniqueDeque.formIndex(before:)`

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
