### PR TITLE
[BasicContainers] Rename reallocate to setCapacity for Rigid and UniqueArray

### DIFF
--- a/Sources/BasicContainers/RigidArray/RigidArray+Deprecated.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Deprecated.swift
@@ -77,7 +77,31 @@ extension RigidArray where Element: ~Copyable {
     }
     return result!
   }
-  
+
+  /// Grow or shrink the capacity of a rigid array instance without discarding
+  /// its contents.
+  ///
+  /// This operation replaces the array's storage buffer with a newly allocated
+  /// buffer of the specified capacity, moving all existing elements
+  /// to its new storage. The old storage is then deallocated.
+  ///
+  /// - Parameter newCapacity: The desired new capacity. `newCapacity` must be
+  ///    greater than or equal to the current count.
+  ///
+  /// - Complexity: O(`count`)
+  @available(*, deprecated, renamed: "setCapacity(_:)")
+  @inlinable
+  public mutating func reallocate(capacity newCapacity: Int) {
+    precondition(newCapacity >= count, "RigidArray capacity overflow")
+    guard newCapacity != capacity else { return }
+    let newStorage: UnsafeMutableBufferPointer<Element> = .allocate(
+      capacity: newCapacity)
+    let i = unsafe newStorage.moveInitialize(fromContentsOf: self._items)
+    assert(i == count)
+    unsafe _storage.deallocate()
+    unsafe _storage = newStorage
+  }
+
   /// Replaces the specified range of elements by a given count of new items,
   /// using a callback to directly initialize array storage by populating
   /// an output span.

--- a/Sources/BasicContainers/RigidArray/RigidArray+Deprecated.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Deprecated.swift
@@ -92,14 +92,7 @@ extension RigidArray where Element: ~Copyable {
   @available(*, deprecated, renamed: "setCapacity(_:)")
   @inlinable
   public mutating func reallocate(capacity newCapacity: Int) {
-    precondition(newCapacity >= count, "RigidArray capacity overflow")
-    guard newCapacity != capacity else { return }
-    let newStorage: UnsafeMutableBufferPointer<Element> = .allocate(
-      capacity: newCapacity)
-    let i = unsafe newStorage.moveInitialize(fromContentsOf: self._items)
-    assert(i == count)
-    unsafe _storage.deallocate()
-    unsafe _storage = newStorage
+    setCapacity(newCapacity)
   }
 
   /// Replaces the specified range of elements by a given count of new items,

--- a/Sources/BasicContainers/RigidArray/RigidArray.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray.swift
@@ -344,9 +344,8 @@ extension RigidArray where Element: ~Copyable {
   /// buffer of the specified capacity, moving all existing elements
   /// to its new storage. The old storage is then deallocated.
   ///
-  /// - Parameter newCapacity: The desired new capacity. `newCapacity` must be
-/// - Parameter newCapacity: The desired new capacity. The new capacity
-///    is set to the maximum of `newCapacity` and the current count.
+  /// - Parameter newCapacity: The desired new capacity. The new capacity
+  ///    is set to the maximum of `newCapacity` and the current count.
   ///
   /// - Complexity: O(`count`)
   @inlinable

--- a/Sources/BasicContainers/RigidArray/RigidArray.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray.swift
@@ -345,7 +345,8 @@ extension RigidArray where Element: ~Copyable {
   /// to its new storage. The old storage is then deallocated.
   ///
   /// - Parameter newCapacity: The desired new capacity. `newCapacity` must be
-  ///    greater than or equal to the current count.
+/// - Parameter newCapacity: The desired new capacity. The new capacity
+///    is set to the maximum of `newCapacity` and the current count.
   ///
   /// - Complexity: O(`count`)
   @inlinable

--- a/Sources/BasicContainers/RigidArray/RigidArray.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray.swift
@@ -349,11 +349,10 @@ extension RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`count`)
   @inlinable
-  public mutating func reallocate(capacity newCapacity: Int) {
-    precondition(newCapacity >= count, "RigidArray capacity overflow")
+  public mutating func setCapacity(_ newCapacity: Int) {
     guard newCapacity != capacity else { return }
     let newStorage: UnsafeMutableBufferPointer<Element> = .allocate(
-      capacity: newCapacity)
+      capacity: Swift.max(newCapacity, count))
     let i = unsafe newStorage.moveInitialize(fromContentsOf: self._items)
     assert(i == count)
     unsafe _storage.deallocate()
@@ -371,7 +370,7 @@ extension RigidArray where Element: ~Copyable {
   @inlinable
   public mutating func reserveCapacity(_ n: Int) {
     guard capacity < n else { return }
-    reallocate(capacity: n)
+    setCapacity(n)
   }
 }
 

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Deprecated.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Deprecated.swift
@@ -87,6 +87,23 @@ extension UniqueArray where Element: ~Copyable {
     return result!
   }
 
+  /// Grow or shrink the capacity of a unique array instance without discarding
+  /// its contents.
+  ///
+  /// This operation replaces the array's storage buffer with a newly allocated
+  /// buffer of the specified capacity, moving all existing elements
+  /// to its new storage. The old storage is then deallocated.
+  ///
+  /// - Parameter newCapacity: The desired new capacity. `newCapacity` must be
+  ///    greater than or equal to the current count.
+  ///
+  /// - Complexity: O(`count`)
+  @available(*, deprecated, renamed: "setCapacity(_:)")
+  @inlinable
+  public mutating func reallocate(capacity: Int) {
+    _storage.reallocate(capacity: capacity)
+  }
+
   /// Replaces the specified range of elements by a given count of new items,
   /// using a callback to directly initialize array storage by populating
   /// an output span.

--- a/Sources/BasicContainers/UniqueArray/UniqueArray.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray.swift
@@ -254,9 +254,8 @@ extension UniqueArray where Element: ~Copyable {
   /// buffer of the specified capacity, moving all existing elements
   /// to its new storage. The old storage is then deallocated.
   ///
-  /// - Parameter newCapacity: The desired new capacity. `newCapacity` must be
-/// - Parameter newCapacity: The desired new capacity. The new capacity
-///    is set to the maximum of `newCapacity` and the current count.
+  /// - Parameter newCapacity: The desired new capacity. The new capacity
+  ///    is set to the maximum of `newCapacity` and the current count.
   ///
   /// - Complexity: O(`count`)
   @inlinable

--- a/Sources/BasicContainers/UniqueArray/UniqueArray.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray.swift
@@ -259,8 +259,8 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`count`)
   @inlinable
-  public mutating func reallocate(capacity: Int) {
-    _storage.reallocate(capacity: capacity)
+  public mutating func setCapacity(_ newCapacity: Int) {
+    _storage.setCapacity(newCapacity)
   }
 
   /// Ensure that the array has capacity to store the specified number of

--- a/Sources/BasicContainers/UniqueArray/UniqueArray.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray.swift
@@ -294,7 +294,7 @@ extension UniqueArray where Element: ~Copyable {
   @inlinable
   internal mutating func _ensureFreeCapacitySlow(_ freeCapacity: Int) {
     let newCapacity = _grow(freeCapacity: freeCapacity)
-    reallocate(capacity: newCapacity)
+    setCapacity(newCapacity)
   }
 }
 

--- a/Sources/BasicContainers/UniqueArray/UniqueArray.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray.swift
@@ -255,7 +255,8 @@ extension UniqueArray where Element: ~Copyable {
   /// to its new storage. The old storage is then deallocated.
   ///
   /// - Parameter newCapacity: The desired new capacity. `newCapacity` must be
-  ///    greater than or equal to the current count.
+/// - Parameter newCapacity: The desired new capacity. The new capacity
+///    is set to the maximum of `newCapacity` and the current count.
   ///
   /// - Complexity: O(`count`)
   @inlinable

--- a/Tests/BasicContainersTests/RigidArrayTests.swift
+++ b/Tests/BasicContainersTests/RigidArrayTests.swift
@@ -491,6 +491,7 @@ class RigidArrayTests: CollectionTestCase {
     }
   }
 
+  @available(*, deprecated)
   func test_reallocate() {
     withSomeArrayLayouts("layout", ofCapacities: [0, 10, 100]) { layout in
       withEvery(

--- a/Tests/BasicContainersTests/RigidArrayTests.swift
+++ b/Tests/BasicContainersTests/RigidArrayTests.swift
@@ -535,7 +535,7 @@ class RigidArrayTests: CollectionTestCase {
           expectEqual(a.count, layout.count)
           expectEqual(a.capacity, Swift.max(newCapacity, layout.count))
           expectEqual(tracker.instances, layout.count)
-          expectIterableContents(
+          expectRigidArrayContents(
             a,
             equivalentTo: 0 ..< layout.count,
             by: { $0.payload == $1 },

--- a/Tests/BasicContainersTests/RigidArrayTests.swift
+++ b/Tests/BasicContainersTests/RigidArrayTests.swift
@@ -517,6 +517,33 @@ class RigidArrayTests: CollectionTestCase {
     }
   }
 
+  func test_setCapacity() {
+    withSomeArrayLayouts("layout", ofCapacities: [0, 10, 100]) { layout in
+      withEvery(
+        "newCapacity",
+        in: [
+          layout.capacity, layout.count, layout.count + 1, layout.capacity + 1,
+          0, layout.count - 1
+        ] as Set<Int>
+      ) { newCapacity in
+        withLifetimeTracking { tracker in
+          var a = tracker.rigidArray(layout: layout)
+          expectEqual(a.count, layout.count)
+          expectEqual(a.capacity, layout.capacity)
+          a.setCapacity(newCapacity)
+          expectEqual(a.count, layout.count)
+          expectEqual(a.capacity, Swift.max(newCapacity, layout.count))
+          expectEqual(tracker.instances, layout.count)
+          expectIterableContents(
+            a,
+            equivalentTo: 0 ..< layout.count,
+            by: { $0.payload == $1 },
+            printer: { "\($0.payload)" })
+        }
+      }
+    }
+  }
+
   func test_reserveCapacity() {
     withSomeArrayLayouts("layout", ofCapacities: [0, 10, 100]) { layout in
       withEvery(

--- a/Tests/BasicContainersTests/UniqueArrayTests.swift
+++ b/Tests/BasicContainersTests/UniqueArrayTests.swift
@@ -439,6 +439,7 @@ class UniqueArrayTests: CollectionTestCase {
     }
   }
 
+  @available(*, deprecated)
   func test_reallocate() {
     withSomeArrayLayouts("layout", ofCapacities: [0, 10, 100]) { layout in
       withEvery(

--- a/Tests/BasicContainersTests/UniqueArrayTests.swift
+++ b/Tests/BasicContainersTests/UniqueArrayTests.swift
@@ -465,6 +465,33 @@ class UniqueArrayTests: CollectionTestCase {
     }
   }
 
+  func test_setCapacity() {
+    withSomeArrayLayouts("layout", ofCapacities: [0, 10, 100]) { layout in
+      withEvery(
+        "newCapacity",
+        in: [
+          layout.capacity, layout.count, layout.count + 1, layout.capacity + 1,
+          0, layout.count - 1
+        ] as Set<Int>
+      ) { newCapacity in
+        withLifetimeTracking { tracker in
+          var a = tracker.uniqueArray(layout: layout)
+          expectEqual(a.count, layout.count)
+          expectEqual(a.capacity, layout.capacity)
+          a.setCapacity(newCapacity)
+          expectEqual(a.count, layout.count)
+          expectEqual(a.capacity, Swift.max(newCapacity, layout.count))
+          expectEqual(tracker.instances, layout.count)
+          expectIterableContents(
+            a,
+            equivalentTo: 0 ..< layout.count,
+            by: { $0.payload == $1 },
+            printer: { "\($0.payload)" })
+        }
+      }
+    }
+  }
+
   func test_reserveCapacity() {
     withSomeArrayLayouts("layout", ofCapacities: [0, 10, 100]) { layout in
       withEvery(

--- a/Tests/BasicContainersTests/UniqueArrayTests.swift
+++ b/Tests/BasicContainersTests/UniqueArrayTests.swift
@@ -483,7 +483,7 @@ class UniqueArrayTests: CollectionTestCase {
           expectEqual(a.count, layout.count)
           expectEqual(a.capacity, Swift.max(newCapacity, layout.count))
           expectEqual(tracker.instances, layout.count)
-          expectIterableContents(
+          expectUniqueArrayContents(
             a,
             equivalentTo: 0 ..< layout.count,
             by: { $0.payload == $1 },


### PR DESCRIPTION
Based on the accepted name of this function in the recent standard library proposal, rename `reallocate` here to `setCapacity` as well deprecating the old name.

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
