### PR TITLE
[Rigid/UniqueDictionary] Add mutableValue(forKey:) to new dictionary types

### DIFF
--- a/Sources/BasicContainers/RigidDictionary/RigidDictionary+Lookup.swift
+++ b/Sources/BasicContainers/RigidDictionary/RigidDictionary+Lookup.swift
@@ -26,12 +26,21 @@ extension RigidDictionary where Key: ~Copyable, Value: ~Copyable {
   ) -> (bucket: _Bucket?, hashValue: Int) {
     self._keys._find(key)
   }
-  
+
+  /// Checks if the given key is present in the `RigidDictionary`.
+  ///
+  /// - Parameter key: The key to find in the dictionary.
   @inlinable
   public func containsKey(_ key: borrowing Key) -> Bool {
     _find(key).bucket != nil
   }
 
+  /// Checks if the given key is present in the `RigidDictionary`, and returns
+  /// a reference to the value associated with it.
+  ///
+  /// - Parameter key: The key to find in the dictionary.
+  /// - Returns: A reference to the value associated with the given `key`, or
+  ///            nil if the `key` is not found.
   @available(SwiftStdlib 6.4, *)
   @inlinable
   @_lifetime(borrow self)
@@ -40,6 +49,22 @@ extension RigidDictionary where Key: ~Copyable, Value: ~Copyable {
   ) -> Ref<Value>? {
     guard let bucket = self._find(key).bucket else { return nil }
     return Ref(unsafeAddress: _valuePtr(at: bucket), borrowing: self)
+  }
+
+  /// Checks if the given key is present in the `RigidDictionary`, and returns
+  /// a mutable reference to the value associated with it.
+  ///
+  /// - Parameter key: The key to find in the dictionary.
+  /// - Returns: A mutable reference to the value associated with the given
+  ///            `key`, or nil if the `key` is not found.
+  @available(SwiftStdlib 6.4, *)
+  @inlinable
+  @_lifetime(&self)
+  public mutating func mutableValue(
+    forKey key: borrowing Key
+  ) -> MutableRef<Value>? {
+    guard let bucket = self._find(key).bucket else { return nil }
+    return MutableRef(unsafeAddress: _valuePtr(at: bucket), mutating: &self)
   }
 
   /// A stand-in for a `struct Ref`-returning lookup operation.

--- a/Sources/BasicContainers/UniqueDictionary/UniqueDictionary+Lookup.swift
+++ b/Sources/BasicContainers/UniqueDictionary/UniqueDictionary+Lookup.swift
@@ -19,11 +19,20 @@ import ContainersPreview
 
 @available(SwiftStdlib 5.0, *)
 extension UniqueDictionary where Key: ~Copyable, Value: ~Copyable {
+  /// Checks if the given key is present in the `UniqueDictionary`.
+  ///
+  /// - Parameter key: The key to find in the dictionary.
   @inlinable
   public func containsKey(_ key: borrowing Key) -> Bool {
     _storage.containsKey(key)
   }
 
+  /// Checks if the given key is present in the `RigidDictionary`, and returns
+  /// a reference to the value associated with it.
+  ///
+  /// - Parameter key: The key to find in the dictionary.
+  /// - Returns: A reference to the value associated with the given `key`, or
+  ///            nil if the `key` is not found.
   @available(SwiftStdlib 6.4, *)
   @inlinable
   @_lifetime(borrow self)
@@ -32,6 +41,21 @@ extension UniqueDictionary where Key: ~Copyable, Value: ~Copyable {
   ) -> Ref<Value>? {
     // FIXME: Why is this override necessary? Is it sound? It was triggered by RigidDictionary becoming `@_addressableForDependencies`.
     _overrideLifetime(_storage.value(forKey: key), borrowing: self)
+  }
+
+  /// Checks if the given key is present in the `RigidDictionary`, and returns
+  /// a mutable reference to the value associated with it.
+  ///
+  /// - Parameter key: The key to find in the dictionary.
+  /// - Returns: A mutable reference to the value associated with the given
+  ///            `key`, or nil if the `key` is not found.
+  @available(SwiftStdlib 6.4, *)
+  @inlinable
+  @_lifetime(&self)
+  public mutating func mutableValue(
+    forKey key: borrowing Key
+  ) -> MutableRef<Value>? {
+    _storage.mutableValue(forKey: key)
   }
 
   /// A stand-in for a `struct Ref`-returning lookup operation.

--- a/Tests/BasicContainersTests/RigidDictionaryTests.swift
+++ b/Tests/BasicContainersTests/RigidDictionaryTests.swift
@@ -43,6 +43,32 @@ class RigidDictionaryTests: CollectionTestCase {
     }
   }
   
+  func test_mutableValueForKey() {
+    typealias Key = LifetimeTracked<Int>
+    typealias Value = LifetimeTracked<String>
+    withLifetimeTracking { tracker in
+      var d = RigidDictionary<Key, Value>(capacity: 20)
+      let firstKey = tracker.instance(for: 67)
+      let firstValue = tracker.instance(for: "sixty-seven")
+      expectNil(d.insertValue(firstValue, forKey: firstKey))
+
+      if #available(SwiftStdlib 6.4, *) {
+        let secondKey = tracker.instance(for: 67)
+        expectNotNil(d.mutableValue(forKey: secondKey)) { tmpRef in
+          // FIXME: The language needs to grow up to allow us to elide this
+          //        binding definition.
+          var valueRef = tmpRef
+          expectIdentical(valueRef.value, firstValue)
+
+          let secondValue = tracker.instance(for: "six-seven")
+          valueRef.value = secondValue
+          expectNotIdentical(valueRef.value, firstValue)
+          expectIdentical(valueRef.value, secondValue)
+        }
+      }
+    }
+  }
+
   func test_insertValue_one() {
     typealias Key = LifetimeTracked<Int>
     typealias Value = LifetimeTracked<String>

--- a/Tests/BasicContainersTests/UniqueDictionaryTests.swift
+++ b/Tests/BasicContainersTests/UniqueDictionaryTests.swift
@@ -43,6 +43,32 @@ class UniqueDictionaryTests: CollectionTestCase {
     }
   }
   
+  func test_mutableValueForKey() {
+    typealias Key = LifetimeTracked<Int>
+    typealias Value = LifetimeTracked<String>
+    withLifetimeTracking { tracker in
+      var d = UniqueDictionary<Key, Value>(minimumCapacity: 20)
+      let firstKey = tracker.instance(for: 67)
+      let firstValue = tracker.instance(for: "sixty-seven")
+      expectNil(d.insertValue(firstValue, forKey: firstKey))
+
+      if #available(SwiftStdlib 6.4, *) {
+        let secondKey = tracker.instance(for: 67)
+        expectNotNil(d.mutableValue(forKey: secondKey)) { tmpRef in
+          // FIXME: The language needs to grow up to allow us to elide this
+          //        binding definition.
+          var valueRef = tmpRef
+          expectIdentical(valueRef.value, firstValue)
+
+          let secondValue = tracker.instance(for: "six-seven")
+          valueRef.value = secondValue
+          expectNotIdentical(valueRef.value, firstValue)
+          expectIdentical(valueRef.value, secondValue)
+        }
+      }
+    }
+  }
+
   func test_insert_one() {
     typealias Key = LifetimeTracked<Int>
     typealias Value = LifetimeTracked<String>

--- a/Tests/_CollectionsTestSupport/AssertionContexts/Assertions.swift
+++ b/Tests/_CollectionsTestSupport/AssertionContexts/Assertions.swift
@@ -133,14 +133,14 @@ public func expectNotNil<T>(
 
 #if compiler(>=6.2)
 public func expectNotNil<T: ~Copyable & ~Escapable>(
-  _ value: borrowing Optional<T>,
+  _ value: consuming Optional<T>,
   _ message: @autoclosure () -> String = "",
   trapping: Bool = false,
   file: StaticString = #filePath,
   line: UInt = #line,
-  _ handler: (borrowing T) throws -> Void = { _ in }
+  _ handler: (consuming T) throws -> Void = { _ in }
 ) rethrows {
-  switch value {
+  switch consume value {
   case let value?:
     try handler(value)
   case nil:
@@ -156,7 +156,7 @@ public func expectNotNil<T>(
   trapping: Bool = false,
   file: StaticString = #filePath,
   line: UInt = #line,
-  _ handler: (borrowing T) throws -> Void = { _ in }
+  _ handler: (consuming T) throws -> Void = { _ in }
 ) rethrows {
   switch value {
   case let value?:


### PR DESCRIPTION
We have `Ref`/`MutableRef` now in addition to the already existing `value(forKey:)` that returns the non-mutable ref, but we can also provide a mutable version!

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [X] I've updated the documentation if necessary.
