### PR TITLE
[SortedCollections] Name the documented arguments the way the declarations name them

### DIFF
--- a/Sources/SortedCollections/BTree/_BTree+UnsafeCursor.swift
+++ b/Sources/SortedCollections/BTree/_BTree+UnsafeCursor.swift
@@ -376,8 +376,8 @@ extension _BTree {
   /// This 'consumes' the tree, however it expects the callee to retain the root of the tree for the duration of
   /// the cursors lifetime.
   ///
-  /// - Parameter key: The key to search for
-  /// - Returns: A cursor to the key or where the key should be inserted.
+  /// - Parameter index: The index to take the cursor at
+  /// - Returns: A cursor to the element at that index.
   /// - Complexity: O(`log n`)
   @inlinable
   internal mutating func takeCursor(at index: Index) -> UnsafeCursor {

--- a/Sources/SortedCollections/BTree/_BTree.Index.swift
+++ b/Sources/SortedCollections/BTree/_BTree.Index.swift
@@ -58,7 +58,7 @@ extension _BTree {
     ///   - node: The node to which this index points.
     ///   - slot: The specific slot within node where the path points
     ///   - childSlots: The children's offsets for this path.
-    ///   - index: The absolute offset of this path's element in the tree.
+    ///   - offset: The absolute offset of this path's element in the tree.
     ///   - tree: The tree of this index.
     @inlinable
     @inline(__always)

--- a/Sources/SortedCollections/BTree/_BTree.swift
+++ b/Sources/SortedCollections/BTree/_BTree.swift
@@ -451,11 +451,6 @@ extension _BTree {
 
 // MARK: Custom Indexing Operations
 extension _BTree {
-  /// Returns a path to the key at absolute offset `i`.
-  /// - Parameter offset: 0-indexed offset within BTree bounds, else may panic.
-  /// - Returns: the index of the appropriate element.
-  /// - Complexity: O(`log n`)
-  
 
   /// Obtains the start index for a key (or where it would exist).
   @inlinable

--- a/Sources/SortedCollections/BTree/_Node.Splinter.swift
+++ b/Sources/SortedCollections/BTree/_Node.Splinter.swift
@@ -34,7 +34,7 @@ extension _Node {
     
     /// Converts the splinter object to a node.
     /// - Parameters:
-    ///   - node: The node generating the splinter. Becomes the returned
+    ///   - leftChild: The node generating the splinter. Becomes the returned
     ///     node's left child.
     ///   - capacity: The desired capacity of the new node.
     /// - Returns: A new node of `capacity` with a single element.

--- a/Sources/SortedCollections/BTree/_Node.UnsafeHandle.swift
+++ b/Sources/SortedCollections/BTree/_Node.UnsafeHandle.swift
@@ -395,7 +395,7 @@ extension _Node.UnsafeHandle {
   /// This moves initialized elements to an sequence of initialized element slots in the target handle.
   ///
   /// - Parameters:
-  ///   - newHandle: The destination handle to write to which could be the same
+  ///   - target: The destination handle to write to which could be the same
   ///       as the source to move within a handle.
   ///   - sourceSlot: The offset of the source handle to move from.
   ///   - destinationSlot: The offset of the destination handle to write to.
@@ -437,7 +437,7 @@ extension _Node.UnsafeHandle {
   /// This moves initialized children to an sequence of initialized element slots in the target handle.
   ///
   /// - Parameters:
-  ///   - newHandle: The destination handle to write to which could be the same
+  ///   - target: The destination handle to write to which could be the same
   ///       as the source to move within a handle.
   ///   - sourceSlot: The offset of the source handle to move from.
   ///   - destinationSlot: The offset of the destintion handle to write to.
@@ -664,7 +664,7 @@ extension _Node.UnsafeHandle {
   /// Swaps the child at a given slot, returning the old one
   /// - Parameters:
   ///   - slot: The initialized slot at which to swap the child
-  ///   - newElement: The new child to insert
+  ///   - newChild: The new child to insert
   /// - Returns: The old child from the slot.
   @inlinable
   @inline(__always)

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary+Keys.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary+Keys.swift
@@ -118,7 +118,7 @@ extension SortedDictionary.Keys: BidirectionalCollection {
   /// The specified index must be a valid index less than `endIndex`, or the
   /// returned value won't be a valid index in the collection.
   ///
-  /// - Parameter i: A valid index of the collection.
+  /// - Parameter index: A valid index of the collection.
   ///
   /// - Complexity: O(log(`self.count`))
   @inlinable
@@ -132,9 +132,9 @@ extension SortedDictionary.Keys: BidirectionalCollection {
   /// The specified index must be a valid index less than `endIndex`, or the
   /// returned value won't be a valid index in the collection.
   ///
-  /// - Parameter i: A valid index of the collection.
+  /// - Parameter index: A valid index of the collection.
   ///
-  /// - Returns: The index immediately after `i`.
+  /// - Returns: The index immediately after `index`.
   ///
   /// - Complexity: O(log(`self.count`))
   @inlinable
@@ -148,7 +148,7 @@ extension SortedDictionary.Keys: BidirectionalCollection {
   /// The specified index must be a valid index less than `endIndex`, or the
   /// returned value won't be a valid index in the collection.
   ///
-  /// - Parameter i: A valid index of the collection.
+  /// - Parameter index: A valid index of the collection.
   ///
   /// - Complexity: O(log(`self.count`))
   @inlinable
@@ -162,9 +162,9 @@ extension SortedDictionary.Keys: BidirectionalCollection {
   /// The specified index must be a valid index greater than `startIndex`, or
   /// the returned value won't be a valid index in the collection.
   ///
-  /// - Parameter i: A valid index of the collection.
+  /// - Parameter index: A valid index of the collection.
   ///
-  /// - Returns: The index immediately before `i`.
+  /// - Returns: The index immediately before `index`.
   ///
   /// - Complexity: O(log(`self.count`))
   @inlinable
@@ -214,8 +214,8 @@ extension SortedDictionary.Keys: BidirectionalCollection {
 extension SortedDictionary.Keys {
   /// Accesses the element at the specified position.
   ///
-  /// - Parameter index: The position of the element to access. `index` must be
-  ///   greater than or equal to `startIndex` and less than `endIndex`.
+  /// - Parameter position: The position of the element to access. `position` must
+  ///   be greater than or equal to `startIndex` and less than `endIndex`.
   ///
   /// - Complexity: O(1)
   @inlinable

--- a/Sources/SortedCollections/SortedDictionary/SortedDictionary+Values.swift
+++ b/Sources/SortedCollections/SortedDictionary/SortedDictionary+Values.swift
@@ -118,7 +118,7 @@ extension SortedDictionary.Values: BidirectionalCollection {
   /// The specified index must be a valid index less than `endIndex`, or the
   /// returned value won't be a valid index in the collection.
   ///
-  /// - Parameter i: A valid index of the collection.
+  /// - Parameter index: A valid index of the collection.
   ///
   /// - Complexity: O(log(`self.count`))
   @inlinable
@@ -132,9 +132,9 @@ extension SortedDictionary.Values: BidirectionalCollection {
   /// The specified index must be a valid index less than `endIndex`, or the
   /// returned value won't be a valid index in the collection.
   ///
-  /// - Parameter i: A valid index of the collection.
+  /// - Parameter index: A valid index of the collection.
   ///
-  /// - Returns: The index immediately after `i`.
+  /// - Returns: The index immediately after `index`.
   ///
   /// - Complexity: O(log(`self.count`))
   @inlinable
@@ -148,7 +148,7 @@ extension SortedDictionary.Values: BidirectionalCollection {
   /// The specified index must be a valid index less than `endIndex`, or the
   /// returned value won't be a valid index in the collection.
   ///
-  /// - Parameter i: A valid index of the collection.
+  /// - Parameter index: A valid index of the collection.
   ///
   /// - Complexity: O(log(`self.count`))
   @inlinable
@@ -162,9 +162,9 @@ extension SortedDictionary.Values: BidirectionalCollection {
   /// The specified index must be a valid index greater than `startIndex`, or
   /// the returned value won't be a valid index in the collection.
   ///
-  /// - Parameter i: A valid index of the collection.
+  /// - Parameter index: A valid index of the collection.
   ///
-  /// - Returns: The index immediately before `i`.
+  /// - Returns: The index immediately before `index`.
   ///
   /// - Complexity: O(`log n`) where `n` is the number of key-value pairs in the
   ///   sorted dictionary.
@@ -215,8 +215,8 @@ extension SortedDictionary.Values: BidirectionalCollection {
 extension SortedDictionary.Values {
   /// Accesses the element at the specified position.
   ///
-  /// - Parameter index: The position of the element to access. `index` must be
-  ///   greater than or equal to `startIndex` and less than `endIndex`.
+  /// - Parameter position: The position of the element to access. `position` must
+  ///   be greater than or equal to `startIndex` and less than `endIndex`.
   ///
   /// - Complexity: O(1)
   @inlinable


### PR DESCRIPTION
#701 covers the shipping modules. This is the same thing in `SortedCollections`, which sits behind the `UnstableSortedCollections` trait and so is not in a default build

17 doc comments here name an argument that the declaration below them does not have, mostly renames the comment did not follow:

- `SortedDictionary.Keys` and `.Values` carry 8 blocks documenting `- Parameter i` while every one of those declarations takes `index`
- `_Node.UnsafeHandle` documents `newHandle` where the argument is `target`, and `newElement` where it is `newChild`
- `_Node.Splinter` documents `node`, the initializer takes `leftChild`
- `_BTree.Index` documents `index`, the initializer takes `offset`
- `_BTree+UnsafeCursor` documents `key` where `takeCursor(at:)` takes `index`

Where a `- Returns` line carried the old name too, it came along, so each block reads consistently. `index(after:)` and `index(before:)` in `Keys` and `Values` returned "the index immediately after `i`", and `takeCursor(at:)` returned "a cursor to the key or where the key should be inserted", which is the other overload's behaviour

The `i` in the neighbouring blocks is left alone on purpose: `index(after i:)`, `formIndex(_ i:)` and `index(_ i:, offsetBy:)` really are named that, and only these overloads were renamed without the comments following

One block is removed rather than renamed. `_BTree.swift` documents "a path to the key at absolute offset" with `- Parameter offset`, `- Returns` and `- Complexity`, then comes a blank line and then the doc comment for `startIndex(forKey:)`, so it binds to nothing

Comments only, no API change. Fine by me to close it if you would rather leave this module alone

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [x] I've updated the documentation if necessary.