### PR TITLE
[BitSet] Fix isEqualSet(to: Range<Int>) for empty ranges

### DIFF
--- a/Sources/BitCollections/BitSet/BitSet+SetAlgebra isEqualSet.swift
+++ b/Sources/BitCollections/BitSet/BitSet+SetAlgebra isEqualSet.swift
@@ -41,6 +41,7 @@ extension BitSet {
   /// - Complexity: O(min(*max*, `other.upperBound`), where *max* is the largest
   ///    member of `self`.
   public func isEqualSet(to other: Range<Int>) -> Bool {
+    if other.isEmpty { return isEmpty }
     guard let other = other._toUInt() else { return false }
     return _read { $0.isEqualSet(to: other) }
   }

--- a/Tests/BitCollectionsTests/BitSetTests.swift
+++ b/Tests/BitCollectionsTests/BitSetTests.swift
@@ -1135,6 +1135,21 @@ final class BitSetTest: CollectionTestCase {
         expectFalse(c.isEqualSet(to: i ..< (j + 1)))
       }
     }
+    // An empty range is equal to the empty set, whatever its bounds are.
+    // (Ranges with negative bounds can never round-trip through `_toUInt`.)
+    expectTrue(BitSet().isEqualSet(to: 0 ..< 0))
+    expectTrue(BitSet().isEqualSet(to: -5 ..< -5))
+    expectTrue(BitSet().isEqualSet(to: Int.min ..< Int.min))
+    expectFalse(BitSet([1]).isEqualSet(to: -5 ..< -5))
+
+    // A nonempty range holding negative values is never equal to a bit set.
+    expectFalse(BitSet().isEqualSet(to: -5 ..< 0))
+    expectFalse(BitSet([0, 1, 2]).isEqualSet(to: -5 ..< 3))
+    expectFalse(BitSet([0, 1, 2]).isEqualSet(to: -1 ..< 3))
+
+    // The counted variant forwards to the same implementation.
+    expectTrue(BitSet.Counted().isEqualSet(to: -5 ..< -5))
+    expectFalse(BitSet.Counted([0, 1, 2]).isEqualSet(to: -5 ..< 3))
   }
 
   func test_isEqual_to_counted_BitSet() {


### PR DESCRIPTION
`_toUInt()` returns nil whenever a bound is negative, and the guard maps that straight to `false`. That is right for a nonempty range — a bit set can never hold a negative value — but an empty range equals the empty set wherever its bounds sit, so `BitSet().isEqualSet(to: -5 ..< -5)` answered false.

On `main` that lets a bit set be both a subset and a superset of a range it calls unequal:

```swift
let s = BitSet()
s.isSubset(of: -5 ..< -5)    // true
s.isSuperset(of: -5 ..< -5)  // true
s.isEqualSet(to: -5 ..< -5)  // false
```

It also splits the generic overload against itself, since that one `_specialize`s `Range<Int>` back into this one: `isEqualSet(to: -5 ..< -5)` is false while `isEqualSet(to: Array(-5 ..< -5))` is true.

Five of the six `Range<Int>` predicates already handle it — `isSubset`/`isDisjoint` clamp, `isStrictSubset` composes those, `isSuperset`/`isStrictSuperset` check `other.isEmpty` before converting. This adds the same guard. `BitSet.Counted` forwards here, so it is covered too.

Clamping instead, to mirror `isSubset`, is tidier but wrong: it would make `BitSet([0, 1, 2]).isEqualSet(to: -5 ..< 3)` true.

New assertions extend `test_isEqual_to_integer_range` and fail on `main` with 3 failures. Full `swift test` is green (813 tests).

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections/blob/main/README.md#contributing-to-swift-collections)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.
