### PR TITLE
Mark `_Word.allBits` as `@inlinable`

### DIFF
--- a/Benchmarks/Sources/Benchmarks/BitArrayBenchmarks.swift
+++ b/Benchmarks/Sources/Benchmarks/BitArrayBenchmarks.swift
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2021 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0 WITH Swift-exception
+//
+//===----------------------------------------------------------------------===//
+
+import CollectionsBenchmark
+import BitCollections
+
+extension Benchmark {
+
+  public mutating func addBitArrayBenchmarks() {
+    self.add(
+      title: "BitArray fill(with: true)",
+      input: Int.self
+    ) { input in
+      guard input > 0 else { return nil }
+      return { timer in
+        var a = BitArray(repeating: false, count: input)
+        timer.measure {
+          a.fill(with: true)
+        }
+        blackHole(a)
+      }
+    }
+
+    self.add(
+      title: "BitArray init(repeating: true, count:)",
+      input: Int.self
+    ) { input in
+      guard input > 0 else { return nil }
+      return { timer in
+        timer.measure {
+          blackHole(BitArray(repeating: true, count: input))
+        }
+      }
+    }
+
+    self.add(
+      title: "BitArray append(repeating: true, count:)",
+      input: Int.self
+    ) { input in
+      guard input > 0 else { return nil }
+      return { timer in
+        var a = BitArray()
+        a.reserveCapacity(input)
+        timer.measure {
+          a.append(repeating: true, count: input)
+        }
+        blackHole(a)
+      }
+    }
+
+    self.add(
+      title: "BitArray insert(repeating: true, count:at:)",
+      input: Int.self
+    ) { input in
+      guard input > 0 else { return nil }
+      return { timer in
+        var a = BitArray(repeating: false, count: 64)
+        timer.measure {
+          a.insert(repeating: true, count: input, at: 32)
+        }
+        blackHole(a)
+      }
+    }
+
+    self.add(
+      title: "BitArray truncateOrExtend(toCount:with: true)",
+      input: Int.self
+    ) { input in
+      guard input > 0 else { return nil }
+      return { timer in
+        var a = BitArray()
+        a.reserveCapacity(input)
+        timer.measure {
+          a.truncateOrExtend(toCount: input, with: true)
+        }
+        blackHole(a)
+      }
+    }
+  }
+}

--- a/Benchmarks/Sources/Benchmarks/BitsetBenchmarks.swift
+++ b/Benchmarks/Sources/Benchmarks/BitsetBenchmarks.swift
@@ -383,5 +383,73 @@ extension Benchmark {
         blackHole(a)
       }
     }
+
+    self.add(
+      title: "BitSet formUnion with Range",
+      input: Int.self
+    ) { input in
+      guard input > 0 else { return nil }
+      return { timer in
+        var a = BitSet(reservingCapacity: input)
+        a.insert(input - 1)
+        timer.measure {
+          a.formUnion(0 ..< input)
+        }
+        blackHole(a)
+      }
+    }
+
+    self.add(
+      title: "BitSet init from Range",
+      input: Int.self
+    ) { input in
+      guard input > 0 else { return nil }
+      return { timer in
+        timer.measure {
+          blackHole(BitSet(0 ..< input))
+        }
+      }
+    }
+
+    self.add(
+      title: "BitSet union with Range",
+      input: Int.self
+    ) { input in
+      guard input > 0 else { return nil }
+      var a = BitSet(reservingCapacity: input)
+      a.insert(input - 1)
+      return { timer in
+        timer.measure {
+          blackHole(a.union(0 ..< input))
+        }
+      }
+    }
+
+    self.add(
+      title: "BitSet.Counted formUnion with Range",
+      input: Int.self
+    ) { input in
+      guard input > 0 else { return nil }
+      return { timer in
+        var a = BitSet.Counted(reservingCapacity: input)
+        a.insert(input - 1)
+        timer.measure {
+          a.formUnion(0 ..< input)
+        }
+        blackHole(a)
+      }
+    }
+
+    self.add(
+      title: "BitSet.Counted init from Range",
+      input: Int.self
+    ) { input in
+      guard input > 0 else { return nil }
+      return { timer in
+        timer.measure {
+          blackHole(BitSet.Counted(0 ..< input))
+        }
+      }
+    }
   }
 }

--- a/Benchmarks/Sources/benchmark-tool/main.swift
+++ b/Benchmarks/Sources/benchmark-tool/main.swift
@@ -43,6 +43,7 @@ benchmark.addSortedDictionaryBenchmarks()
 #endif
 benchmark.addHeapBenchmarks()
 benchmark.addBitSetBenchmarks()
+benchmark.addBitArrayBenchmarks()
 benchmark.addTreeSetBenchmarks()
 benchmark.addCppBenchmarks()
 #if EnableRustBenchmarks

--- a/Sources/InternalCollectionsUtilities/UnsafeBitSet/_UnsafeBitSet+_Word.swift
+++ b/Sources/InternalCollectionsUtilities/UnsafeBitSet/_UnsafeBitSet+_Word.swift
@@ -250,6 +250,7 @@ extension _UnsafeBitSet._Word {
     Self(0)
   }
 
+  @inlinable
   @inline(__always)
   package static var allBits: Self {
     Self(UInt.max)


### PR DESCRIPTION
Probably by accident `@inlinable` was left out here. Ideally we would eventually move to the official non underscore `@inline(always)` variant that implies `@inlinable` and would make this not look like it get's inlined but only within the module like it was before this patch. But that requires Swift 6.3+.

This has a surprisingly big effect on some algorithms. Over 10x for `BitArray.fill(with: true)` and `BitSet.fromUnion` given a Range:
<img width="1280" height="480" alt="PNG image" src="https://github.com/user-attachments/assets/402f67a7-58f4-49a3-930c-ff4cdee05dde" />

<img width="1280" height="480" alt="PNG image" src="https://github.com/user-attachments/assets/e756aa3e-063f-4f5c-9ec6-d7bd00209d74" />

Some other see "minor" improvements as well:

<img width="1280" height="480" alt="PNG image" src="https://github.com/user-attachments/assets/c463d102-52a2-4e7f-bcb9-83c733034c0a" />
<img width="1280" height="480" alt="PNG image" src="https://github.com/user-attachments/assets/673bcbd6-64d7-44c9-8eaa-335cf1b559bf" />
<img width="1280" height="480" alt="PNG image" src="https://github.com/user-attachments/assets/2b3265ba-0271-4d78-9043-c854fbab74c5" />

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.
