### PR TITLE
[OrderedCollections] Use exchange(_:with:) in replaceElement's equal-key path

### DIFF
--- a/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift
+++ b/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary+Partial MutableCollection.swift
@@ -83,8 +83,7 @@ extension OrderedDictionary {
     // in place. The hash bucket is unchanged, so no rehash is needed.
     if existingIndex == index {
       let oldKey = _keys.update(key, at: index)
-      let oldValue = _values[index]
-      _values[index] = value
+      let oldValue = exchange(&_values[index], with: value)
       _checkInvariants()
       return (oldKey, oldValue)
     }


### PR DESCRIPTION
## Summary

`OrderedDictionary.replaceElement(at:withKey:value:)` overwrites the value at `index` in both of its paths. #688 switched one of them to `exchange(_:with:)`; this switches the other, so both move the old value out instead of copying it. Behavior-preserving; no public API change.

## Motivation

#688 factored the general case onto `OrderedSet._replaceNew(at:with:in:)`, and in review adopted `exchange(_:with:)` for the value overwrite that the same commit had just rewritten. The equal-key path above it wasn't part of that diff — #688 noted it was left unchanged — so it still does the read-then-assign it has always done.

Going back over `replaceElement` and `replace(at:with:)` now that #688 has landed, this is the one place left in the function where the old value is copied out before being overwritten, rather than moved out. The two paths do the same thing to `_values[index]` a dozen lines apart; they should be written the same way:

```diff
 if existingIndex == index {
   let oldKey = _keys.update(key, at: index)
-  let oldValue = _values[index]
-  _values[index] = value
+  let oldValue = exchange(&_values[index], with: value)
   _checkInvariants()
   return (oldKey, oldValue)
 }
```

Nothing else moves: the key still goes through `_keys.update(key, at: index)`, the hash table is still left untouched on this path, and `replaceElement`'s preconditions, returned element, and complexity (expected amortized O(1)) are unchanged. No public API is added, changed, or removed.

## Testing

Behavior-preserving change, so no new tests are added. This path is already covered by `test_replaceElement_sameKey` in both `OrderedDictionary Tests.swift` and `OrderedDictionary+Elements Tests.swift` — added alongside the equal-key path itself — covering sizes 1 through 19 with every valid index position, both unique and shared (copy-on-write) storage via `withHiddenCopies`, lifetime tracking, and the returned old key and value. All 261 `OrderedCollectionsTests` pass with and without `-Xswiftc -DCOLLECTIONS_INTERNAL_CHECKS`.

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.