### PR TITLE
Fix inverted SortedDictionary Keys/Values/SubSequence equality

### DIFF
--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary+Keys.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary+Keys.swift
@@ -239,7 +239,7 @@ extension SortedDictionary.Keys: Equatable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     if lhs.count != rhs.count { return false }
     for (e1, e2) in zip(lhs, rhs) {
-      if e1 == e2 {
+      if e1 != e2 {
         return false
       }
     }

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary+SubSequence.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary+SubSequence.swift
@@ -300,7 +300,7 @@ extension SortedDictionary.SubSequence: Equatable where Value: Equatable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     if lhs.count != rhs.count { return false }
     for (e1, e2) in zip(lhs, rhs) {
-      if e1.key != e2.key || e1.value != e2.value {
+      if e1 != e2 {
         return false
       }
     }

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary+SubSequence.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary+SubSequence.swift
@@ -300,7 +300,7 @@ extension SortedDictionary.SubSequence: Equatable where Value: Equatable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     if lhs.count != rhs.count { return false }
     for (e1, e2) in zip(lhs, rhs) {
-      if e1 == e2 {
+      if e1.key != e2.key || e1.value != e2.value {
         return false
       }
     }

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary+Values.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary+Values.swift
@@ -258,7 +258,7 @@ extension SortedDictionary.Values: Equatable where Value: Equatable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     if lhs.count != rhs.count { return false }
     for (e1, e2) in zip(lhs, rhs) {
-      if e1 == e2 {
+      if e1 != e2 {
         return false
       }
     }

--- a/Tests/SortedCollectionsTests/SortedDictionary/SortedDictionary Tests.swift
+++ b/Tests/SortedCollectionsTests/SortedDictionary/SortedDictionary Tests.swift
@@ -284,6 +284,97 @@ final class SortedDictionaryTests: CollectionTestCase {
       }
     }
   }
+
+  func test_keys_Equatable() {
+    let left: SortedDictionary = [
+      1: "one",
+      2: "two",
+      3: "three",
+    ]
+    let rightEqual: SortedDictionary = [
+      3: "trois",
+      1: "un",
+      2: "deux",
+    ]
+    let rightUnequal: SortedDictionary = [
+      1: "one",
+      2: "two",
+      4: "four",
+    ]
+
+    expectEqual(left.keys, left.keys)
+    expectEqual(left.keys, rightEqual.keys)
+    expectNotEqual(left.keys, rightUnequal.keys)
+
+    checkEquatable(equivalenceClasses: [
+      [SortedDictionary<Int, String>().keys, SortedDictionary<Int, String>().keys],
+      [left.keys, rightEqual.keys],
+      [rightUnequal.keys],
+    ])
+  }
+
+  func test_values_Equatable() {
+    let left: SortedDictionary = [
+      1: "one",
+      2: "two",
+      3: "three",
+    ]
+    let rightEqual: SortedDictionary = [
+      1: "one",
+      2: "two",
+      3: "three",
+    ]
+    let rightUnequal: SortedDictionary = [
+      1: "one",
+      2: "two",
+      3: "trois",
+    ]
+
+    expectEqual(left.values, left.values)
+    expectEqual(left.values, rightEqual.values)
+    expectNotEqual(left.values, rightUnequal.values)
+
+    checkEquatable(equivalenceClasses: [
+      [SortedDictionary<Int, String>().values, SortedDictionary<Int, String>().values],
+      [left.values, rightEqual.values],
+      [rightUnequal.values],
+    ])
+  }
+
+  func test_subSequence_Equatable() {
+    let left: SortedDictionary = [
+      1: "one",
+      2: "two",
+      3: "three",
+      4: "four",
+    ]
+    let rightEqual: SortedDictionary = [
+      1: "one",
+      2: "two",
+      3: "three",
+      4: "four",
+    ]
+    let rightUnequal: SortedDictionary = [
+      1: "one",
+      2: "two",
+      3: "trois",
+      4: "four",
+    ]
+
+    let leftSlice = left[left.index(after: left.startIndex)..<left.index(before: left.endIndex)]
+    let rightEqualSlice = rightEqual[
+      rightEqual.index(after: rightEqual.startIndex)
+        ..< rightEqual.index(before: rightEqual.endIndex)
+    ]
+    let rightUnequalSlice = rightUnequal[
+      rightUnequal.index(after: rightUnequal.startIndex)
+        ..< rightUnequal.index(before: rightUnequal.endIndex)
+    ]
+
+    expectEqual(leftSlice, leftSlice)
+    expectEqual(leftSlice, rightEqualSlice)
+    expectNotEqual(leftSlice, rightUnequalSlice)
+  }
 }
 
 #endif


### PR DESCRIPTION
## Summary
- Fixes inverted element comparisons in `SortedDictionary.Keys`, `.Values`, and `.SubSequence` equality (`==` was used where `!=` was intended).
- Adds focused Equatable coverage for those views.
- Resolves #696.

## Test plan
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --traits UnstableSortedCollections --filter 'SortedDictionaryTests.test_(keys|values|subSequence)_Equatable'`
- [ ] CI on this PR