### PR TITLE
Fix Collections reexports under MemberImportVisibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -361,7 +361,7 @@ let targets: [CustomTarget] = [
     kind: .test,
     name: "CollectionsModuleTests",
     dependencies: ["Collections", "_CollectionsTestSupport"],
-    settings: _baseSettings),
+    settings: _testSettings),
 ]
 
 let _products: [Product] = targets.compactMap { t in

--- a/Sources/Collections/BitCollections reexports.swift
+++ b/Sources/Collections/BitCollections reexports.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #if !COLLECTIONS_SINGLE_MODULE
-import BitCollections
+@_exported import BitCollections
 
 public typealias BitSet = BitCollections.BitSet
 public typealias BitArray = BitCollections.BitArray

--- a/Sources/Collections/DequeModule reexports.swift
+++ b/Sources/Collections/DequeModule reexports.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #if !COLLECTIONS_SINGLE_MODULE
-import DequeModule
+@_exported import DequeModule
 
 public typealias Deque<Element> = DequeModule.Deque<Element>
 #endif

--- a/Sources/Collections/HashTreeCollections reexports.swift
+++ b/Sources/Collections/HashTreeCollections reexports.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #if !COLLECTIONS_SINGLE_MODULE
-import HashTreeCollections
+@_exported import HashTreeCollections
 
 public typealias TreeSet<Element: Hashable> = HashTreeCollections.TreeSet<Element>
 public typealias TreeDictionary<Key: Hashable, Value> = HashTreeCollections.TreeDictionary<Key, Value>

--- a/Sources/Collections/HeapModule reexports.swift
+++ b/Sources/Collections/HeapModule reexports.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #if !COLLECTIONS_SINGLE_MODULE
-import HeapModule
+@_exported import HeapModule
 
 public typealias Heap<Element: Comparable> = HeapModule.Heap<Element>
 #endif

--- a/Sources/Collections/OrderedCollections reexports.swift
+++ b/Sources/Collections/OrderedCollections reexports.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #if !COLLECTIONS_SINGLE_MODULE
-import OrderedCollections
+@_exported import OrderedCollections
 
 public typealias OrderedSet<Element: Hashable> = OrderedCollections.OrderedSet<Element>
 public typealias OrderedDictionary<Key: Hashable, Value> = OrderedCollections.OrderedDictionary<Key, Value>

--- a/Tests/CollectionsModuleTests/CollectionsTests.swift
+++ b/Tests/CollectionsModuleTests/CollectionsTests.swift
@@ -62,4 +62,12 @@ class CollectionsTests: XCTestCase {
     items.prepend(42)
     XCTAssertEqual(items.first, 42)
   }
+
+  func testOrderedSetMemberImportVisibility() {
+    var values: OrderedSet<String> = []
+    let insert = values.append("hello")
+
+    XCTAssertEqual(insert.index, values.startIndex)
+    XCTAssertEqual(values[values.startIndex], "hello")
+  }
 }


### PR DESCRIPTION
## Summary

- re-export component modules from the aggregate Collections module
- run CollectionsModuleTests with the repo's upcoming feature settings
- add an OrderedSet member/import visibility regression

Fixes #663

## Testing

- `git diff --check`
- Attempted `swift test --filter CollectionsTests/testOrderedSetMemberImportVisibility`; local Swift 6.1.2 cannot parse the current package manifest because it uses newer manifest APIs
