### PR TITLE
[SortedCollections] Fix _BTree default node capacity capping at 16

### DIFF
--- a/Sources/SortedCollections/BTree/_BTree.swift
+++ b/Sources/SortedCollections/BTree/_BTree.swift
@@ -31,7 +31,7 @@ internal struct _BTree<Key: Comparable, Value> {
     return 4
     #else
     let capacityInBytes = 128
-    return Swift.min(16, capacityInBytes / MemoryLayout<Key>.stride)
+    return Swift.max(16, capacityInBytes / MemoryLayout<Key>.stride)
     #endif
   }
   
@@ -43,7 +43,7 @@ internal struct _BTree<Key: Comparable, Value> {
     return 5
     #else
     let capacityInBytes = 2000
-    return Swift.min(16, capacityInBytes / MemoryLayout<Key>.stride)
+    return Swift.max(16, capacityInBytes / MemoryLayout<Key>.stride)
     #endif
   }
   


### PR DESCRIPTION
In `_BTree`, both `defaultInternalCapacity` and `defaultLeafCapacity` computed their release-build node capacity as:

```swift
return Swift.min(16, capacityInBytes / MemoryLayout<Key>.stride)
```

`Swift.min` here means the node capacity is **capped at 16**, regardless of element size. That defeats the byte-budget intent: for small elements (e.g. `Int`, stride 8), `capacityInBytes / stride` is much larger than 16 (250 for the 2000-byte leaf budget), yet the node is still clamped to 16. As a result, leaves could never hold more than 16 elements even when many small elements would comfortably fit within the byte budget.

This is the behavior reported in #257, where the maintainer confirmed: "it looks like this should use `Swift.max`, not `Swift.min`."

This change replaces `Swift.min` with `Swift.max` in both computations so that:
- `16` acts as a **floor** (a node always holds at least 16 elements), and
- the byte budget (`capacityInBytes / stride`) governs the **upper bound**, allowing larger nodes for small elements while still keeping nodes reasonable for large elements.

Only the release (`#else`) path is affected; the `#if DEBUG` fixed values (4 and 5) used by the test suite are unchanged.

Note: `SortedCollections` remains a source-unstable prototype module (gated behind the `UnstableSortedCollections` package trait), as noted by the maintainer in the issue. The maintainer also mentioned that `capacityInBytes` itself may be tuned (e.g. raised to ~16KiB) as part of later performance work; this PR is limited to the `min`/`max` correctness fix and does not change the byte budgets.

### Verification
- `swift build -c release --traits UnstableSortedCollections` — compiles the changed (release-path) lines successfully.
- `swift test --traits UnstableSortedCollections` — full suite passes: 887 XCTest cases, 0 failures, including all `SortedCollections` suites (`BTreeTests`, `BTreeBuilderTests`, `NodeTests`, `NodeBalancingTests`, `NodeDeletionTests`, `NodeInsertionTests`, `NodeJoinTests`, `SortedDictionaryTests`, `SortedSetTests`).

Fixes #257

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate). (No new code paths; this corrects an existing computation. The release-path capacity is not currently covered by tests, which exercise the DEBUG fixed values.)
- [ ] I've added benchmarks covering new functionality (if appropriate). (Not applicable.)
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary. (Not applicable — internal computed property.)
