### PR TITLE
Fix typos in doc comments and a DocC article

### DIFF
--- a/Sources/BitCollections/BitArray/BitArray+Descriptions.swift
+++ b/Sources/BitCollections/BitArray/BitArray+Descriptions.swift
@@ -31,7 +31,7 @@ extension BitArray: CustomStringConvertible {
   /// Bit arrays print themselves as a string of binary bits, with the
   /// highest-indexed elements appearing first, as in the binary representation
   /// of integers. The digits are surrounded by angle brackets, so that the
-  /// notation is non-ambigous even for empty bit arrays:
+  /// notation is non-ambiguous even for empty bit arrays:
   ///
   ///     let bits: BitArray = [false, false, false, true, true]
   ///     print(bits) // "<11000>"

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Initializers.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Initializers.swift
@@ -140,7 +140,7 @@ extension UniqueDeque /*where Element: Copyable*/ {
   ///
   /// - Parameters:
   ///   - capacity: The storage capacity of the new deque, or nil to let the
-  ///      deque grow itself as needed to accomodate all items in `contents`.
+  ///      deque grow itself as needed to accommodate all items in `contents`.
   ///   - contents: A sequence whose contents to copy into the new deque.
   @_alwaysEmitIntoClient
   @inline(__always)
@@ -159,7 +159,7 @@ extension UniqueDeque /*where Element: Copyable*/ {
   ///
   /// - Parameters:
   ///   - capacity: The storage capacity of the new deque, or nil to let the
-  ///      deque grow itself as needed to accomodate all items in `contents`.
+  ///      deque grow itself as needed to accommodate all items in `contents`.
   ///   - contents: The sequence whose contents to copy into the new deque.
   @_alwaysEmitIntoClient
   @inline(__always)
@@ -177,7 +177,7 @@ extension UniqueDeque /*where Element: Copyable*/ {
   ///
   /// - Parameters:
   ///   - capacity: The storage capacity of the new deque, or nil to let the
-  ///      deque grow itself as needed to accomodate all items in `contents`.
+  ///      deque grow itself as needed to accommodate all items in `contents`.
   ///   - contents: A sequence whose contents to copy into the new deque.
   ///      The sequence must not contain more than `capacity` elements.
   @_alwaysEmitIntoClient

--- a/Sources/TrailingElementsModule/TrailingArray.swift
+++ b/Sources/TrailingElementsModule/TrailingArray.swift
@@ -120,7 +120,7 @@ where Header: ~Copyable
   /// that memory. The underlying storage will not be freed by this buffer;
   /// it is the responsibility of the caller. The header pointer and
   /// underlying storage are returned separately, to handle cases where
-  /// the alignment of the elements is greater than than of the header.
+  /// the alignment of the elements is greater than that of the header.
   @_alwaysEmitIntoClient
   public consuming func leakStorage() -> (
     pointer: UnsafeMutablePointer<Header>,

--- a/Sources/TrailingElementsModule/TrailingElementsModule.docc/TrailingElementsModule.md
+++ b/Sources/TrailingElementsModule/TrailingElementsModule.docc/TrailingElementsModule.md
@@ -61,7 +61,7 @@ TrailingArray.withTemporaryValue(header: Coordinates(numPoints: 3), repeating: P
 ```
 
 ### Interoperability with unsafe C APIs
-``TrailingArray`` provides facilities for working with the underlying unsafe pointers, which can be useful when interoperating with C APIs. ``TrailingArray`` can take ownership of a heap-allocated pointer to its `Header` type (such as one might get back from a C API api) using `init(consuming:)`:
+``TrailingArray`` provides facilities for working with the underlying unsafe pointers, which can be useful when interoperating with C APIs. ``TrailingArray`` can take ownership of a heap-allocated pointer to its `Header` type (such as one might get back from a C API) using `init(consuming:)`:
 
 ```swift
 init(consuming pointer: UnsafeMutablePointer<Header>)


### PR DESCRIPTION
Small documentation-only fixes in doc comments and one DocC article:

- TrailingArray: fix duplicated wording in the capacity comparison.
- TrailingElementsModule.docc: remove duplicated 'api' after 'C API'.
- UniqueDeque+Initializers: fix 'accomodate' -> 'accommodate' in three doc comments.
- BitArray+Descriptions: fix 'non-ambigous' -> 'non-ambiguous'.

No API or behavior changes.