### PR TITLE
Name the documented arguments the way the declarations name them

### DIFF
--- a/Sources/BasicContainers/RigidArray/RigidArray+Append.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Append.swift
@@ -238,10 +238,10 @@ extension RigidArray {
   /// buffer, then this triggers a runtime error.
   ///
   /// - Parameters:
-  ///    - newElements: A fully initialized buffer whose contents to copy into
+  ///    - items: A fully initialized buffer whose contents to copy into
   ///        the array.
   ///
-  /// - Complexity: O(`newElements.count`)
+  /// - Complexity: O(`items.count`)
   @_alwaysEmitIntoClient
   public mutating func append(
     copying items: UnsafeMutableBufferPointer<Element>
@@ -255,9 +255,9 @@ extension RigidArray {
   /// span, then this triggers a runtime error.
   ///
   /// - Parameters:
-  ///    - newElements: A span whose contents to copy into the array.
+  ///    - items: A span whose contents to copy into the array.
   ///
-  /// - Complexity: O(`newElements.count`)
+  /// - Complexity: O(`items.count`)
   @_alwaysEmitIntoClient
   public mutating func append(copying items: Span<Element>) {
     precondition(items.count <= freeCapacity, "RigidArray capacity overflow")

--- a/Sources/BasicContainers/RigidArray/RigidArray+Initializers.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Initializers.swift
@@ -52,7 +52,7 @@ extension RigidArray where Element: ~Copyable {
   ///
   /// - Parameters:
   ///   - capacity: The storage capacity of the new array.
-  ///   - body: A callback that gets called at most once to directly
+  ///   - initializer: A callback that gets called at most once to directly
   ///       populate newly reserved storage within the array. The function
   ///       is allowed to add fewer than `capacity` items. The array is
   ///       initialized with however many items the callback adds to the

--- a/Sources/BasicContainers/RigidArray/RigidArray+Insertions.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Insertions.swift
@@ -369,7 +369,7 @@ extension RigidArray {
   /// elements, then this method triggers a runtime error.
   ///
   /// - Parameters:
-  ///    - newElements: The new elements to insert into the array.
+  ///    - items: The new elements to insert into the array.
   ///    - index: The position at which to insert the new elements. It must be
   ///        a valid index of the array.
   ///

--- a/Sources/BasicContainers/RigidArray/RigidArray+Removals.swift
+++ b/Sources/BasicContainers/RigidArray/RigidArray+Removals.swift
@@ -25,7 +25,7 @@ extension RigidArray where Element: ~Copyable {
   /// All the elements following the specified position are moved to close the
   /// gap.
   ///
-  /// - Parameter i: The position of the element to remove. `index` must be
+  /// - Parameter index: The position of the element to remove. `index` must be
   ///   a valid index of the array that is not equal to the end index.
   /// - Returns: The removed element.
   ///

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Deprecated.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Deprecated.swift
@@ -127,7 +127,7 @@ extension UniqueArray where Element: ~Copyable {
   /// buffer of the specified capacity, moving all existing elements
   /// to its new storage. The old storage is then deallocated.
   ///
-  /// - Parameter newCapacity: The desired new capacity. `newCapacity` must be
+  /// - Parameter capacity: The desired new capacity. `capacity` must be
   ///    greater than or equal to the current count.
   ///
   /// - Complexity: O(`count`)

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Insertions.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Insertions.swift
@@ -34,7 +34,7 @@ extension UniqueArray where Element: ~Copyable {
   /// make room for the new item.
   ///
   /// - Parameter item: The new element to insert into the array.
-  /// - Parameter i: The position at which to insert the new element.
+  /// - Parameter index: The position at which to insert the new element.
   ///   `index` must be a valid index in the array.
   ///
   /// - Complexity: O(`self.count`)
@@ -72,7 +72,7 @@ extension UniqueArray where Element: ~Copyable {
   ///     // `buffer` now contains [-999, 0, 1, 2, 999]
   ///
   /// - Parameters:
-  ///    - count: The number of items to insert into the array.
+  ///    - newItemCount: The number of items to insert into the array.
   ///    - index: The position at which to insert the new items.
   ///       `index` must be a valid index in the array.
   ///    - body: A callback that gets called at most once to directly

--- a/Sources/BasicContainers/UniqueArray/UniqueArray+Removals.swift
+++ b/Sources/BasicContainers/UniqueArray/UniqueArray+Removals.swift
@@ -69,7 +69,7 @@ extension UniqueArray where Element: ~Copyable {
   /// All the elements following the specified position are moved to close the
   /// gap.
   ///
-  /// - Parameter i: The position of the element to remove. `index` must be
+  /// - Parameter index: The position of the element to remove. `index` must be
   ///   a valid index of the array that is not equal to the end index.
   /// - Returns: The removed element.
   ///

--- a/Sources/BitCollections/BitArray/BitArray+Collection.swift
+++ b/Sources/BitCollections/BitArray/BitArray+Collection.swift
@@ -56,9 +56,9 @@ extension BitArray: RandomAccessCollection, MutableCollection {
 
   /// Returns the position immediately after the given index.
   ///
-  /// - Parameter `index`: A valid index of the bit set. `index` must be less than `endIndex`.
+  /// - Parameter i: A valid index of the bit set. `i` must be less than `endIndex`.
   ///
-  /// - Returns: The valid index immediately after `index`.
+  /// - Returns: The valid index immediately after `i`.
   ///
   /// - Complexity: O(1)
   @inlinable @inline(__always)
@@ -66,10 +66,10 @@ extension BitArray: RandomAccessCollection, MutableCollection {
 
   /// Returns the position immediately before the given index.
   ///
-  /// - Parameter `index`: A valid index of the bit set. `index` must be greater
+  /// - Parameter i: A valid index of the bit set. `i` must be greater
   ///    than `startIndex`.
   ///
-  /// - Returns: The valid index immediately before `index`.
+  /// - Returns: The valid index immediately before `i`.
   ///
   /// - Complexity: O(1)
   @inlinable @inline(__always)

--- a/Sources/BitCollections/BitSet/BitSet+SetAlgebra basics.swift
+++ b/Sources/BitCollections/BitSet/BitSet+SetAlgebra basics.swift
@@ -19,7 +19,7 @@ extension BitSet {
   /// Returns a Boolean value that indicates whether the given element exists
   /// in the set.
   ///
-  /// - Parameter element: An element to look for in the set.
+  /// - Parameter member: An element to look for in the set.
   ///
   /// - Returns: `true` if `member` exists in the set; otherwise, `false`.
   ///

--- a/Sources/ContainersPreview/Protocols/Container/Container.swift
+++ b/Sources/ContainersPreview/Protocols/Container/Container.swift
@@ -195,7 +195,7 @@ public protocol Container<Element>:
   /// collection’s end index. The end index refers to the position one past the
   /// last element of a collection, so it doesn’t correspond with an element.
   ///
-  /// - Parameter position: The position of the element to access.
+  /// - Parameter index: The position of the element to access.
   ///    `position` must be a valid index of the container that is not equal
   ///    to the `endIndex` property.
   /// - Complexity: O(1). This is a hard requirement.

--- a/Sources/ContainersPreview/Protocols/Container/MutableContainer.swift
+++ b/Sources/ContainersPreview/Protocols/Container/MutableContainer.swift
@@ -21,7 +21,7 @@ where
 {
   /// Accesses the element at the specified position.
   ///
-  /// - Parameter position: The position of the element to access.
+  /// - Parameter index: The position of the element to access.
   ///    `position` must be a valid index of the container that is not equal
   ///    to the `endIndex` property.
   /// - Complexity: O(1)

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Initializers.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Initializers.swift
@@ -41,7 +41,7 @@ extension RigidDeque where Element: ~Copyable {
   ///   - capacity: The number of elements to allocate space for in the new
   ///     rigid deque.
   ///   - initializer: A closure that initializes the elements of the new deque.
-  ///     - Parameter outputSpan: An `OutputSpan` allowing initialization of the
+  ///     - Parameter initializer: An `OutputSpan` allowing initialization of the
   ///       deque's initial elements.
   @inlinable @inline(__always)
   public init<E: Error>(

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Insertions.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Insertions.swift
@@ -414,7 +414,7 @@ extension RigidDeque /* where Element: Copyable */ {
   /// elements, then this method triggers a runtime error.
   ///
   /// - Parameters:
-  ///    - newElements: The new elements to insert into the deque.
+  ///    - items: The new elements to insert into the deque.
   ///    - index: The position at which to insert the new elements. It must be
   ///        a valid index of the deque.
   ///

--- a/Sources/DequeModule/RigidDeque/RigidDeque+Prepend.swift
+++ b/Sources/DequeModule/RigidDeque/RigidDeque+Prepend.swift
@@ -202,7 +202,7 @@ extension RigidDeque where Element: ~Copyable {
   /// many items as promised.
   ///
   /// - Parameters:
-  ///    - maxCount: The maximum number of items to prepend to the deque, or
+  ///    - newItemCount: The maximum number of items to prepend to the deque, or
   ///       nil to use all available capacity.
   ///    - producer: A producer that generates the items to prepend.
   ///

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Initializers.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Initializers.swift
@@ -43,7 +43,7 @@ extension UniqueDeque where Element: ~Copyable {
   ///   - capacity: The number of elements to allocate space for in the new
   ///     rigid deque.
   ///   - initializer: A closure that initializes the elements of the new deque.
-  ///     - Parameter outputSpan: An `OutputSpan` allowing initialization of the
+  ///     - Parameter initializer: An `OutputSpan` allowing initialization of the
   ///       deque's initial elements.
   @inlinable @inline(__always)
   public init<E: Error>(

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Insertions.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Insertions.swift
@@ -434,7 +434,7 @@ extension UniqueDeque /* where Element: Copyable */ {
   /// geometric growth rate.
   ///
   /// - Parameters:
-  ///    - newElements: The new elements to insert into the deque.
+  ///    - items: The new elements to insert into the deque.
   ///    - index: The position at which to insert the new elements. It must be
   ///        a valid index of the deque.
   ///

--- a/Sources/DequeModule/UniqueDeque/UniqueDeque+Prepend.swift
+++ b/Sources/DequeModule/UniqueDeque/UniqueDeque+Prepend.swift
@@ -496,7 +496,7 @@ extension UniqueDeque /*where Element: Copyable*/ {
   /// sequence, then this triggers a runtime error.
   ///
   /// - Parameters:
-  ///    - newElements: The new elements to copy into the deque.
+  ///    - items: The new elements to copy into the deque.
   ///
   /// - Complexity: O(*m*), where *m* is the length of `items` when amortized
   ///     over many similar invocations on the same deque.

--- a/Sources/DequeModule/_UnsafeDequeHandle.swift
+++ b/Sources/DequeModule/_UnsafeDequeHandle.swift
@@ -745,7 +745,7 @@ extension _UnsafeDequeHandle where Element: ~Copyable {
   /// successfully initialized before the callback terminated.
   ///
   /// - Parameters:
-  ///    - capacity: The maximum number of items to append to the deque.
+  ///    - newItemCount: The maximum number of items to append to the deque.
   ///    - body: A callback that gets called at most twice to directly
   ///       populate newly reserved storage within the deque. The function
   ///       is allowed to initialize fewer than `count` items. The deque is
@@ -805,7 +805,7 @@ extension _UnsafeDequeHandle where Element: ~Copyable {
   ///     // `buffer` now contains [0, 1, 2, 3, 4, 5, 10]
   ///
   /// - Parameters:
-  ///    - count: The number of items to append to the deque.
+  ///    - newItemCount: The number of items to append to the deque.
   ///    - body: A callback that gets called at most twice to directly
   ///       populate newly reserved storage within the deque. The function
   ///       is allowed to initialize fewer than `count` items. The deque is

--- a/Sources/OrderedCollections/HashTable/_HashTable+UnsafeHandle.swift
+++ b/Sources/OrderedCollections/HashTable/_HashTable+UnsafeHandle.swift
@@ -560,7 +560,6 @@ extension _UnsafeHashTable {
   /// Fill an empty hash table by populating it with data from `elements`.
   ///
   /// - Parameter elements: A random-access collection for which this table is being generated.
-  /// - Parameter stoppingOnFirstDuplicateValue: If true, check for duplicate values and stop inserting items when one is found.
   /// - Returns: `(success, index)` where `success` is a boolean value indicating that every value in `elements` was successfully inserted. A false success indicates that duplicate elements have been found; in this case `index` points to the first duplicate value; otherwise `index` is set to `elements.endIndex`.
   @inlinable
   internal func fill<C: RandomAccessCollection>(

--- a/Sources/OrderedCollections/HashTable/_HashTable.swift
+++ b/Sources/OrderedCollections/HashTable/_HashTable.swift
@@ -61,7 +61,6 @@ extension _HashTable {
   ///
   /// - Parameter scale: The desired hash table scale or nil to use the minimum scale that satisfies invariants.
   /// - Parameter reservedScale: The reserved scale to remember in the returned storage.
-  /// - Parameter duplicates: The strategy to use to handle duplicate items.
   /// - Returns: `(storage, index)` where `storage` is a storage instance. The contents of `storage` reflects all elements in `contents[contents.startIndex ..< index]`. `index` is usually `contents.endIndex`, except when the function was asked to reject duplicates, in which case `index` addresses the first duplicate element in `contents` (if any).
   @inlinable
   @inline(never)
@@ -87,7 +86,6 @@ extension _HashTable {
   ///
   /// - Parameter scale: The desired hash table scale or nil to use the minimum scale that satisfies invariants.
   /// - Parameter reservedScale: The reserved scale to remember in the returned storage.
-  /// - Parameter duplicates: The strategy to use to handle duplicate items.
   /// - Returns: `(storage, index)` where `storage` is a storage instance. The contents of `storage` reflects all elements in `contents[contents.startIndex ..< index]`. `index` is usually `contents.endIndex`, except when the function was asked to reject duplicates, in which case `index` addresses the first duplicate element in `contents` (if any).
   @inlinable
   @inline(never)


### PR DESCRIPTION
25 doc comments in the shipping modules name an argument that the declaration below them does not have, so DocC has nothing to bind the description to and drops it. Nothing warns about this: Swift has no equivalent of `-Wdocumentation`, and DocC stays silent rather than complaining

Most are renames the comment did not follow, and the file itself usually holds the proof:

- `RigidDeque.prepend` documents `- maxCount` while its own `- Complexity: O(newItemCount ?? self.freeCapacity)` two lines below already uses the new name
- `RigidArray.append(copying:)` has 3 overloads. The oldest takes `newElements` and its comment is right; the 2 newer ones take `items` and carry the older one's wording
- `BitArray.index(after:)` writes the name in backticks, which DocC does not bind either, and the argument is `i`. Two functions below, `formIndex(after i:)` gets it right

3 entries name an argument that no longer exists at all rather than a renamed one, so they are removed instead: `stoppingOnFirstDuplicateValue` on `fill(untilFirstDuplicateIn:)` and `duplicates` on the two `_HashTable.create` overloads, where the behaviour now lives in the function name

where a description or a `- Complexity:` line referred to the old name too, it was brought along, so each block reads consistently

`SortedCollections` is left out on purpose: it sits behind the `UnstableSortedCollections` trait and has 17 more of these, which felt like a separate conversation. Happy to send that as its own PR if you want it

One I left alone: `UniqueArray.nextSpan(after:)` documents `maxCount`, but the whole block looks copied from the `nextSpan(maxCount:after:)` overload, and I could not tell whether you would rather drop the entry or the block

Comments only, no API change

btw these came out of a checker I wrote for exactly this, run over the tree and then read one by one. 6 of the things it flagged turned out to be my parser rather than your code, and those are fixed on my side rather than sent to you

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.