### PR TITLE
[OrderedCollections] Add OrderedSet.replace(_:at:)

### DIFF
--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
@@ -210,7 +210,7 @@ extension OrderedSet {
   /// takes over its position:
   ///
   ///     var set: OrderedSet = [1, 2, 3]
-  ///     let old = set.replace(4, at: 1)
+  ///     let old = set.replace(at: 1, with: 4)
   ///     // old == 2
   ///     // set is now [1, 4, 3]
   ///
@@ -218,12 +218,12 @@ extension OrderedSet {
   /// different index triggers a runtime error, as that would introduce a
   /// duplicate.
   ///
+  /// - Parameter index: The index of the member to replace. It must be a valid
+  ///     index below `endIndex`.
+  ///
   /// - Parameter item: The element to place at `index`. It must not already be
   ///     a member of the set, unless it compares equal to the member currently
   ///     at `index`.
-  ///
-  /// - Parameter index: The index of the member to replace. It must be a valid
-  ///     index below `endIndex`.
   ///
   /// - Returns: The original member that was replaced.
   ///
@@ -231,7 +231,7 @@ extension OrderedSet {
   ///     high-quality hashing.
   @inlinable
   @discardableResult
-  public mutating func replace(_ item: Element, at index: Int) -> Element {
+  public mutating func replace(at index: Int, with item: Element) -> Element {
     precondition(index >= 0 && index < count, "Index out of bounds")
     defer { _checkInvariants() }
     let (existing, bucket) = _find(item)

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
@@ -202,6 +202,57 @@ extension OrderedSet {
 }
 
 extension OrderedSet {
+  /// Replace the member at the given index with a new element.
+  ///
+  /// If `item` compares equal to the member currently at `index`, then it is
+  /// replaced in place, leaving the set's order unchanged (as in
+  /// `update(_:at:)`). Otherwise the original member is removed and `item`
+  /// takes over its position:
+  ///
+  ///     var set: OrderedSet = [1, 2, 3]
+  ///     let old = set.replace(4, at: 1)
+  ///     // old == 2
+  ///     // set is now [1, 4, 3]
+  ///
+  /// Replacing a member with an element that is already in the set at a
+  /// different index triggers a runtime error, as that would introduce a
+  /// duplicate.
+  ///
+  /// - Parameter item: The element to place at `index`. It must not already be
+  ///     a member of the set, unless it compares equal to the member currently
+  ///     at `index`.
+  ///
+  /// - Parameter index: The index of the member to replace. It must be a valid
+  ///     index below `endIndex`.
+  ///
+  /// - Returns: The original member that was replaced.
+  ///
+  /// - Complexity: Expected amortized O(1), if `Element` implements
+  ///     high-quality hashing.
+  @inlinable
+  @discardableResult
+  public mutating func replace(_ item: Element, at index: Int) -> Element {
+    precondition(index >= 0 && index < count, "Index out of bounds")
+    defer { _checkInvariants() }
+    let (existing, bucket) = _find(item)
+
+    // The new element compares equal to the one already at `index` — replace
+    // it in place. Its hash table bucket is unchanged, so no rehash is needed.
+    if existing == index {
+      return update(item, at: index)
+    }
+
+    precondition(existing == nil, "Duplicate element")
+
+    // Append the new element, swap it into the target position, and remove the
+    // old member from the end — each step is O(1).
+    _appendNew(item, in: bucket)
+    swapAt(index, count - 1)
+    return removeLast()
+  }
+}
+
+extension OrderedSet {
   /// Adds the given element to the set unconditionally, either appending it to
   /// the set, or replacing an existing value if it's already present.
   ///

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -565,6 +565,56 @@ class OrderedSetTests: CollectionTestCase {
     }
   }
 
+  func test_replace_at() {
+    withOrderedSetLayouts(scales: [0, 5, 6]) { layout in
+      withEvery("isShared", in: [false, true]) { isShared in
+        withLifetimeTracking { tracker in
+          let count = layout.count
+          let contents = (0 ..< count).map { tracker.instance(for: $0) }
+          withEvery("offset", in: 0 ..< count) { offset in
+            var set = OrderedSet(layout: layout, contents: contents)
+            withHiddenCopies(if: isShared, of: &set, checker: { $0._checkInvariants() }) { set in
+              let new = tracker.instance(for: count + offset) // Not yet a member.
+              let old = set.replace(new, at: offset)
+              expectIdentical(old, contents[offset])
+              expectIdentical(set[offset], new)
+              expectEqual(set.firstIndex(of: new), offset)
+              expectNil(set.firstIndex(of: contents[offset]))
+              // The other members keep their original positions and identities.
+              withEvery("j", in: 0 ..< count) { j in
+                if j != offset { expectIdentical(set[j], contents[j]) }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  func test_replace_at_equalElement() {
+    // Replacing a member with an equal element swaps the new instance into
+    // place, like `update(_:at:)`.
+    withOrderedSetLayouts(scales: [0, 5, 6]) { layout in
+      withEvery("isShared", in: [false, true]) { isShared in
+        withLifetimeTracking { tracker in
+          let count = layout.count
+          let contents = (0 ..< count).map { tracker.instance(for: $0) }
+          withEvery("offset", in: 0 ..< count) { offset in
+            var set = OrderedSet(layout: layout, contents: contents)
+            withHiddenCopies(if: isShared, of: &set, checker: { $0._checkInvariants() }) { set in
+              // Equal to `contents[offset]`, but a distinct instance.
+              let new = tracker.instance(for: offset)
+              let old = set.replace(new, at: offset)
+              expectIdentical(old, contents[offset])
+              expectIdentical(set[offset], new)
+              expectEqualElements(set, contents)
+            }
+          }
+        }
+      }
+    }
+  }
+
   func test_partition() {
     withOrderedSetLayouts(scales: [0, 5, 6]) { layout in
       withEvery("offset", in: 0 ... layout.count) { offset in

--- a/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedSet/OrderedSetTests.swift
@@ -575,7 +575,7 @@ class OrderedSetTests: CollectionTestCase {
             var set = OrderedSet(layout: layout, contents: contents)
             withHiddenCopies(if: isShared, of: &set, checker: { $0._checkInvariants() }) { set in
               let new = tracker.instance(for: count + offset) // Not yet a member.
-              let old = set.replace(new, at: offset)
+              let old = set.replace(at: offset, with: new)
               expectIdentical(old, contents[offset])
               expectIdentical(set[offset], new)
               expectEqual(set.firstIndex(of: new), offset)
@@ -604,7 +604,7 @@ class OrderedSetTests: CollectionTestCase {
             withHiddenCopies(if: isShared, of: &set, checker: { $0._checkInvariants() }) { set in
               // Equal to `contents[offset]`, but a distinct instance.
               let new = tracker.instance(for: offset)
-              let old = set.replace(new, at: offset)
+              let old = set.replace(at: offset, with: new)
               expectIdentical(old, contents[offset])
               expectIdentical(set[offset], new)
               expectEqualElements(set, contents)


### PR DESCRIPTION
## Summary

Add `replace(_:at:)` to `OrderedSet`, replacing the member at a given index with a new element in expected amortized O(1) time.

```swift
var set: OrderedSet = [1, 2, 3]
let old = set.replace(4, at: 1)
// old == 2
// set is now [1, 4, 3]
```

## Motivation

`OrderedSet` provides index-based mutations — `update(_:at:)`, `insert(_:at:)`, `swapAt(_:_:)`, `remove(at:)` — but there is no operation to replace the member at an index with a *different* element. `update(_:at:)` looks like it should, but it requires the replacement to compare *equal* to the existing member: it's meant for swapping in an equal-but-distinct instance (such as a canonical or freshly-fetched copy), and traps on anything else.

I ran into this gap while implementing `OrderedDictionary.replaceElement(at:withKey:value:)` (#616): replacing a key at a given index meant performing this very operation by hand on the dictionary's keys, which are an `OrderedSet` — append the new key, swap it into position, then remove the old one from the end (`_keys._appendNew`, `_keys.swapAt`, `_keys.removeLast`). The capability effectively already exists inside `OrderedDictionary`; it just isn't exposed as a first-class `OrderedSet` API. This PR adds it.

| Existing approach | Issue |
|---|---|
| `update(_:at:)` | Traps unless the new element compares equal to the current one |
| `remove(at:)` + `insert(_:at:)` | Correct, but O(`count`) due to element shifting |
| `append` + `swapAt` + `removeLast` | O(1), but a non-obvious dance with easy-to-omit duplicate and bounds checks |

`replace(_:at:)` fills this gap as a first-class O(1) operation, in the same spirit as `swapAt` exposing an index-based permutation primitive. (Conversely, `OrderedDictionary.replaceElement` could later be reimplemented on top of `replace(_:at:)`; that's left out here to keep this PR purely additive.)

## Detailed design

```swift
@discardableResult
public mutating func replace(_ item: Element, at index: Int) -> Element
```

- If `item` compares equal to the member at `index`, it is replaced in place via the existing `update(_:at:)`, leaving the hash table untouched.
- Otherwise the new element is appended, swapped into position, and the old member is removed from the end — each step O(1).
- Replacing a member with an element already present at a different index traps, as that would introduce a duplicate.
- Returns the replaced member; marked `@discardableResult`.
- Complexity: expected amortized O(1), if `Element` implements high-quality hashing.
- Purely additive: no existing API is changed, deprecated, or removed.

**Naming.** `OrderedSet` names its element operations without a target suffix — `append`, `insert`, `update`, `remove`, `swapAt` — because the member is the only thing to act on, mirroring the standard `Set`. (By contrast `OrderedDictionary` uses suffixes — `updateValue`, `replaceElement` — where the suffix distinguishes the value from the whole element.) So the operation is spelled `replace(_:at:)` here, reading as the general-element counterpart of `update(_:at:)`.

## Testing

Tests added in `OrderedSetTests.swift` (`test_replace_at` and `test_replace_at_equalElement`), covering:

- Every interesting hash-table `scale`/`bias` and size via `withOrderedSetLayouts` (including small sizes with no hash table), at every valid index
- Both unique and shared (copy-on-write) storage via `withHiddenCopies`
- Lifetime tracking to verify no memory leaks
- Both the different-element and the equal-element (in-place, like `update(_:at:)`) paths
- Return value correctness (the replaced member, by identity)
- That the new element is swapped into the target position, and the other members keep their original positions and identities
- Forward lookup (`firstIndex(of: new) == index`)
- Reverse lookup (`firstIndex(of: oldMember) == nil`)
- Internal invariants via `_checkInvariants()`

All `OrderedSetTests` pass with and without `-Xswiftc -DCOLLECTIONS_INTERNAL_CHECKS`.

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (to the extent possible).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexpected benchmark regressions.
- [x] I've updated the documentation (if appropriate).