### PR TITLE
Fix stale paths in internals documentation

### DIFF
--- a/Documentation/Internals/README.md
+++ b/Documentation/Internals/README.md
@@ -2,7 +2,7 @@
 
 ## Benchmarks
 
-The package includes an extensive library of benchmarks in the [Benchmarks](./Benchmarks) directory, driven by a command-line executable target, called `benchmark`. These benchmarks, the executable target, and its command-line interface are not considered part of the public interface of the package. As such, new releases may break them without any special ceremony. We do expect the benchmarks will stabilize with time.
+The package includes an extensive library of benchmarks in the [Benchmarks](../../Benchmarks) directory, driven by a command-line executable target, called `benchmark`. These benchmarks, the executable target, and its command-line interface are not considered part of the public interface of the package. As such, new releases may break them without any special ceremony. We do expect the benchmarks will stabilize with time.
 
 For more information on our benchmarking tool, please see its dedicated package, [**Swift Collections Benchmark**][swift-collections-benchmark].
 
@@ -10,13 +10,13 @@ For more information on our benchmarking tool, please see its dedicated package,
 
 ## Test Support Library
 
-The package comes with a rich test support library in the [Sources/_CollectionsTestSupport](../../Sources/_CollectionsTestSupport) directory. These were loosely adapted from the contents of the `StdlibUnittest*` modules in the [Swift compiler repository](https://github.com/apple/swift/tree/main/stdlib/private), with some custom additions.
+The package comes with a rich test support library in the [Tests/_CollectionsTestSupport](../../Tests/_CollectionsTestSupport) directory. These were loosely adapted from the contents of the `StdlibUnittest*` modules in the [Swift compiler repository](https://github.com/apple/swift/tree/main/stdlib/private), with some custom additions.
 
 These components would likely be of interest to the wider Swift community, but they aren't yet stable enough (or documented enough) to publish them. Accordingly, these testing helpers are currently considered implementation details of this package, and are subject to change at whim.
 
 The test support library currently provides the following functionality:
 
-- [`AssertionContexts`](../../Sources/_CollectionsTestSupport/AssertionContexts): Custom test assertions with support for keeping track of nested context information, including stopping execution when the current context matches a particular value. (Useful for debugging combinatorial tests.)
+- [`AssertionContexts`](../../Tests/_CollectionsTestSupport/AssertionContexts): Custom test assertions with support for keeping track of nested context information, including stopping execution when the current context matches a particular value. (Useful for debugging combinatorial tests.)
 
   <details>
    <summary><strong>Click here for a short demonstration</strong></summary>
@@ -62,7 +62,7 @@ The test support library currently provides the following functionality:
 
     </details>
 
-- [`Combinatorics`](../../Sources/_CollectionsTestSupport/AssertionContexts/Combinatorics.swift): Basic support for exhaustive combinatorial testing. This allows us to easily verify that a collection operation works correctly on all possible instances up to a certain size, including behavioral variations such as unique/shared storage. This file also contains a basic set of functions for executing the same test code for all subsets or all permutations of a given collection, with each iteration registered in the current test context, for easy reproduction of failed cases.
+- [`Combinatorics`](../../Tests/_CollectionsTestSupport/AssertionContexts/Combinatorics.swift): Basic support for exhaustive combinatorial testing. This allows us to easily verify that a collection operation works correctly on all possible instances up to a certain size, including behavioral variations such as unique/shared storage. This file also contains a basic set of functions for executing the same test code for all subsets or all permutations of a given collection, with each iteration registered in the current test context, for easy reproduction of failed cases.
 
   <details>
    <summary><strong>Click here for an example</strong></summary>
@@ -87,32 +87,32 @@ The test support library currently provides the following functionality:
     
   </details>
   
-- [`ConformanceCheckers`](../../Sources/_CollectionsTestSupport/ConformanceCheckers): A set of generic, semi-automated protocol conformance tests for some Standard Library protocols. These can be used to easily validate the custom protocol conformances provided by this package. These checks aren't (can't be) complete -- but when used correctly, they are able to detect most accidental mistakes. 
+- [`ConformanceCheckers`](../../Tests/_CollectionsTestSupport/ConformanceCheckers): A set of generic, semi-automated protocol conformance tests for some Standard Library protocols. These can be used to easily validate the custom protocol conformances provided by this package. These checks aren't (can't be) complete -- but when used correctly, they are able to detect most accidental mistakes. 
 
     We currently have conformance checkers for the following protocols:
     
-    - [`Sequence`](../../Sources/_CollectionsTestSupport/ConformanceCheckers/CheckSequence.swift)
-    - [`Collection`](../../Sources/_CollectionsTestSupport/ConformanceCheckers/CheckCollection.swift)
-    - [`BidirectionalCollection`](../../Sources/_CollectionsTestSupport/ConformanceCheckers/CheckBidirectionalCollection.swift)
-    - [`Equatable`](../../Sources/_CollectionsTestSupport/ConformanceCheckers/CheckEquatable.swift)
-    - [`Hashable`](../../Sources/_CollectionsTestSupport/ConformanceCheckers/CheckHashable.swift)
-    - [`Comparable`](../../Sources/_CollectionsTestSupport/ConformanceCheckers/CheckComparable.swift)
+    - [`Sequence`](../../Tests/_CollectionsTestSupport/ConformanceCheckers/CheckSequence.swift)
+    - [`Collection`](../../Tests/_CollectionsTestSupport/ConformanceCheckers/CheckCollection.swift)
+    - [`BidirectionalCollection`](../../Tests/_CollectionsTestSupport/ConformanceCheckers/CheckBidirectionalCollection.swift)
+    - [`Equatable`](../../Tests/_CollectionsTestSupport/ConformanceCheckers/CheckEquatable.swift)
+    - [`Hashable`](../../Tests/_CollectionsTestSupport/ConformanceCheckers/CheckHashable.swift)
+    - [`Comparable`](../../Tests/_CollectionsTestSupport/ConformanceCheckers/CheckComparable.swift)
 
-- [`MinimalTypes`](../../Sources/_CollectionsTestSupport/MinimalTypes): Minimally conforming implementations for standard protocols. These types conform to various standard protocols by implementing the requirements in as narrow-minded way as possible -- sometimes going to extreme lengths to, say, implement collection index invalidation logic in the most unhelpful way possible.
+- [`MinimalTypes`](../../Tests/_CollectionsTestSupport/MinimalTypes): Minimally conforming implementations for standard protocols. These types conform to various standard protocols by implementing the requirements in as narrow-minded way as possible -- sometimes going to extreme lengths to, say, implement collection index invalidation logic in the most unhelpful way possible.
 
-    - [`MinimalSequence`](../../Sources/_CollectionsTestSupport/MinimalTypes/MinimalSequence.swift)
-    - [`MinimalCollection`](../../Sources/_CollectionsTestSupport/MinimalTypes/MinimalCollection.swift)
-    - [`MinimalBidirectionalCollection`](../../Sources/_CollectionsTestSupport/MinimalTypes/MinimalBidirectionalCollection.swift)
-    - [`MinimalRandomAccessCollection`](../../Sources/_CollectionsTestSupport/MinimalTypes/MinimalRandomAccessCollection.swift)
-    - [`MinimalMutableRandomAccessCollection`](../../Sources/_CollectionsTestSupport/MinimalTypes/MinimalMutableRandomAccessCollection.swift)
-    - [`MinimalRangeReplaceableRandomAccessCollection`](../../Sources/_CollectionsTestSupport/MinimalTypes/MinimalRangeReplaceableRandomAccessCollection.swift)
-    - [`MinimalMutableRangeReplaceableRandomAccessCollection`](../../Sources/_CollectionsTestSupport/MinimalTypes/MinimalMutableRangeReplaceableRandomAccessCollection.swift)
-    - [`MinimalIterator`](../../Sources/_CollectionsTestSupport/MinimalTypes/MinimalIterator.swift)
-    - [`MinimalIndex`](../../Sources/_CollectionsTestSupport/MinimalTypes/MinimalIndex.swift)
-    - [`MinimalEncoder`](../../Sources/_CollectionsTestSupport/MinimalTypes/MinimalEncoder.swift)
-    - [`MinimalDecoder`](../../Sources/_CollectionsTestSupport/MinimalTypes/MinimalDecoder.swift)
+    - [`MinimalSequence`](../../Tests/_CollectionsTestSupport/MinimalTypes/MinimalSequence.swift)
+    - [`MinimalCollection`](../../Tests/_CollectionsTestSupport/MinimalTypes/MinimalCollection.swift)
+    - [`MinimalBidirectionalCollection`](../../Tests/_CollectionsTestSupport/MinimalTypes/MinimalBidirectionalCollection.swift)
+    - [`MinimalRandomAccessCollection`](../../Tests/_CollectionsTestSupport/MinimalTypes/MinimalRandomAccessCollection.swift)
+    - [`MinimalMutableRandomAccessCollection`](../../Tests/_CollectionsTestSupport/MinimalTypes/MinimalMutableRandomAccessCollection.swift)
+    - [`MinimalRangeReplaceableRandomAccessCollection`](../../Tests/_CollectionsTestSupport/MinimalTypes/MinimalRangeReplaceableRandomAccessCollection.swift)
+    - [`MinimalMutableRangeReplaceableRandomAccessCollection`](../../Tests/_CollectionsTestSupport/MinimalTypes/MinimalMutableRangeReplaceableRandomAccessCollection.swift)
+    - [`MinimalIterator`](../../Tests/_CollectionsTestSupport/MinimalTypes/MinimalIterator.swift)
+    - [`MinimalIndex`](../../Tests/_CollectionsTestSupport/MinimalTypes/MinimalIndex.swift)
+    - [`MinimalEncoder`](../../Tests/_CollectionsTestSupport/MinimalTypes/MinimalEncoder.swift)
+    - [`MinimalDecoder`](../../Tests/_CollectionsTestSupport/MinimalTypes/MinimalDecoder.swift)
 
-- [`Utilities`](../../Sources/_CollectionsTestSupport/Utilities): Utility types. Wrapper types for boxed values, a simple deterministic random number generator, and a lifetime tracker for catching simple memory management issues such as memory leaks. (The [Address Sanitizer][asan] can be used to catch more serious problems.)
+- [`Utilities`](../../Tests/_CollectionsTestSupport/Utilities): Utility types. Wrapper types for boxed values, a simple deterministic random number generator, and a lifetime tracker for catching simple memory management issues such as memory leaks. (The [Address Sanitizer][asan] can be used to catch more serious problems.)
 
 [asan]: https://developer.apple.com/documentation/xcode/diagnosing_memory_thread_and_crash_issues_early?language=objc
 

--- a/Documentation/Internals/ReleaseChecklist.md
+++ b/Documentation/Internals/ReleaseChecklist.md
@@ -2,8 +2,8 @@
 
 1. Create a milestone for the new version (if one doesn't exist yet).
 2. Collect all issues & PRs that are going to be included in the new tag under the new milestone.
-3. If the new release moves code between source files or adds new API that has the potential to cause mutual dependencies between source files, then run the [shuffle-sources.sh](./Utils/shuffle-sources.sh) script for at least a few hundred iterations on the affected module to help catch [nondeterministic build issues with the compiler's MergeModules phase](https://github.com/apple/swift-collections/issues/7). (Note: it's best to do this on a fresh clone. We can stop doing this when MergeModules is no longer used to build debug configurations in SPM.)
-4. Run the [full tests script](./Utils/run-full-tests.sh) on the commit that you intend to tag, with all supported (major) toolchain releases, and on as many supported platforms as are practical. (At minimum, run the script with the latest stable toolchain releases on macOS and one Linux distribution.)
+3. If the new release moves code between source files or adds new API that has the potential to cause mutual dependencies between source files, then run the [shuffle-sources.sh](../../Utils/shuffle-sources.sh) script for at least a few hundred iterations on the affected module to help catch [nondeterministic build issues with the compiler's MergeModules phase](https://github.com/apple/swift-collections/issues/7). (Note: it's best to do this on a fresh clone. We can stop doing this when MergeModules is no longer used to build debug configurations in SPM.)
+4. Run the [full tests script](../../Utils/run-full-tests.sh) on the commit that you intend to tag, with all supported (major) toolchain releases, and on as many supported platforms as are practical. (At minimum, run the script with the latest stable toolchain releases on macOS and one Linux distribution.)
   The script exercises a tiny subset of the environments this package can be built and run on.
   
    The full matrix includes the following axes:


### PR DESCRIPTION
Fixes 26 broken links in `Documentation/Internals/` (mechanical link audit; every corrected target verified to exist):

- `README.md` — 23 links to `../../Sources/_CollectionsTestSupport/...`: the test support library lives under `Tests/_CollectionsTestSupport` → updated paths (and the one visible `Sources/...` label); `./Benchmarks` → `../../Benchmarks` (repo-root relative)
- `ReleaseChecklist.md` — `./Utils/shuffle-sources.sh` and `./Utils/run-full-tests.sh` → `../../Utils/...` (the Utils directory is at the repo root)

Documentation only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)