### PR TITLE
[workflows] Update CI workflows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.14
     with:
       enable_macos_checks: true
       macos_xcode_versions: '["swift_6.1", "swift_6.2", "swift_6.3", "swift_6.4"]'
@@ -24,7 +24,7 @@ jobs:
 
   containers-tests:
     name: Containers Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.14
     with:
       linux_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}, {"swift_version": "6.3"}, {"swift_version": "nightly-6.3"}]'
       enable_macos_checks: false
@@ -34,7 +34,7 @@ jobs:
 
   hashed-containers-tests:
     name: Hashed Containers Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.14
     with:
       linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}, {"swift_version": "6.3"}, {"swift_version": "nightly-6.3"}]'
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}]'
@@ -46,7 +46,7 @@ jobs:
 
   all-traits-tests:
     name: All Unstable Package Traits Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.14
     with:
       linux_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}, {"swift_version": "6.3"}, {"swift_version": "nightly-6.3"}]'
       enable_macos_checks: false
@@ -56,7 +56,7 @@ jobs:
 
   embedded-swift:
     name: Build with Embedded Swift
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.14
     with:
       enable_linux_checks: false
       enable_macos_checks: false
@@ -67,7 +67,7 @@ jobs:
 
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.13
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.14
     with:
       license_header_check_project_name: "Swift.org"
       # https://github.com/apple/swift-collections/issues/428

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,6 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.14
     with:
       enable_macos_checks: true
-      macos_xcode_versions: '["swift_6.1", "swift_6.2", "swift_6.3", "swift_6.4"]'
       macos_exclude_xcode_versions: '[]'
       linux_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}]'
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}]'
@@ -26,7 +25,7 @@ jobs:
     name: Containers Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.14
     with:
-      linux_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}, {"swift_version": "6.3"}, {"swift_version": "nightly-6.3"}]'
+      linux_swift_versions: '["6.0", "nightly-main"]'
       enable_macos_checks: false
       enable_linux_checks: true
       enable_windows_checks: false
@@ -36,9 +35,7 @@ jobs:
     name: Hashed Containers Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.14
     with:
-      linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}, {"swift_version": "6.3"}, {"swift_version": "nightly-6.3"}]'
-      windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}]'
-      macos_exclude_xcode_versions: '[{"xcode_version": "swift_6.1"}, {"xcode_version": "swift_6.2"}]'
+      linux_swift_versions: '["6.0", "nightly-main"]'
       enable_macos_checks: false
       enable_linux_checks: true
       enable_windows_checks: false
@@ -48,7 +45,7 @@ jobs:
     name: All Unstable Package Traits Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.14
     with:
-      linux_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}, {"swift_version": "6.3"}, {"swift_version": "nightly-6.3"}]'
+      linux_swift_versions: '["6.0", "nightly-main"]'
       enable_macos_checks: false
       enable_linux_checks: true
       enable_windows_checks: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,7 +25,7 @@ jobs:
     name: Containers Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.14
     with:
-      linux_swift_versions: '["6.0", "nightly-main"]'
+      linux_swift_versions: '["6.2", "nightly-main"]'
       enable_macos_checks: false
       enable_linux_checks: true
       enable_windows_checks: false
@@ -35,7 +35,7 @@ jobs:
     name: Hashed Containers Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.14
     with:
-      linux_swift_versions: '["6.0", "nightly-main"]'
+      linux_swift_versions: '["6.2", "nightly-main"]'
       enable_macos_checks: false
       enable_linux_checks: true
       enable_windows_checks: false
@@ -45,7 +45,7 @@ jobs:
     name: All Unstable Package Traits Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.14
     with:
-      linux_swift_versions: '["6.0", "nightly-main"]'
+      linux_swift_versions: '["6.2", "nightly-main"]'
       enable_macos_checks: false
       enable_linux_checks: true
       enable_windows_checks: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,21 +12,21 @@ jobs:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
-      linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}]'
-      windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}]'
-      macos_exclude_xcode_versions: '[{"xcode_version": "26.0"}]'
       enable_macos_checks: true
+      macos_xcode_versions: '["swift_6.1", "swift_6.2", "swift_6.3", "swift_6.4"]'
+      macos_exclude_xcode_versions: '[]'
+      linux_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}]'
+      windows_exclude_swift_versions: '[{"swift_version": "5.9"}]'
       enable_wasm_sdk_build: true
       enable_android_sdk_build: true
       enable_android_sdk_checks: true
+      enable_freebsd_checks: true
 
   containers-tests:
     name: Containers Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
-      linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}, {"swift_version": "6.3"}, {"swift_version": "nightly-6.3"}]'
-      windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}]'
-      macos_exclude_xcode_versions: '[{"xcode_version": "26.0"}, {"xcode_version": "16.3"}, {"xcode_version": "16.4"}]'
+      linux_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}, {"swift_version": "6.3"}, {"swift_version": "nightly-6.3"}]'
       enable_macos_checks: false
       enable_linux_checks: true
       enable_windows_checks: false
@@ -38,11 +38,21 @@ jobs:
     with:
       linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}, {"swift_version": "6.3"}, {"swift_version": "nightly-6.3"}]'
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}]'
-      macos_exclude_xcode_versions: '[{"xcode_version": "26.0"}, {"xcode_version": "16.3"}, {"xcode_version": "16.4"}]'
+      macos_exclude_xcode_versions: '[{"xcode_version": "swift_6.1"}, {"xcode_version": "swift_6.2"}]'
       enable_macos_checks: false
       enable_linux_checks: true
       enable_windows_checks: false
-      swift_flags: --traits UnstableContainersPreview,UnstableHashedContainers
+      swift_flags: --traits UnstableHashedContainers
+
+  all-traits-tests:
+    name: All Unstable Package Traits Test
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
+    with:
+      linux_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "6.2"}, {"swift_version": "6.3"}, {"swift_version": "nightly-6.3"}]'
+      enable_macos_checks: false
+      enable_linux_checks: true
+      enable_windows_checks: false
+      swift_flags: --traits UnstableHashedContainers,UnstableContainersPreview,UnstableSortedCollections
 
   embedded-swift:
     name: Build with Embedded Swift
@@ -93,3 +103,18 @@ jobs:
         run: cmake -G Ninja -S . -B .cmake-build
       - name: Build
         run: cmake --build .cmake-build
+
+  xcode-build:
+    name: Xcode Project Build
+    runs-on: [self-hosted, macos, "tahoe", "ARM64"]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+      - name: Select Xcode
+        run: echo "DEVELOPER_DIR=/Applications/Xcode_swift_6.4.app/Contents/Developer" >> $GITHUB_ENV
+      - name: Xcode version
+        run: xcrun xcodebuild -version
+      - name: Swift version
+        run: xcrun swift --version
+      - name: Build
+        run: xcrun xcodebuild -project Xcode/Collections.xcodeproj -scheme Collections


### PR DESCRIPTION
- Enable tests on FreeBSD
- Switch to symbolic Xcode version specifications that are based on the Swift version, not the precise Xcode version number. This lets us avoid having to laboriously update the specs every time Xcode gets a new minor release or beta — CI runners will pick up the latest Xcode they have installed that includes the specified Swift release.
- Stop excluding obsolete Swift versions that are no longer configured on runners.
- Add a job that tries to build the Xcode project at `Xcode/Collections.xcodeproj` under the latest Xcode on macOS.
- Add a job that runs tests with all unstable package traits enabled (`UnstableContainersPreview`, `UnstableHashedContainers`, `UnstableSortedCollections`.
- In exchange, change `hashed-container-tests` to only enable `UnstableHashedContainers`.

(This is not going to be mergeable until this repo's configuration is updated to require an updated set of actions.)

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
