### PR TITLE
Add missing availability to Borrow

### DIFF
--- a/Sources/ContainersPreview/Types/Ref.swift
+++ b/Sources/ContainersPreview/Types/Ref.swift
@@ -143,6 +143,7 @@ extension Ref where Value: ~Copyable {
   }
 }
 
+@available(SwiftStdlib 5.0, *)
 @available(*, deprecated, renamed: "Ref")
 public typealias Borrow = Ref
 


### PR DESCRIPTION
Build failure on latest compiler snapshot (5-17) when testing https://github.com/apple/swift-async-algorithms/pull/421:

```
/Volumes/Data/swift-async-algorithms/.build/checkouts/swift-collections/Sources/ContainersPreview/Types/Ref.swift:147:27: error: 'Ref' is only available in macOS 10.14.4 or newer
145 | 
146 | @available(*, deprecated, renamed: "Ref")
147 | public typealias Borrow = Ref
    |                  |        `- error: 'Ref' is only available in macOS 10.14.4 or newer
    |                  `- note: add '@available' attribute to enclosing type alias
148 | 
149 | @available(SwiftStdlib 5.0, *)
```