### PR TITLE
Fix superset set algebra doc comments

### DIFF
--- a/Sources/BitCollections/BitSet/BitSet+SetAlgebra isStrictSuperset.swift
+++ b/Sources/BitCollections/BitSet/BitSet+SetAlgebra isStrictSuperset.swift
@@ -32,7 +32,8 @@ extension BitSet {
   ///
   /// - Parameter other: Another bit set.
   ///
-  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a strict superset of `other`;
+  ///     otherwise, `false`.
   ///
   /// - Complexity: O(*max*), where *max* is the largest item in `other`.
   public func isStrictSuperset(of other: BitSet) -> Bool {
@@ -48,26 +49,29 @@ extension BitSet {
   ///
   /// - Parameter other: A counted bit set.
   ///
-  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a strict superset of `other`;
+  ///     otherwise, `false`.
   ///
   /// - Complexity: O(*max*), where *max* is the largest item in `other`.
   public func isStrictSuperset(of other: BitSet.Counted) -> Bool {
     other._bits.isStrictSubset(of: self)
   }
 
-  /// Returns a Boolean value that indicates whether this set is a superset of
-  /// a given range of integers.
+  /// Returns a Boolean value that indicates whether this set is a strict
+  /// superset of a given range of integers.
   ///
-  /// Set *A* is a superset of another set *B* if every member of *B* is also a
-  /// member of *A*.
+  /// Set *A* is a strict superset of another set *B* if every member of *B* is
+  /// also a member of *A* and *A* contains at least one element that is *not*
+  /// a member of *B*.
   ///
   ///     let a: BitSet = [0, 1, 2, 3, 4, 10]
-  ///     a.isSuperset(of: 0 ..< 4) // true
-  ///     a.isSuperset(of: -10 ..< 4) // false
+  ///     a.isStrictSuperset(of: 0 ..< 4) // true
+  ///     a.isStrictSuperset(of: -10 ..< 4) // false
   ///
   /// - Parameter other: An arbitrary range of integers.
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a strict superset of `other`;
+  ///     otherwise, `false`.
   ///
   /// - Complexity: O(`range.count`)
   public func isStrictSuperset(of other: Range<Int>) -> Bool {
@@ -81,22 +85,24 @@ extension BitSet {
     return _read { $0.isSuperset(of: r) }
   }
 
-  /// Returns a Boolean value that indicates whether this set is a superset of
-  /// the values in a given sequence of integers.
+  /// Returns a Boolean value that indicates whether this set is a strict
+  /// superset of the values in a given sequence of integers.
   ///
-  /// Set *A* is a superset of another set *B* if every member of *B* is also a
-  /// member of *A*.
+  /// Set *A* is a strict superset of another set *B* if every member of *B* is
+  /// also a member of *A* and *A* contains at least one element that is *not*
+  /// a member of *B*.
   ///
   ///     let a = [1, 2, 3]
   ///     let b: BitSet = [0, 1, 2, 3, 4]
   ///     let c: BitSet = [0, 1, 2]
-  ///     b.isSuperset(of: a) // true
-  ///     c.isSuperset(of: a) // false
+  ///     b.isStrictSuperset(of: a) // true
+  ///     c.isStrictSuperset(of: a) // false
   ///
   /// - Parameter other: A sequence of arbitrary integers, some of whose members
   ///    may appear more than once. (Duplicate items are ignored.)
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a strict superset of `other`;
+  ///     otherwise, `false`.
   ///
   /// - Complexity: O(*max*) + *k*, where *max* is the largest item in `other`,
   ///    and *k* is the complexity of iterating over all elements in `other`.

--- a/Sources/BitCollections/BitSet/BitSet+SetAlgebra isSuperset.swift
+++ b/Sources/BitCollections/BitSet/BitSet+SetAlgebra isSuperset.swift
@@ -65,7 +65,7 @@ extension BitSet {
   ///
   /// - Parameter other: An arbitrary range of integers.
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
   ///
   /// - Complexity: O(`range.count`)
   public func isSuperset(of other: Range<Int>) -> Bool {
@@ -89,7 +89,7 @@ extension BitSet {
   /// - Parameter other: A sequence of arbitrary integers, some of whose members
   ///    may appear more than once. (Duplicate items are ignored.)
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
   ///
   /// - Complexity: The same as the complexity of iterating over all elements
   ///    in `other`.

--- a/Sources/BitCollections/BitSet/BitSet.Counted.swift
+++ b/Sources/BitCollections/BitSet/BitSet.Counted.swift
@@ -1076,7 +1076,7 @@ extension BitSet.Counted {
   ///
   /// - Parameter other: An arbitrary range of integers.
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
   ///
   /// - Complexity: O(`range.count`)
   public func isSuperset(of other: Range<Int>) -> Bool {
@@ -1098,7 +1098,7 @@ extension BitSet.Counted {
   /// - Parameter other: A sequence of arbitrary integers, some of whose members
   ///    may appear more than once. (Duplicate items are ignored.)
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
   ///
   /// - Complexity: The same as the complexity of iterating over all elements
   ///    in `other`.
@@ -1217,7 +1217,8 @@ extension BitSet.Counted {
   ///
   /// - Parameter other: Another bit set.
   ///
-  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a strict superset of `other`;
+  ///     otherwise, `false`.
   ///
   /// - Complexity: O(*max*), where *max* is the largest item in `other`.
   public func isStrictSuperset(of other: BitSet.Counted) -> Bool {
@@ -1233,48 +1234,53 @@ extension BitSet.Counted {
   ///
   /// - Parameter other: Another bit set.
   ///
-  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a strict superset of `other`;
+  ///     otherwise, `false`.
   ///
   /// - Complexity: O(*max*), where *max* is the largest item in `other`.
   public func isStrictSuperset(of other: BitSet) -> Bool {
     other.isStrictSubset(of: self)
   }
 
-  /// Returns a Boolean value that indicates whether this set is a superset of
-  /// a given range of integers.
+  /// Returns a Boolean value that indicates whether this set is a strict
+  /// superset of a given range of integers.
   ///
-  /// Set *A* is a superset of another set *B* if every member of *B* is also a
-  /// member of *A*.
+  /// Set *A* is a strict superset of another set *B* if every member of *B* is
+  /// also a member of *A* and *A* contains at least one element that is *not*
+  /// a member of *B*.
   ///
   ///     let a: BitSet.Counted = [0, 1, 2, 3, 4, 10]
-  ///     a.isSuperset(of: 0 ..< 4) // true
-  ///     a.isSuperset(of: -10 ..< 4) // false
+  ///     a.isStrictSuperset(of: 0 ..< 4) // true
+  ///     a.isStrictSuperset(of: -10 ..< 4) // false
   ///
   /// - Parameter other: An arbitrary range of integers.
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a strict superset of `other`;
+  ///     otherwise, `false`.
   ///
   /// - Complexity: O(`range.count`)
   public func isStrictSuperset(of other: Range<Int>) -> Bool {
     _bits.isStrictSuperset(of: other)
   }
 
-  /// Returns a Boolean value that indicates whether this set is a superset of
-  /// the values in a given sequence of integers.
+  /// Returns a Boolean value that indicates whether this set is a strict
+  /// superset of the values in a given sequence of integers.
   ///
-  /// Set *A* is a superset of another set *B* if every member of *B* is also a
-  /// member of *A*.
+  /// Set *A* is a strict superset of another set *B* if every member of *B* is
+  /// also a member of *A* and *A* contains at least one element that is *not*
+  /// a member of *B*.
   ///
   ///     let a = [1, 2, 3]
   ///     let b: BitSet.Counted = [0, 1, 2, 3, 4]
   ///     let c: BitSet.Counted = [0, 1, 2]
-  ///     b.isSuperset(of: a) // true
-  ///     c.isSuperset(of: a) // false
+  ///     b.isStrictSuperset(of: a) // true
+  ///     c.isStrictSuperset(of: a) // false
   ///
   /// - Parameter other: A sequence of arbitrary integers, some of whose members
   ///    may appear more than once. (Duplicate items are ignored.)
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a strict superset of `other`;
+  ///     otherwise, `false`.
   ///
   /// - Complexity: O(*max*) + *k*, where *max* is the largest item in `other`,
   ///    and *k* is the complexity of iterating over all elements in `other`.

--- a/Sources/HashTreeCollections/TreeSet/TreeSet+SetAlgebra isStrictSuperset.swift
+++ b/Sources/HashTreeCollections/TreeSet/TreeSet+SetAlgebra isStrictSuperset.swift
@@ -25,7 +25,7 @@ extension TreeSet {
   ///
   ///     let a: TreeSet = [1, 2, 3, 4]
   ///     let b: TreeSet = [4, 2, 1]
-  ///     a.isStrictSuperset(of: b.unordered) // true
+  ///     a.isStrictSuperset(of: b) // true
   ///
   /// - Parameter other: Another set.
   ///
@@ -45,17 +45,17 @@ extension TreeSet {
   /// Returns a Boolean value that indicates whether the set is a strict
   /// superset of the given set.
   ///
-  /// Set *A* is a strict subset of another set *B* if every member of *A* is
-  /// also a member of *B* and *B* contains at least one element that is not a
-  /// member of *A*. (Ignoring the order the elements appear in the sets.)
+  /// Set *A* is a strict superset of another set *B* if every member of *B* is
+  /// also a member of *A* and *A* contains at least one element that is not a
+  /// member of *B*. (Ignoring the order the elements appear in the sets.)
   ///
   ///     let a: TreeSet = [1, 2, 3, 4]
-  ///     let b: TreeSet = [4, 2, 1]
-  ///     a.isStrictSuperset(of: b.unordered) // true
+  ///     let b: TreeDictionary = [4: "four", 2: "two", 1: "one"]
+  ///     a.isStrictSuperset(of: b.keys) // true
   ///
   /// - Parameter other: The keys view of a persistent dictionary.
   ///
-  /// - Returns: `true` if `self` is a strict subset of `other`; otherwise,
+  /// - Returns: `true` if `self` is a strict superset of `other`; otherwise,
   ///    `false`.
   ///
   /// - Complexity: Expected to be O(`other.count`) on average, if `Element`
@@ -73,18 +73,18 @@ extension TreeSet {
   /// Returns a Boolean value that indicates whether the set is a strict
   /// superset of the given set.
   ///
-  /// Set *A* is a strict subset of another set *B* if every member of *A* is
-  /// also a member of *B* and *B* contains at least one element that is not a
-  /// member of *A*. (Ignoring the order the elements appear in the sets.)
+  /// Set *A* is a strict superset of another set *B* if every member of *B* is
+  /// also a member of *A* and *A* contains at least one element that is not a
+  /// member of *B*. (Ignoring the order the elements appear in the sets.)
   ///
   ///     let a: TreeSet = [1, 2, 3, 4]
   ///     let b: TreeSet = [4, 2, 1]
-  ///     a.isStrictSuperset(of: b.unordered) // true
+  ///     a.isStrictSuperset(of: b) // true
   ///
   /// - Parameter other: A sequence of elements, some of whose elements may
   ///    appear more than once. (Duplicate items are ignored.)
   ///
-  /// - Returns: `true` if `self` is a strict subset of `other`; otherwise,
+  /// - Returns: `true` if `self` is a strict superset of `other`; otherwise,
   ///    `false`.
   ///
   /// - Complexity: In the worst case, this makes O(*n*) calls to

--- a/Sources/HashTreeCollections/TreeSet/TreeSet+SetAlgebra isSuperset.swift
+++ b/Sources/HashTreeCollections/TreeSet/TreeSet+SetAlgebra isSuperset.swift
@@ -28,7 +28,7 @@ extension TreeSet {
   ///
   /// - Parameter other: Another set.
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
   ///
   /// - Complexity: Expected to be O(`other.count`) on average, if `Element`
   ///    implements high-quality hashing. The implementation is careful to make
@@ -51,7 +51,7 @@ extension TreeSet {
   ///
   /// - Parameter other: The keys view of a persistent dictionary.
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
   ///
   /// - Complexity: Expected to be O(`other.count`) on average, if `Element`
   ///    implements high-quality hashing. The implementation is careful to make
@@ -77,7 +77,7 @@ extension TreeSet {
   /// - Parameter other: A sequence of elements, some of whose elements may
   ///    appear more than once. (Duplicate items are ignored.)
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
   ///
   /// - Complexity: O(*n*) calls to `self.contains`, where *n* is the number
   ///    of elements in `other`.

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+UnorderedView.swift
@@ -748,7 +748,7 @@ extension OrderedSet.UnorderedView {
   ///
   /// - Parameter other: Another set.
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
   ///
   /// - Complexity: Expected to be O(`other.count`) on average, if `Element`
   ///    implements high-quality hashing.
@@ -771,7 +771,7 @@ extension OrderedSet.UnorderedView {
   ///
   /// - Parameter other: Another set.
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
   ///
   /// - Complexity: Expected to be O(`other.count`) on average, if `Element`
   ///    implements high-quality hashing.
@@ -792,7 +792,7 @@ extension OrderedSet.UnorderedView {
   ///
   /// - Parameter other: A finite sequence of elements.
   ///
-  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
+  /// - Returns: `true` if the set is a superset of `other`; otherwise, `false`.
   ///
   /// - Complexity: Expected to be O(*n*) on average, where *n* is the number of
   ///    elements in `other`, if `Element` implements high-quality hashing.


### PR DESCRIPTION
Fixes documentation comments for set-algebra superset APIs where several overloads described the result as a subset check, or used examples that did not match the overload.

This updates BitSet, BitSet.Counted, TreeSet, and OrderedSet.UnorderedView comments so isSuperset and isStrictSuperset descriptions/examples match the implemented API semantics.

Documentation only; no behavior changes.