### PR TITLE
[OrderedCollections] Share OrderedSet's replace primitive with OrderedDictionary.replaceElement

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Elements.swift
@@ -408,8 +408,9 @@ extension OrderedDictionary.Elements {
   ///     dict.elements.replaceElement(at: 1, withKey: "é", value: 2)
   ///     // dict is now ["a": 1, "é": 2, "c": 3]
   ///
-  /// In the general case, the new pair is appended, swapped into position,
-  /// and the old element is removed from the end — each step is O(1).
+  /// In the general case, the new key is appended, swapped into position, and
+  /// the old key removed from the end, while the value is overwritten in
+  /// place — each step is O(1).
   /// When the new key compares equal to the one being replaced, the pair
   /// is updated in place and the hash table is left untouched.
   ///

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift
@@ -44,8 +44,9 @@ extension OrderedDictionary {
   ///     dict.replaceElement(at: 1, withKey: "é", value: 2)
   ///     // dict is now ["a": 1, "é": 2, "c": 3]
   ///
-  /// In the general case, the new pair is appended, swapped into position,
-  /// and the old element is removed from the end — each step is O(1).
+  /// In the general case, the new key is appended, swapped into position, and
+  /// the old key removed from the end, while the value is overwritten in
+  /// place — each step is O(1).
   /// When the new key compares equal to the one being replaced, the pair
   /// is updated in place and the hash table is left untouched.
   ///
@@ -90,17 +91,11 @@ extension OrderedDictionary {
 
     precondition(existingIndex == nil, "Duplicate key: '\(key)'")
 
-    // Append the new key-value pair at the end — amortized O(1)
-    _keys._appendNew(key, in: bucket)
-    _values.append(value)
-
-    // Swap the new element into the target position — O(1)
-    _keys.swapAt(index, count - 1)
-    _values.swapAt(index, count - 1)
-
-    // Remove the old element from the end — O(1)
-    let oldKey = _keys.removeLast()
-    let oldValue = _values.removeLast()
+    // Replace the key through OrderedSet's shared primitive, then overwrite the
+    // value at `index` — each step is O(1).
+    let oldKey = _keys._replaceNew(at: index, with: key, in: bucket)
+    let oldValue = _values[index]
+    _values[index] = value
 
     _checkInvariants()
     return (oldKey, oldValue)

--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift
@@ -94,8 +94,7 @@ extension OrderedDictionary {
     // Replace the key through OrderedSet's shared primitive, then overwrite the
     // value at `index` — each step is O(1).
     let oldKey = _keys._replaceNew(at: index, with: key, in: bucket)
-    let oldValue = _values[index]
-    _values[index] = value
+    let oldValue = exchange(&_values[index], with: value)
 
     _checkInvariants()
     return (oldKey, oldValue)

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Insertions.swift
@@ -202,6 +202,25 @@ extension OrderedSet {
 }
 
 extension OrderedSet {
+  /// Replace the member at `index` with `item`, a new element that is not yet a
+  /// member of the set, registering it in the given hash table `bucket` (as
+  /// returned by `_find`) without verifying that it isn't present elsewhere.
+  /// The member currently at `index` is removed and returned.
+  ///
+  /// Appends the new element, swaps it into `index`, then removes the old
+  /// member from the end — each step is O(1).
+  ///
+  /// - Complexity: Amortized O(1)
+  @inlinable
+  @discardableResult
+  internal mutating func _replaceNew(
+    at index: Int, with item: Element, in bucket: _Bucket
+  ) -> Element {
+    _appendNew(item, in: bucket)
+    swapAt(index, count - 1)
+    return removeLast()
+  }
+
   /// Replace the member at the given index with a new element.
   ///
   /// If `item` compares equal to the member currently at `index`, then it is
@@ -243,12 +262,7 @@ extension OrderedSet {
     }
 
     precondition(existing == nil, "Duplicate element")
-
-    // Append the new element, swap it into the target position, and remove the
-    // old member from the end — each step is O(1).
-    _appendNew(item, in: bucket)
-    swapAt(index, count - 1)
-    return removeLast()
+    return _replaceNew(at: index, with: item, in: bucket)
   }
 }
 


### PR DESCRIPTION
## Summary

`OrderedDictionary.replaceElement(at:withKey:value:)` and `OrderedSet.replace(at:with:)` each performed the same "append the new member, swap it into position, then remove the old one from the end" step inline. This factors that step into an internal `OrderedSet._replaceNew(at:with:in:)` primitive shared by both. Behavior-preserving cleanup; no public API change.

## Motivation

This is the follow-up flagged in #669. Adding `OrderedSet.replace(at:with:)` there, I noted that `OrderedDictionary.replaceElement` (added in #616) already performed this very operation by hand on its keys — `_keys._appendNew`, `_keys.swapAt`, `_keys.removeLast` — and could be reimplemented on top of `replace`. #669 left that out to keep it purely additive; this is that cleanup.

Rather than having `replaceElement` call `replace(at:with:)` directly, it shares only the *mechanical* step through an internal primitive. Calling `replace` directly is simpler, but it would route the dictionary's key mutation through `OrderedSet`'s checks and replace the dictionary's own diagnostics:

| | Direct `replace` call | Shared `_replaceNew` primitive (this PR) |
|---|---|---|
| Duplicate key | traps with `Duplicate element` | keeps `Duplicate key: '\(key)'` |
| Out-of-range index | traps with `Index out of bounds` | keeps `Index out of range` |
| Hash lookup | re-runs `_find` inside `replace` | reuses the `bucket` the caller already resolved |

The primitive mirrors the existing `_appendNew` / `_removeExistingMember` internal primitives that `OrderedDictionary` already delegates its key-side mutations to.

## Detailed design

Adds an internal `OrderedSet._replaceNew(at:with:in:)`:

```swift
@inlinable
@discardableResult
internal mutating func _replaceNew(
  at index: Int, with item: Element, in bucket: _Bucket
) -> Element
```

- Takes the target `bucket` already resolved by the caller's `_find`, appends `item`, swaps it into `index`, then removes the old member from the end — each step O(1). It performs no duplicate/bounds checks; the caller is responsible for those, matching `_appendNew(_:in:)` and `_removeExistingMember(at:in:)`.
- `OrderedSet.replace(at:with:)` now calls it after its own `_find` + precondition, instead of inlining the append/swap/remove.
- `OrderedDictionary.replaceElement`'s general case routes the *key* through `_keys._replaceNew` and overwrites the *value* at `index` in place — rather than moving the value through the same append/swap/remove step. Its equal-key in-place path and its own preconditions (`Index out of range`, `Duplicate key: '\(key)'`) are unchanged.
- No public API is added, changed, or removed; behavior and complexity (amortized O(1)) are unchanged.

## Testing

Behavior-preserving refactor, so no new tests are added. The existing `OrderedCollectionsTests` suite passes, and the affected `replace(at:with:)` / `replaceElement` tests — which exercise every index across small element counts with both shared and unshared storage — pass with and without `-Xswiftc -DCOLLECTIONS_INTERNAL_CHECKS`.

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.