### PR TITLE
[Deque/HashTree] Remove references to ManagedBuffer.capacity and use the given minCapacity

### DIFF
--- a/Sources/DequeModule/Deque/Deque._Storage.swift
+++ b/Sources/DequeModule/Deque/Deque._Storage.swift
@@ -51,13 +51,11 @@ extension Deque._Storage {
   internal init(minimumCapacity: Int) {
     let object = _DequeBuffer<Element>.create(
       minimumCapacity: minimumCapacity,
-      makingHeaderWith: {
-        #if os(OpenBSD)
-        let capacity = minimumCapacity
-        #else
-        let capacity = $0.capacity
-        #endif
-        return _DequeBufferHeader(capacity: capacity, count: 0, startSlot: .zero)
+      makingHeaderWith: { _ in
+        return _DequeBufferHeader(
+          capacity: minimumCapacity,
+          count: 0,
+          startSlot: .zero)
       })
     self.init(_buffer: _Buffer(unsafeBufferObject: object))
   }

--- a/Sources/DequeModule/Deque/Deque._UnsafeHandle.swift
+++ b/Sources/DequeModule/Deque/Deque._UnsafeHandle.swift
@@ -296,14 +296,9 @@ extension Deque._UnsafeHandle {
     assert(minimumCapacity >= count)
     let object = _DequeBuffer<Element>.create(
       minimumCapacity: minimumCapacity,
-      makingHeaderWith: {
-        #if os(OpenBSD)
-        let capacity = minimumCapacity
-        #else
-        let capacity = $0.capacity
-        #endif
+      makingHeaderWith: { _ in
         return _DequeBufferHeader(
-          capacity: capacity,
+          capacity: minimumCapacity,
           count: count,
           startSlot: .zero)
       })
@@ -330,14 +325,9 @@ extension Deque._UnsafeHandle {
     assert(minimumCapacity >= count)
     let object = _DequeBuffer<Element>.create(
       minimumCapacity: minimumCapacity,
-      makingHeaderWith: {
-        #if os(OpenBSD)
-        let capacity = minimumCapacity
-        #else
-        let capacity = $0.capacity
-        #endif
+      makingHeaderWith: { _ in
         return _DequeBufferHeader(
-          capacity: capacity,
+          capacity: minimumCapacity,
           count: count,
           startSlot: .zero)
       })

--- a/Sources/HashTreeCollections/HashNode/_HashNode+Storage.swift
+++ b/Sources/HashTreeCollections/HashNode/_HashNode+Storage.swift
@@ -85,12 +85,8 @@ extension _HashNode.Storage {
     let mincap = (bytes &+ childStride &- 1) / childStride
     let object = _HashNode.Storage.create(
       minimumCapacity: mincap
-    ) { buffer in
-#if os(OpenBSD)
+    ) { _ in
       _HashNodeHeader(byteCapacity: mincap * childStride)
-#else
-      _HashNodeHeader(byteCapacity: buffer.capacity * childStride)
-#endif
     }
 
     object.withUnsafeMutablePointers { header, elements in


### PR DESCRIPTION
When creating a `ManagedBuffer` object, the factory closure passes the newly created `ManagedBuffer` instance for the caller to make the header with. Referencing `ManagedBuffer.capacity` will end up making calls to `malloc_size` to return the allocation size, but the caller has already supplied it with a minimumCapacity argument. For embedded, it's critical that we don't needlessly link against system symbols that may or may not exist especially since the information we need is already there (and in fact the code was already guarding against it for OpenBSD).

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
