### PR TITLE
[RigidDictionary] Store a sentinel value for values ptr if null

### DIFF
--- a/Sources/BasicContainers/RigidDictionary/RigidDictionary+Initializers.swift
+++ b/Sources/BasicContainers/RigidDictionary/RigidDictionary+Initializers.swift
@@ -11,9 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6.4) && UnstableHashedContainers
-
+#if !COLLECTIONS_SINGLE_MODULE
 import InternalCollectionsUtilities
+#endif
+
+#if compiler(>=6.4) && UnstableHashedContainers
 
 @available(SwiftStdlib 5.0, *)
 extension RigidDictionary where Key: ~Copyable, Value: ~Copyable {

--- a/Sources/BasicContainers/RigidDictionary/RigidDictionary+Initializers.swift
+++ b/Sources/BasicContainers/RigidDictionary/RigidDictionary+Initializers.swift
@@ -13,6 +13,8 @@
 
 #if compiler(>=6.4) && UnstableHashedContainers
 
+import InternalCollectionsUtilities
+
 @available(SwiftStdlib 5.0, *)
 extension RigidDictionary where Key: ~Copyable, Value: ~Copyable {
   @inlinable
@@ -23,9 +25,9 @@ extension RigidDictionary where Key: ~Copyable, Value: ~Copyable {
   @inlinable
   package init(_table: consuming _HTable) {
     let keys = RigidSet<Key>(_table: _table)
-    let values: UnsafeMutablePointer<Value>?
+    let values: UnsafeMutablePointer<Value>
     if keys.capacity == 0 {
-      values = nil
+      values = ._dangling()
     } else {
       values = .allocate(capacity: keys._storageCapacity)
     }

--- a/Sources/BasicContainers/RigidDictionary/RigidDictionary+Removals.swift
+++ b/Sources/BasicContainers/RigidDictionary/RigidDictionary+Removals.swift
@@ -40,7 +40,6 @@ extension RigidDictionary where Key: ~Copyable, Value: ~Copyable {
     self._keys._table.createHole(at: bucket)
     let seed = self._keys._seed
     let keys = self._keys._members.unsafelyUnwrapped
-    let values = self._values.unsafelyUnwrapped
     self._keys._table.resolveHole(
       at: bucket,
       hashGenerator: {
@@ -48,7 +47,7 @@ extension RigidDictionary where Key: ~Copyable, Value: ~Copyable {
       },
       mover: {
         (keys + $1.offset).initialize(to: (keys + $0.offset).move())
-        (values + $1.offset).initialize(to: (values + $0.offset).move())
+        (_values + $1.offset).initialize(to: (_values + $0.offset).move())
       })
   }
 
@@ -65,12 +64,11 @@ extension RigidDictionary where Key: ~Copyable, Value: ~Copyable {
 
     let oldValue = self._valuePtr(at: bucket).move()
     let keys = self._keys._members.unsafelyUnwrapped
-    let values = self._values.unsafelyUnwrapped
     self._keys._table.finalizeHole(
       at: bucket,
       mover: {
         (keys + $1.offset).initialize(to: (keys + $0.offset).move())
-        (values + $1.offset).initialize(to: (values + $0.offset).move())
+        (_values + $1.offset).initialize(to: (_values + $0.offset).move())
       })
     return oldValue
   }

--- a/Sources/BasicContainers/RigidDictionary/RigidDictionary+Resizing.swift
+++ b/Sources/BasicContainers/RigidDictionary/RigidDictionary+Resizing.swift
@@ -52,9 +52,9 @@ extension RigidDictionary where Key: ~Copyable, Value: ~Copyable {
     }
 
     let sourceKeys = old._keys._members.unsafelyUnwrapped
-    let sourceValues = old._values.unsafelyUnwrapped
+    let sourceValues = old._values
     let targetKeys = self._keys._members.unsafelyUnwrapped
-    let targetValues = self._values.unsafelyUnwrapped
+    let targetValues = self._values
     if self._keys._table.isSmall {
       self._keys._table.migrateItems_Small(from: &old._keys._table) { src, dst in
         (targetKeys + dst.offset).initialize(to: (sourceKeys + src.offset).move())

--- a/Sources/BasicContainers/RigidDictionary/RigidDictionary.swift
+++ b/Sources/BasicContainers/RigidDictionary/RigidDictionary.swift
@@ -42,15 +42,15 @@ public struct RigidDictionary<
   package var _keys: RigidSet<Key>
 
   @_alwaysEmitIntoClient
-  package var _values: UnsafeMutablePointer<Value>?
+  package var _values: UnsafeMutablePointer<Value>
   
   @_alwaysEmitIntoClient
   @_transparent
   package init(
     _keys: consuming RigidSet<Key>,
-    values: UnsafeMutablePointer<Value>?
+    values: UnsafeMutablePointer<Value>
   ) {
-    assert((values != nil) == (_keys._members != nil))
+    assert((values != ._dangling()) == (_keys._members != nil))
     self._keys = _keys
     self._values = values
   }
@@ -62,8 +62,8 @@ public struct RigidDictionary<
     // here.
     if !isEmpty {
       _deinitializeValues()
+      _values.deallocate()
     }
-    _values?.deallocate()
   }
   
   @_alwaysEmitIntoClient
@@ -135,7 +135,7 @@ extension RigidDictionary where Key: ~Copyable, Value: ~Copyable {
     at bucket: _HTable.Bucket
   ) -> UnsafeMutablePointer<Value> {
     assert(_keys._table.isValid(bucket))
-    return _values.unsafelyUnwrapped.advanced(by: bucket.offset)
+    return _values.advanced(by: bucket.offset)
   }
   
   @_alwaysEmitIntoClient

--- a/Tests/BasicContainersTests/RigidDictionaryTests.swift
+++ b/Tests/BasicContainersTests/RigidDictionaryTests.swift
@@ -23,6 +23,12 @@ import ContainersPreview
 #if compiler(>=6.4) && UnstableHashedContainers
 
 class RigidDictionaryTests: CollectionTestCase {
+  func test_memory_layout() {
+    let word = MemoryLayout<Int>.size
+    expectEqual(MemoryLayout<RigidDictionary<String, Int>>.stride, 7 * word)
+    expectEqual(MemoryLayout<RigidDictionary<String, Int>?>.stride, 7 * word)
+  }
+  
   func test_empty() {
     let s = RigidDictionary<Int, String>()
     expectEqual(s.count, 0)

--- a/Tests/BasicContainersTests/RigidSetTests.swift
+++ b/Tests/BasicContainersTests/RigidSetTests.swift
@@ -59,6 +59,12 @@ func expectConsistentSet<Element: ~Copyable>(
 }
 
 class RigidSetTests: CollectionTestCase {
+  func test_memory_layout() {
+    let word = MemoryLayout<Int>.size
+    expectEqual(MemoryLayout<RigidSet<Int>>.stride, 6 * word)
+    expectEqual(MemoryLayout<RigidSet<Int>?>.stride, 6 * word)
+  }
+  
   func test_empty() {
     let s = RigidSet<Int>()
     expectEqual(s.count, 0)

--- a/Tests/BasicContainersTests/UniqueDictionaryTests.swift
+++ b/Tests/BasicContainersTests/UniqueDictionaryTests.swift
@@ -23,6 +23,12 @@ import ContainersPreview
 #if compiler(>=6.4) && UnstableHashedContainers
 
 class UniqueDictionaryTests: CollectionTestCase {
+  func test_memory_layout() {
+    let word = MemoryLayout<Int>.size
+    expectEqual(MemoryLayout<UniqueDictionary<String, Int>>.stride, 7 * word)
+    expectEqual(MemoryLayout<UniqueDictionary<String, Int>?>.stride, 7 * word)
+  }
+  
   func test_empty() {
     let s = UniqueDictionary<Int, String>()
     expectEqual(s.count, 0)

--- a/Tests/BasicContainersTests/UniqueSetTests.swift
+++ b/Tests/BasicContainersTests/UniqueSetTests.swift
@@ -22,6 +22,12 @@ import BasicContainers
 
 #if compiler(>=6.4) && UnstableHashedContainers
 class UniqueSetTests: CollectionTestCase {
+  func test_memory_layout() {
+    let word = MemoryLayout<Int>.size
+    expectEqual(MemoryLayout<UniqueSet<Int>>.stride, 6 * word)
+    expectEqual(MemoryLayout<UniqueSet<Int>?>.stride, 6 * word)
+  }
+  
   func test_empty() {
     let s = UniqueSet<Int>()
     expectEqual(s.count, 0)


### PR DESCRIPTION
This wins us back an optional bit for `RigidDictionary<K, V>?` to be the same size as `RigidDictionary<K, V>`.

### Checklist
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [X] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [X] I've updated the documentation if necessary.
