### PR TITLE
[Rigid/UniqueArray] Eliminate some duplicate bounds checks for UniqueArray

### DIFF
--- a/Sources/BasicContainers/RigidArray/RigidArray+Append.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Append.swift
@@ -153,19 +153,6 @@ extension RigidArray where Element: ~Copyable {
   }
 #endif
 
-  @_alwaysEmitIntoClient
-  @unsafe
-  internal mutating func _appendUnchecked(
-    moving items: inout OutputSpan<Element>
-  ) {
-    // FIXME: Remove this when `OutputSpan` starts conforming to RangeReplaceableContainer
-    items.withUnsafeMutableBufferPointer { buffer, count in
-      let source = buffer._extracting(first: count)
-      unsafe _appendUnchecked(moving: source)
-      count = 0
-    }
-  }
-
   /// Moves the elements of an output span to the end of this array, leaving the
   /// span empty.
   ///
@@ -180,8 +167,13 @@ extension RigidArray where Element: ~Copyable {
   public mutating func append(
     moving items: inout OutputSpan<Element>
   ) {
+    // FIXME: Remove this when `OutputSpan` starts conforming to RangeReplaceableContainer
     precondition(items.count <= freeCapacity, "RigidArray capacity overflow")
-    _appendUnchecked(moving: &items)
+    items.withUnsafeMutableBufferPointer { buffer, count in
+      let source = buffer._extracting(first: count)
+      unsafe _appendUnchecked(moving: source)
+      count = 0
+    }
   }
 
 #if !UnstableContainersPreview
@@ -257,14 +249,6 @@ extension RigidArray {
     unsafe self.append(copying: UnsafeBufferPointer(items))
   }
 
-  @_alwaysEmitIntoClient
-  @unsafe
-  internal mutating func _appendUnchecked(copying items: Span<Element>) {
-    items.withUnsafeBufferPointer { source in
-      unsafe _appendUnchecked(copying: source)
-    }
-  }
-
   /// Copies the elements of a span to the end of this array.
   ///
   /// If the array does not have sufficient capacity to hold all items in the
@@ -277,7 +261,9 @@ extension RigidArray {
   @_alwaysEmitIntoClient
   public mutating func append(copying items: Span<Element>) {
     precondition(items.count <= freeCapacity, "RigidArray capacity overflow")
-    _appendUnchecked(copying: items)
+    items.withUnsafeBufferPointer { source in
+      unsafe _appendUnchecked(copying: source)
+    }
   }
 
   @_alwaysEmitIntoClient

--- a/Sources/BasicContainers/RigidArray/RigidArray+Append.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Append.swift
@@ -20,6 +20,13 @@ import ContainersPreview
 
 @available(SwiftStdlib 5.0, *)
 extension RigidArray where Element: ~Copyable {
+  @inlinable
+  @unsafe
+  internal mutating func _appendUnchecked(_ item: consuming Element) {
+    unsafe _storage.initializeElement(at: _count, to: item)
+    _count &+= 1
+  }
+
   /// Adds an element to the end of the array.
   ///
   /// If the array does not have sufficient capacity to hold any more elements,
@@ -31,8 +38,7 @@ extension RigidArray where Element: ~Copyable {
   @inlinable
   public mutating func append(_ item: consuming Element) {
     precondition(!isFull, "RigidArray capacity overflow")
-    unsafe _storage.initializeElement(at: _count, to: item)
-    _count &+= 1
+    unsafe _appendUnchecked(item)
   }
 
   /// Adds an element to the end of the array, if possible.
@@ -48,7 +54,7 @@ extension RigidArray where Element: ~Copyable {
   @inlinable
   public mutating func pushLast(_ item: consuming Element) -> Element? {
     if isFull { return item }
-    append(item)
+    unsafe _appendUnchecked(item)
     return nil
   }
 }
@@ -93,6 +99,17 @@ extension RigidArray where Element: ~Copyable {
 
 @available(SwiftStdlib 5.0, *)
 extension RigidArray where Element: ~Copyable {
+  @inlinable
+  @unsafe
+  internal mutating func _appendUnchecked(
+    moving items: UnsafeMutableBufferPointer<Element>
+  ) {
+    guard items.count > 0 else { return }
+    let c = unsafe _freeSpace._moveInitializePrefix(from: items)
+    assert(c == items.count)
+    _count &+= items.count
+  }
+
   /// Moves the elements of a buffer to the end of this array, leaving the
   /// buffer uninitialized.
   ///
@@ -109,10 +126,7 @@ extension RigidArray where Element: ~Copyable {
     moving items: UnsafeMutableBufferPointer<Element>
   ) {
     precondition(items.count <= freeCapacity, "RigidArray capacity overflow")
-    guard items.count > 0 else { return }
-    let c = unsafe _freeSpace._moveInitializePrefix(from: items)
-    assert(c == items.count)
-    _count &+= items.count
+    unsafe _appendUnchecked(moving: items)
   }
 
 #if UnstableContainersPreview
@@ -139,6 +153,19 @@ extension RigidArray where Element: ~Copyable {
   }
 #endif
 
+  @_alwaysEmitIntoClient
+  @unsafe
+  internal mutating func _appendUnchecked(
+    moving items: inout OutputSpan<Element>
+  ) {
+    // FIXME: Remove this when `OutputSpan` starts conforming to RangeReplaceableContainer
+    items.withUnsafeMutableBufferPointer { buffer, count in
+      let source = buffer._extracting(first: count)
+      unsafe _appendUnchecked(moving: source)
+      count = 0
+    }
+  }
+
   /// Moves the elements of an output span to the end of this array, leaving the
   /// span empty.
   ///
@@ -153,12 +180,8 @@ extension RigidArray where Element: ~Copyable {
   public mutating func append(
     moving items: inout OutputSpan<Element>
   ) {
-    // FIXME: Remove this when `OutputSpan` starts conforming to RangeReplaceableContainer
-    items.withUnsafeMutableBufferPointer { buffer, count in
-      let source = buffer._extracting(first: count)
-      unsafe self.append(moving: source)
-      count = 0
-    }
+    precondition(items.count <= freeCapacity, "RigidArray capacity overflow")
+    _appendUnchecked(moving: &items)
   }
 
 #if !UnstableContainersPreview
@@ -186,6 +209,17 @@ extension RigidArray where Element: ~Copyable {
 
 @available(SwiftStdlib 5.0, *)
 extension RigidArray {
+  @_alwaysEmitIntoClient
+  @unsafe
+  internal mutating func _appendUnchecked(
+    copying newElements: UnsafeBufferPointer<Element>
+  ) {
+    guard newElements.count > 0 else { return }
+    unsafe _freeSpace.baseAddress.unsafelyUnwrapped.initialize(
+      from: newElements.baseAddress.unsafelyUnwrapped, count: newElements.count)
+    _count &+= newElements.count
+  }
+
   /// Copies the elements of a buffer to the end of this array.
   ///
   /// If the array does not have sufficient capacity to hold all items in the
@@ -203,10 +237,7 @@ extension RigidArray {
     precondition(
       newElements.count <= freeCapacity,
       "RigidArray capacity overflow")
-    guard newElements.count > 0 else { return }
-    unsafe _freeSpace.baseAddress.unsafelyUnwrapped.initialize(
-      from: newElements.baseAddress.unsafelyUnwrapped, count: newElements.count)
-    _count &+= newElements.count
+    unsafe _appendUnchecked(copying: newElements)
   }
 
   /// Copies the elements of a buffer to the end of this array.
@@ -226,6 +257,14 @@ extension RigidArray {
     unsafe self.append(copying: UnsafeBufferPointer(items))
   }
 
+  @_alwaysEmitIntoClient
+  @unsafe
+  internal mutating func _appendUnchecked(copying items: Span<Element>) {
+    items.withUnsafeBufferPointer { source in
+      unsafe _appendUnchecked(copying: source)
+    }
+  }
+
   /// Copies the elements of a span to the end of this array.
   ///
   /// If the array does not have sufficient capacity to hold all items in the
@@ -237,9 +276,8 @@ extension RigidArray {
   /// - Complexity: O(`newElements.count`)
   @_alwaysEmitIntoClient
   public mutating func append(copying items: Span<Element>) {
-    items.withUnsafeBufferPointer { source in
-      unsafe self.append(copying: source)
-    }
+    precondition(items.count <= freeCapacity, "RigidArray capacity overflow")
+    _appendUnchecked(copying: items)
   }
 
   @_alwaysEmitIntoClient

--- a/Sources/BasicContainers/RigidArray/RigidArray+Append.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Append.swift
@@ -20,7 +20,7 @@ import ContainersPreview
 
 @available(SwiftStdlib 5.0, *)
 extension RigidArray where Element: ~Copyable {
-  @inlinable
+  @_alwaysEmitIntoClient
   @unsafe
   internal mutating func _appendUnchecked(_ item: consuming Element) {
     unsafe _storage.initializeElement(at: _count, to: item)
@@ -99,7 +99,7 @@ extension RigidArray where Element: ~Copyable {
 
 @available(SwiftStdlib 5.0, *)
 extension RigidArray where Element: ~Copyable {
-  @inlinable
+  @_alwaysEmitIntoClient
   @unsafe
   internal mutating func _appendUnchecked(
     moving items: UnsafeMutableBufferPointer<Element>

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Append.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Append.swift
@@ -129,7 +129,11 @@ extension UniqueArray where Element: ~Copyable {
     moving items: inout OutputSpan<Element>
   ) {
     _ensureFreeCapacity(items.count)
-    unsafe _storage._appendUnchecked(moving: &items)
+    items.withUnsafeMutableBufferPointer { buffer, count in
+      let source = buffer._extracting(first: count)
+      unsafe _appendUnchecked(moving: source)
+      count = 0
+    }
   }
 
 #if !UnstableContainersPreview
@@ -254,7 +258,9 @@ extension UniqueArray {
   @_alwaysEmitIntoClient
   public mutating func append(copying newElements: Span<Element>) {
     _ensureFreeCapacity(newElements.count)
-    unsafe _storage._appendUnchecked(copying: newElements)
+    items.withUnsafeBufferPointer { source in
+      unsafe _storage._appendUnchecked(copying: source)
+    }
   }
 
 #if compiler(>=6.4) && UnstableContainersPreview

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Append.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Append.swift
@@ -32,7 +32,7 @@ extension UniqueArray where Element: ~Copyable {
   @inlinable
   public mutating func append(_ item: consuming Element) {
     _ensureFreeCapacity(1)
-    _storage.append(item)
+    unsafe _storage._appendUnchecked(item)
   }
 }
 
@@ -89,7 +89,7 @@ extension UniqueArray where Element: ~Copyable {
     moving items: UnsafeMutableBufferPointer<Element>
   ) {
     _ensureFreeCapacity(items.count)
-    _storage.append(moving: items)
+    _storage._appendUnchecked(moving: items)
   }
   
 #if UnstableContainersPreview
@@ -129,7 +129,7 @@ extension UniqueArray where Element: ~Copyable {
     moving items: inout OutputSpan<Element>
   ) {
     _ensureFreeCapacity(items.count)
-    _storage.append(moving: &items)
+    unsafe _storage._appendUnchecked(moving: &items)
   }
 
 #if !UnstableContainersPreview
@@ -218,7 +218,7 @@ extension UniqueArray {
     copying newElements: UnsafeBufferPointer<Element>
   ) {
     _ensureFreeCapacity(newElements.count)
-    unsafe _storage.append(copying: newElements)
+    unsafe _storage._appendUnchecked(copying: newElements)
   }
 
   /// Copies the elements of a buffer to the end of this array.
@@ -254,7 +254,7 @@ extension UniqueArray {
   @_alwaysEmitIntoClient
   public mutating func append(copying newElements: Span<Element>) {
     _ensureFreeCapacity(newElements.count)
-    _storage.append(copying: newElements)
+    unsafe _storage._appendUnchecked(copying: newElements)
   }
 
 #if compiler(>=6.4) && UnstableContainersPreview
@@ -272,7 +272,7 @@ extension UniqueArray {
       let span = try it.nextSpan()
       if span.isEmpty { break }
       _ensureFreeCapacity(span.count)
-      _storage.append(copying: span)
+      unsafe _storage._appendUnchecked(copying: span)
     }
   }
   // FIXME: Add _append(copyingContainer:), forwarding to the same method on RigidArray
@@ -323,7 +323,7 @@ extension UniqueArray {
   public mutating func append(copying newElements: some Sequence<Element>) {
     let done: Void? = newElements.withContiguousStorageIfAvailable { buffer in
       _ensureFreeCapacity(buffer.count)
-      unsafe _storage.append(copying: buffer)
+      unsafe _storage._appendUnchecked(copying: buffer)
       return
     }
     if done != nil { return }
@@ -331,8 +331,7 @@ extension UniqueArray {
     _ensureFreeCapacity(newElements.underestimatedCount)
     var it = _storage._append(prefixOf: newElements)
     while let item = it.next() {
-      _ensureFreeCapacity(1)
-      _storage.append(item)
+      self.append(item)
     }
   }
   

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Append.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Append.swift
@@ -258,7 +258,7 @@ extension UniqueArray {
   @_alwaysEmitIntoClient
   public mutating func append(copying newElements: Span<Element>) {
     _ensureFreeCapacity(newElements.count)
-    items.withUnsafeBufferPointer { source in
+    newElements.withUnsafeBufferPointer { source in
       unsafe _storage._appendUnchecked(copying: source)
     }
   }

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Append.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Append.swift
@@ -131,7 +131,7 @@ extension UniqueArray where Element: ~Copyable {
     _ensureFreeCapacity(items.count)
     items.withUnsafeMutableBufferPointer { buffer, count in
       let source = buffer._extracting(first: count)
-      unsafe _appendUnchecked(moving: source)
+      unsafe _storage._appendUnchecked(moving: source)
       count = 0
     }
   }

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Append.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Append.swift
@@ -278,7 +278,9 @@ extension UniqueArray {
       let span = try it.nextSpan()
       if span.isEmpty { break }
       _ensureFreeCapacity(span.count)
-      unsafe _storage._appendUnchecked(copying: span)
+      span.withUnsafeBufferPointer { source in
+        unsafe _storage._appendUnchecked(copying: source)
+      }
     }
   }
   // FIXME: Add _append(copyingContainer:), forwarding to the same method on RigidArray


### PR DESCRIPTION
`UniqueArray` had calls to `_ensureFreeCapacity` followed by calls to various `RigidArray.append(*)` which had its own bounds check. Split off the append logic from `RigidArray` into unchecked variants that it and `UniqueArray` can both call once they've done their bounds checking.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
