### PR TITLE
Guard `UniqueBox.borrow` correctly

### DIFF
--- a/Sources/ContainersPreview/Types/UniqueBox.swift
+++ b/Sources/ContainersPreview/Types/UniqueBox.swift
@@ -198,7 +198,7 @@ extension UniqueBox where Value: ~Copyable {
   }
 #endif
 
-#if UnstableContainersPreview
+#if compiler(>=6.3) && UnstableContainersPreview
   /// Return a borrowing reference to the contents of this box.
   @available(SwiftStdlib 5.0, *)
   @_alwaysEmitIntoClient


### PR DESCRIPTION
Correctly guard the `borrow` method behind the compiler version