### PR TITLE
Resolve source break in the Collections module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -124,14 +124,14 @@ let extraSettings: [SwiftSetting] = [
   // CMakeLists.txt and Xcode/Shared.xcconfig.
 ]
 
-let _settings: [SwiftSetting] = (
+let _baseSettings: [SwiftSetting] = (
   defines
   + availabilityMacros.map { name, value in
       .enableExperimentalFeature("AvailabilityMacro=\(name): \(value)")
   }
-  + extraSettings
 )
 
+let _settings: [SwiftSetting] = _baseSettings + extraSettings
 let _testSettings: [SwiftSetting] = _settings
 
 struct CustomTarget {
@@ -359,7 +359,12 @@ let targets: [CustomTarget] = [
       "OrderedCollections",
       "_RopeModule",
     ],
-    exclude: ["CMakeLists.txt"])
+    exclude: ["CMakeLists.txt"]),
+  .target(
+    kind: .test,
+    name: "CollectionsModuleTests",
+    dependencies: ["Collections", "_CollectionsTestSupport"],
+    settings: _baseSettings),
 ]
 
 let _products: [Product] = targets.compactMap { t in

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -79,14 +79,14 @@ let extraSettings: [SwiftSetting] = [
   .enableExperimentalFeature("BuiltinModule"),
 ]
 
-let _sharedSettings: [SwiftSetting] = (
+let _baseSettings: [SwiftSetting] = (
   defines.map { .define($0) }
   + availabilityMacros.map { name, value in
       .enableExperimentalFeature("AvailabilityMacro=\(name): \(value)")
   }
-  + extraSettings
 )
 
+let _sharedSettings: [SwiftSetting] = _baseSettings + extraSettings
 let _settings: [SwiftSetting] = _sharedSettings + []
 let _testSettings: [SwiftSetting] = _sharedSettings + []
 
@@ -354,7 +354,12 @@ let targets: [CustomTarget] = [
       "_RopeModule",
       //"SortedCollections",
     ],
-    exclude: ["CMakeLists.txt"])
+    exclude: ["CMakeLists.txt"]),
+  .target(
+    kind: .test,
+    name: "CollectionsModuleTests",
+    dependencies: ["Collections", "_CollectionsTestSupport"],
+    settings: _baseSettings),
 ]
 
 var _products: [Product] = []

--- a/Sources/Collections/DequeModule reexports.swift
+++ b/Sources/Collections/DequeModule reexports.swift
@@ -14,5 +14,5 @@
 #if !COLLECTIONS_SINGLE_MODULE
 import DequeModule
 
-public typealias Deque = DequeModule.Deque
+public typealias Deque<Element> = DequeModule.Deque<Element>
 #endif

--- a/Sources/Collections/HashTreeCollections reexports.swift
+++ b/Sources/Collections/HashTreeCollections reexports.swift
@@ -14,6 +14,6 @@
 #if !COLLECTIONS_SINGLE_MODULE
 import HashTreeCollections
 
-public typealias TreeSet = HashTreeCollections.TreeSet
-public typealias TreeDictionary = HashTreeCollections.TreeDictionary
+public typealias TreeSet<Element: Hashable> = HashTreeCollections.TreeSet<Element>
+public typealias TreeDictionary<Key: Hashable, Value> = HashTreeCollections.TreeDictionary<Key, Value>
 #endif

--- a/Sources/Collections/HeapModule reexports.swift
+++ b/Sources/Collections/HeapModule reexports.swift
@@ -14,5 +14,5 @@
 #if !COLLECTIONS_SINGLE_MODULE
 import HeapModule
 
-public typealias Heap = HeapModule.Heap
+public typealias Heap<Element: Comparable> = HeapModule.Heap<Element>
 #endif

--- a/Sources/Collections/OrderedCollections reexports.swift
+++ b/Sources/Collections/OrderedCollections reexports.swift
@@ -14,6 +14,6 @@
 #if !COLLECTIONS_SINGLE_MODULE
 import OrderedCollections
 
-public typealias OrderedSet = OrderedCollections.OrderedSet
-public typealias OrderedDictionary = OrderedCollections.OrderedDictionary
+public typealias OrderedSet<Element: Hashable> = OrderedCollections.OrderedSet<Element>
+public typealias OrderedDictionary<Key: Hashable, Value> = OrderedCollections.OrderedDictionary<Key, Value>
 #endif

--- a/Tests/CollectionsModuleTests/CollectionsTests.swift
+++ b/Tests/CollectionsModuleTests/CollectionsTests.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0 WITH Swift-exception
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Collections
+
+// Verify that importing `Collections` makes available the expected types,
+// including their member APIs, as if it was reexporting its component modules.
+// (Accessing member APIs is incompatible with `MemberImportVisibility`, but
+// that is not by itself source breaking.)
+
+public func check(_ items: OrderedSet<Int>) -> Int {
+  items[items.startIndex]
+}
+
+public func check(_ items: OrderedDictionary<Int, Int>) -> Int {
+  items[42] ?? 23
+}
+
+public func check(_ items: Deque<Int>) -> Int {
+  items[items.startIndex]
+}
+
+public func check(_ items: BitSet) -> Int {
+  items[items.startIndex]
+}
+
+public func check(_ items: BitArray) -> Int {
+  items.count
+}
+
+public func check2(_ items: BitArray) -> Int {
+  Int(items)
+}
+
+public func check(_ items: inout Heap<Int>) -> Int {
+  items.removeMin()
+}
+
+public func check(_ items: TreeSet<Int>) -> Int {
+  items[items.startIndex]
+}
+
+public func check(_ items: TreeDictionary<Int, Int>) -> Int {
+  items[42] ?? 23
+}
+
+
+class CollectionsTests: XCTestCase {
+  func testDummy() {
+    var items = Deque<Int>()
+    items.prepend(42)
+    XCTAssertEqual(items.first, 42)
+  }
+}

--- a/Xcode/Collections.xcodeproj/project.pbxproj
+++ b/Xcode/Collections.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 		7DA23F582F32C66300E4C03A /* RigidArray+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DA23F572F32C65900E4C03A /* RigidArray+Equatable.swift */; };
 		7DA23F5A2F32C68300E4C03A /* RigidArray+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DA23F592F32C67D00E4C03A /* RigidArray+Hashable.swift */; };
 		7DA23F5C2F32C69100E4C03A /* RigidArray+Descriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DA23F5B2F32C68B00E4C03A /* RigidArray+Descriptions.swift */; };
+		7DA296012FB79DC5005042B0 /* CollectionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DA295FF2FB79DC5005042B0 /* CollectionsTests.swift */; };
 		7DACFA122F75FBF100291F2E /* SpanIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DACFA112F75FBF100291F2E /* SpanIterator.swift */; };
 		7DAD899E2E8B09C300DD5786 /* UInt+first and last set bit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DAD899C2E8B09C300DD5786 /* UInt+first and last set bit.swift */; };
 		7DAD899F2E8B09C300DD5786 /* UInt+reversed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DAD899D2E8B09C300DD5786 /* UInt+reversed.swift */; };
@@ -798,6 +799,7 @@
 		7DA23F572F32C65900E4C03A /* RigidArray+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RigidArray+Equatable.swift"; sourceTree = "<group>"; };
 		7DA23F592F32C67D00E4C03A /* RigidArray+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RigidArray+Hashable.swift"; sourceTree = "<group>"; };
 		7DA23F5B2F32C68B00E4C03A /* RigidArray+Descriptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RigidArray+Descriptions.swift"; sourceTree = "<group>"; };
+		7DA295FF2FB79DC5005042B0 /* CollectionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionsTests.swift; sourceTree = "<group>"; };
 		7DACFA112F75FBF100291F2E /* SpanIterator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanIterator.swift; sourceTree = "<group>"; };
 		7DAD899A2E8B09C300DD5786 /* FixedWidthInteger+roundUpToPowerOfTwo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FixedWidthInteger+roundUpToPowerOfTwo.swift"; sourceTree = "<group>"; };
 		7DAD899B2E8B09C300DD5786 /* Integer rank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Integer rank.swift"; sourceTree = "<group>"; };
@@ -1583,6 +1585,14 @@
 			path = UniqueArray;
 			sourceTree = "<group>";
 		};
+		7DA296002FB79DC5005042B0 /* CollectionsModuleTests */ = {
+			isa = PBXGroup;
+			children = (
+				7DA295FF2FB79DC5005042B0 /* CollectionsTests.swift */,
+			);
+			path = CollectionsModuleTests;
+			sourceTree = "<group>";
+		};
 		7DE91B1C29CA6721004483EB = {
 			isa = PBXGroup;
 			children = (
@@ -2211,6 +2221,7 @@
 				7DE921E429CA8575004483EB /* OrderedCollectionsTests */,
 				7DE921DE29CA8575004483EB /* RopeModuleTests */,
 				C13E81112E78F3D0008DFC5C /* TrailingElementsTests */,
+				7DA296002FB79DC5005042B0 /* CollectionsModuleTests */,
 				7D5A64D829CCF0FE00CB2595 /* README.md */,
 			);
 			name = Tests;
@@ -3170,6 +3181,7 @@
 				7DE9220E29CA8576004483EB /* SampleStrings.swift in Sources */,
 				7DEBDB9129CCE44A00ADC226 /* CollectionTestCase.swift in Sources */,
 				7DE921B929CA81DC004483EB /* _SortedCollection.swift in Sources */,
+				7DA296012FB79DC5005042B0 /* CollectionsTests.swift in Sources */,
 				7DEBDB7B29CCE44A00ADC226 /* IndexRangeCollection.swift in Sources */,
 				7DE9221929CA8576004483EB /* HeapTests.swift in Sources */,
 				7D7646062FAAA2B9008639E5 /* UniqueBoxTests.swift in Sources */,


### PR DESCRIPTION
Surprisingly, the 1.4.0 tag seems to have broken some clients importing the Collections module. Explore the issue and do what we can to fix it if possible.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
