### PR TITLE
Run heap node tests in release

### DIFF
--- a/Sources/HeapModule/CMakeLists.txt
+++ b/Sources/HeapModule/CMakeLists.txt
@@ -29,5 +29,6 @@ target_sources(${module_name} PRIVATE
   "Heap.swift"
   "Heap+Descriptions.swift"
   "Heap+ExpressibleByArrayLiteral.swift"
+  "Heap+Testing.swift"
   "Heap+Invariants.swift"
   "Heap+UnsafeHandle.swift")

--- a/Sources/HeapModule/Heap+Testing.swift
+++ b/Sources/HeapModule/Heap+Testing.swift
@@ -11,9 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(Testing)
-public enum _HeapTestSupport {
-  public static func isMinLevel(offset: Int) -> Bool {
+extension Heap {
+  package static func _isMinLevel(offset: Int) -> Bool {
     _HeapNode(offset: offset).isMinLevel
   }
 }

--- a/Sources/HeapModule/Heap+Testing.swift
+++ b/Sources/HeapModule/Heap+Testing.swift
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2021 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0 WITH Swift-exception
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Testing)
+public enum _HeapTestSupport {
+  public static func isMinLevel(offset: Int) -> Bool {
+    _HeapNode(offset: offset).isMinLevel
+  }
+}

--- a/Tests/HeapTests/HeapNodeTests.swift
+++ b/Tests/HeapTests/HeapNodeTests.swift
@@ -13,9 +13,9 @@
 
 import XCTest
 #if COLLECTIONS_SINGLE_MODULE
-@_spi(Testing) import Collections
+import Collections
 #else
-@_spi(Testing) import HeapModule
+import HeapModule
 #endif
 
 class HeapNodeTests: XCTestCase {
@@ -25,7 +25,7 @@ class HeapNodeTests: XCTestCase {
     for exp in 0...12 {
       // Check [2^exp, 2^(exp + 1))
       for offset in Int(pow(2, Double(exp)) - 1)..<Int(pow(2, Double(exp + 1)) - 1) {
-        XCTAssertEqual(_HeapTestSupport.isMinLevel(offset: offset), isMin)
+        XCTAssertEqual(Heap<Int>._isMinLevel(offset: offset), isMin)
       }
       isMin.toggle()
     }

--- a/Tests/HeapTests/HeapNodeTests.swift
+++ b/Tests/HeapTests/HeapNodeTests.swift
@@ -11,12 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if DEBUG // These unit tests need access to HeapModule internals
 import XCTest
 #if COLLECTIONS_SINGLE_MODULE
-@testable import Collections
+@_spi(Testing) import Collections
 #else
-@testable import HeapModule
+@_spi(Testing) import HeapModule
 #endif
 
 class HeapNodeTests: XCTestCase {
@@ -26,11 +25,9 @@ class HeapNodeTests: XCTestCase {
     for exp in 0...12 {
       // Check [2^exp, 2^(exp + 1))
       for offset in Int(pow(2, Double(exp)) - 1)..<Int(pow(2, Double(exp + 1)) - 1) {
-        let node = _HeapNode(offset: offset)
-        XCTAssertEqual(node.isMinLevel, isMin)
+        XCTAssertEqual(_HeapTestSupport.isMinLevel(offset: offset), isMin)
       }
       isMin.toggle()
     }
   }
 }
-#endif // DEBUG


### PR DESCRIPTION
## Summary
- add a Testing SPI helper for heap level calculation checks
- switch HeapNodeTests from debug-only @testable access to @_spi(Testing) imports
- include the helper in the CMake source list

Fixes #101.

## Validation
- swift test --configuration release --filter HeapNodeTests
- swift test --filter HeapNodeTests
- git diff --check