### PR TITLE
[BitCollections. OrderedCollections] Disable `_UniqueCollection` fast paths in embedded Swift

### DIFF
--- a/Sources/BitCollections/BitSet/BitSet+SetAlgebra isEqualSet.swift
+++ b/Sources/BitCollections/BitSet/BitSet+SetAlgebra isEqualSet.swift
@@ -72,6 +72,7 @@ extension BitSet {
       return other.allSatisfy { _ in false }
     }
 
+#if !$Embedded
     if other is _UniqueCollection {
       // We don't need to create a temporary set.
       guard other.underestimatedCount <= self.count else { return false }
@@ -87,6 +88,7 @@ extension BitSet {
         "Invalid Collection '\(type(of: other))' (bad underestimatedCount)")
       return seen == self.count
     }
+#endif
 
     var seen: BitSet? = BitSet(reservingCapacity: self.max()!)
     var it = other.makeIterator()

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Initializers.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Initializers.swift
@@ -67,11 +67,13 @@ extension OrderedSet {
       self = elements
       return
     }
+#if !$Embedded
     // Fast paths for when we know elements are all unique
     if elements is _UniqueCollection {
       self.init(uncheckedUniqueElements: elements)
       return
     }
+#endif
 
     self.init(minimumCapacity: elements.underestimatedCount)
     append(contentsOf: elements)

--- a/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial SetAlgebra isEqualSet.swift
+++ b/Sources/OrderedCollections/OrderedSet/OrderedSet+Partial SetAlgebra isEqualSet.swift
@@ -57,6 +57,7 @@ extension OrderedSet {
       return other.allSatisfy { _ in false }
     }
 
+#if !$Embedded
     if other is _UniqueCollection {
       // We don't need to create a temporary set.
       guard other.underestimatedCount <= self.count else { return false }
@@ -71,6 +72,7 @@ extension OrderedSet {
         "Invalid Collection '\(type(of: other))' (bad underestimatedCount)")
       return seen == self.count
     }
+#endif
 
     return _UnsafeBitSet.withTemporaryBitSet(capacity: count) { seen in
       var c = 0


### PR DESCRIPTION
As of 2026-09-01, conformance checks are now diagnosed as errors:

```
 70 |     // Fast paths for when we know elements are all unique
 71 |     if elements is _UniqueCollection {
    |                 `- error: cannot perform a dynamic cast to a type involving protocol '_UniqueCollection' in Embedded Swift
```

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
