### PR TITLE
[InternalCollectionsUtilities] Fix _trim returning the wrong buffer region

### DIFF
--- a/Sources/InternalCollectionsUtilities/UnsafeBufferPointer+Extras.swift
+++ b/Sources/InternalCollectionsUtilities/UnsafeBufferPointer+Extras.swift
@@ -146,7 +146,7 @@ extension UnsafeBufferPointer where Element: ~Copyable {
     guard cut > 0 else { return .init(start: nil, count: 0) }
     let oldStart = baseAddress.unsafelyUnwrapped
     self = Self(start: oldStart + cut, count: count - cut)
-    return Self(start: baseAddress, count: cut)
+    return Self(start: oldStart, count: cut)
   }
 
   @_alwaysEmitIntoClient
@@ -154,7 +154,9 @@ extension UnsafeBufferPointer where Element: ~Copyable {
     precondition(maxLength >= 0, "Cannot have a suffix of negative length")
     let cut = Swift.min(maxLength, count)
     guard cut > 0 else { return .init(start: nil, count: 0) }
-    self = .init(start: baseAddress, count: count &- cut)
-    return Self(start: baseAddress.unsafelyUnwrapped + (count &- cut), count: cut)
+    let oldStart = baseAddress.unsafelyUnwrapped
+    let newCount = count &- cut
+    self = .init(start: oldStart, count: newCount)
+    return Self(start: oldStart + newCount, count: cut)
   }
 }

--- a/Sources/InternalCollectionsUtilities/UnsafeMutableBufferPointer+Extras.swift
+++ b/Sources/InternalCollectionsUtilities/UnsafeMutableBufferPointer+Extras.swift
@@ -167,8 +167,10 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable {
     precondition(maxLength >= 0, "Cannot have a suffix of negative length")
     let cut = Swift.min(maxLength, count)
     guard cut > 0 else { return .init(start: nil, count: 0) }
-    self = .init(start: baseAddress, count: count &- cut)
-    return Self(start: baseAddress.unsafelyUnwrapped + (count &- cut), count: cut)
+    let oldStart = baseAddress.unsafelyUnwrapped
+    let newCount = count &- cut
+    self = .init(start: oldStart, count: newCount)
+    return Self(start: oldStart + newCount, count: cut)
   }
 }
 

--- a/Tests/DequeTests/UnsafeBufferTrimTests.swift
+++ b/Tests/DequeTests/UnsafeBufferTrimTests.swift
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0 WITH Swift-exception
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+#if COLLECTIONS_SINGLE_MODULE
+@_spi(Testing) import Collections
+#else
+import _CollectionsTestSupport
+import InternalCollectionsUtilities
+#endif
+
+/// Tests for the `_trim(first:)` and `_trim(last:)` helpers on the unsafe
+/// buffer pointer types in `InternalCollectionsUtilities`. These are used by
+/// the deque consumption/segment machinery, so a wrong result here corrupts
+/// the spans that get handed out to clients.
+final class UnsafeBufferTrimTests: CollectionTestCase {
+  func test_mutableBuffer_trimFirst() {
+    let values = [10, 20, 30, 40, 50]
+    values.withUnsafeBufferPointer { source in
+      let storage = UnsafeMutableBufferPointer<Int>.allocate(capacity: source.count)
+      defer { storage.deallocate() }
+      _ = storage.initialize(fromContentsOf: source)
+      defer { storage.deinitialize() }
+
+      var rest = storage
+      let head = rest._trim(first: 2)
+      expectEqual(Array(head), [10, 20])
+      expectEqual(Array(rest), [30, 40, 50])
+
+      // Trimming more than the count yields everything.
+      var all = storage
+      let everything = all._trim(first: 99)
+      expectEqual(Array(everything), [10, 20, 30, 40, 50])
+      expectEqual(all.count, 0)
+    }
+  }
+
+  func test_mutableBuffer_trimLast() {
+    let values = [10, 20, 30, 40, 50]
+    values.withUnsafeBufferPointer { source in
+      let storage = UnsafeMutableBufferPointer<Int>.allocate(capacity: source.count)
+      defer { storage.deallocate() }
+      _ = storage.initialize(fromContentsOf: source)
+      defer { storage.deinitialize() }
+
+      var rest = storage
+      let tail = rest._trim(last: 2)
+      expectEqual(Array(tail), [40, 50])
+      expectEqual(Array(rest), [10, 20, 30])
+
+      var all = storage
+      let everything = all._trim(last: 99)
+      expectEqual(Array(everything), [10, 20, 30, 40, 50])
+      expectEqual(all.count, 0)
+    }
+  }
+
+  func test_immutableBuffer_trimFirst() {
+    let values = [10, 20, 30, 40, 50]
+    values.withUnsafeBufferPointer { source in
+      var rest = source
+      let head = rest._trim(first: 2)
+      expectEqual(Array(head), [10, 20])
+      expectEqual(Array(rest), [30, 40, 50])
+
+      var all = source
+      let everything = all._trim(first: 99)
+      expectEqual(Array(everything), [10, 20, 30, 40, 50])
+      expectEqual(all.count, 0)
+    }
+  }
+
+  func test_immutableBuffer_trimLast() {
+    let values = [10, 20, 30, 40, 50]
+    values.withUnsafeBufferPointer { source in
+      var rest = source
+      let tail = rest._trim(last: 2)
+      expectEqual(Array(tail), [40, 50])
+      expectEqual(Array(rest), [10, 20, 30])
+
+      var all = source
+      let everything = all._trim(last: 99)
+      expectEqual(Array(everything), [10, 20, 30, 40, 50])
+      expectEqual(all.count, 0)
+    }
+  }
+
+  func test_trim_zeroIsNoOp() {
+    let values = [1, 2, 3]
+    values.withUnsafeBufferPointer { source in
+      var a = source
+      expectEqual(a._trim(first: 0).count, 0)
+      expectEqual(Array(a), [1, 2, 3])
+
+      var b = source
+      expectEqual(b._trim(last: 0).count, 0)
+      expectEqual(Array(b), [1, 2, 3])
+    }
+  }
+}


### PR DESCRIPTION
While reading the buffer-pointer helpers in `InternalCollectionsUtilities`, I noticed that three of the four `_trim` variants compute the trimmed result from `self` after they have already reassigned `self` to the remaining slice. That makes them read the updated `baseAddress`/`count`, so the region they return points into the wrong place in the buffer.

`UnsafeMutableBufferPointer._trim(first:)` does this correctly today: it captures `oldStart` before reassigning `self` and builds the prefix from `oldStart`. (This is the same shape as the earlier fix in #631.) The three siblings were not adjusted to match:

- `UnsafeBufferPointer._trim(first:)` reassigns `self` to `oldStart + cut`, then returns `Self(start: baseAddress, count: cut)`. Since `baseAddress` now points at the remainder, the returned prefix starts `cut` elements too far forward.
- `UnsafeBufferPointer._trim(last:)` and `UnsafeMutableBufferPointer._trim(last:)` set `self` to a buffer of length `count - cut`, then return `Self(start: baseAddress + (count &- cut), count: cut)`. Because `count` has already been reduced by the assignment, the start is computed from the shrunk count and lands `cut` elements too early.

Concretely, for a five-element buffer holding `[10, 20, 30, 40, 50]`:

- `_trim(first: 2)` returned the storage for `[30, 40]` instead of `[10, 20]`.
- `_trim(last: 2)` returned `[20, 30]` instead of `[40, 50]`.

Trimming more than the element count (for example `_trim(first: .max)`) computed a start past the end of the buffer, so the returned span addressed out-of-bounds memory.

The fix captures the original start (and, for the suffix case, the post-trim count) into locals before mutating `self`, so the returned region is derived from the original buffer rather than the already-updated one. This mirrors the existing correct `_trim(first:)` on the mutable buffer.

The mutable `_trim(first:)` overload is reachable today through the deque and array `SubrangeConsumer.drainNext` paths and was already correct; the other three overloads currently have no in-tree callers, but they are part of the same helper family and are wrong as written, so this keeps the set consistent and safe for the next caller that picks them up.

Verification: added direct tests for `_trim(first:)` and `_trim(last:)` on both `UnsafeBufferPointer` and `UnsafeMutableBufferPointer` (plus the over-count and zero-length cases). They fail against the current sources (the immutable `_trim(first:)`, and both `_trim(last:)` overloads, return the wrong elements) and pass with this change. Full `swift test` is green: 802 XCTest cases and 13 swift-testing cases, 0 failures.