### PR TITLE
Fix @inlinable deinit incompatibility with library evolution (HashTree/Sorted storage)

### DIFF
--- a/Sources/HashTreeCollections/HashNode/_HashNode+Storage.swift
+++ b/Sources/HashTreeCollections/HashNode/_HashNode+Storage.swift
@@ -37,6 +37,7 @@ extension _HashNode {
   /// Instances of this class hold (tail-allocated) storage for individual
   /// nodes in a hash tree.
   @usableFromInline
+  @_fixed_layout // Not really! This module isn't ABI stable.
   internal final class Storage: _RawHashStorage {
     @usableFromInline
     internal typealias Element = (key: Key, value: Value)

--- a/Sources/SortedCollections/BTree/_Node.Storage.swift
+++ b/Sources/SortedCollections/BTree/_Node.Storage.swift
@@ -117,7 +117,8 @@ extension _Node {
   /// does not exist, ``_Node.dummyValue`` can be used to obtain a valid value within the type system
   /// that can be passed to APIs.
   @usableFromInline
-  internal class Storage: ManagedBuffer<_Node.Header, Key> {    
+  @_fixed_layout // Not really! This module isn't ABI stable.
+  internal class Storage: ManagedBuffer<_Node.Header, Key> {
     /// Allows **read-only** access to the underlying data behind the node.
     ///
     /// - Parameter body: A closure with a handle which allows interacting with the node


### PR DESCRIPTION
### Problem

Building a package that depends on swift-collections with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES` (library evolution) fails on Xcode 26 / Swift 6.2+:

```
_HashNode+Storage.swift:47:5: error: deinitializer can only be '@inlinable' if the class is '@_fixed_layout'
```

The `Storage` class in HashTreeCollections marks its `deinit` as `@inlinable` but lacks `@_fixed_layout`. Inlining a `deinit` requires a known layout, which library evolution deliberately hides — so the two are mutually exclusive and the build is rejected. This blocks SDK vendors distributing binary XCFrameworks from using 1.4.0+.

### Fix

Add `@_fixed_layout` to the affected internal storage classes, mirroring what is **already done** for the equivalent `ManagedBuffer` storage classes in `DequeModule` (`_DequeBuffer`) and `RopeModule` (`Rope._Storage`). As the comment on `Rope._Storage` states, this does **not** make anything ABI stable — these classes are `@usableFromInline internal` and never part of the public ABI surface. It only allows the modules to build with library evolution enabled.

The same latent issue exists in **SortedCollections** (`_Node.Storage`), which has the identical `@inlinable deinit` without `@_fixed_layout`. A vendor enabling library evolution package-wide hits HashTreeCollections first and SortedCollections immediately after, so both are fixed here. (Happy to split into a separate PR if preferred.)

### Verification

Reproduced the diagnostic with a minimal case at the exact visibility of both classes (`@usableFromInline` class + `@inlinable deinit` + `-enable-library-evolution`) — the error fires before the change and compiles cleanly after. Both modules continue to build normally.

Fixes #676.

### Checklist
- [x] I've read the Contribution Guidelines
- [x] My contributions are licensed under the Swift license.
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths (this is a build-mode constraint with no runtime behavior to test; CI does not currently exercise library-evolution mode).
- [ ] I've added benchmarks (n/a).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary (n/a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)